### PR TITLE
RLF[#23]: Add public accessor for start_time from execute.h (startTim…

### DIFF
--- a/src/include/execute.h
+++ b/src/include/execute.h
@@ -60,7 +60,11 @@ namespace Loci {
 #endif
 #endif
   public:
-    void start() { // This method resets the clock
+    /** ************************************************************************
+     * @brief This method resets the clock
+     **************************************************************************/
+    void start() 
+    { // This method resets the clock
 #ifdef PROFILER
 #ifdef USE_PAPI
       start_time = PAPI_get_real_usec();
@@ -68,8 +72,23 @@ namespace Loci {
       start_time = MPI_Wtime() ;
 #endif
 #endif
-    }
-    double stop() { // This method returns time since last start call
+    } // end of start{}
+
+    /** ************************************************************************
+     * @brief Returns the value for start_time
+     * @return double
+     **************************************************************************/
+    double startTime()
+    {
+      return start_time;
+    } // end startTime
+
+    /** ************************************************************************
+     * @brief  This method returns time since last start call
+     * @return double
+     **************************************************************************/
+    double stop() 
+    { // This method returns time since last start call
 #ifdef PROFILER
 #ifdef USE_PAPI
       return 1e-6*double(PAPI_get_real_usec()-start_time) ;
@@ -79,8 +98,8 @@ namespace Loci {
 #else
       return 0 ;
 #endif
-    }
-  } ;
+    } // end of stop{}
+  } ; // end of class stopWatch
   
 
   // This object is responsible for counting time and events that occur for

--- a/src/include/execute.h
+++ b/src/include/execute.h
@@ -51,54 +51,52 @@ using std::string;
 
 namespace Loci {
 
+  /** ************************************************************************
+   * @brief This class is used for timing a period of execution to the
+   * microsecond resolution in seconds
+   ***************************************************************************/
   class stopWatch {
-#ifdef PROFILER
-#ifdef USE_PAPI
-    long_long start_time ;
-#else
     double start_time ;
-#endif
-#endif
   public:
-    /** ************************************************************************
-     * @brief This method resets the clock
-     **************************************************************************/
-    void start() 
-    { // This method resets the clock
+    /**
+     * @brief The constructor initializes the timer to record that the timer
+     * has not been started
+     **/
+    stopWatch() :start_time(-1.0) {}
+    /**
+     * @brief A static method that returns the current time with microsecond
+     * resolution.  This could be used as a portable way to access time, but
+     * generally this method would be used internally to the stopWatch class.
+     * @return double
+     **/
+    static double timer() {
 #ifdef PROFILER
 #ifdef USE_PAPI
-      start_time = PAPI_get_real_usec();
+      return 1e-6*double(PAPI_get_real_usec());
 #else
-      start_time = MPI_Wtime() ;
-#endif
-#endif
-    } // end of start{}
-
-    /** ************************************************************************
-     * @brief Returns the value for start_time
-     * @return double
-     **************************************************************************/
-    double startTime()
-    {
-      return start_time;
-    } // end startTime
-
-    /** ************************************************************************
-     * @brief  This method returns time since last start call
-     * @return double
-     **************************************************************************/
-    double stop() 
-    { // This method returns time since last start call
-#ifdef PROFILER
-#ifdef USE_PAPI
-      return 1e-6*double(PAPI_get_real_usec()-start_time) ;
-#else
-      return MPI_Wtime()-start_time ;
+      return MPI_Wtime() ;
 #endif
 #else
-      return 0 ;
+      timeval tv ;
+      struct timezone tz ;
+      gettimeofday(&tv,&tz) ;
+      return double(tv.tv_sec)+1e-6*double(tv.tv_usec) ;
 #endif
-    } // end of stop{}
+    }
+    /**
+     * @brief This method starts the timer.
+     **/
+    void start() { 
+      start_time = stopWatch::timer() ;
+    }
+    /**
+     * @brief This method returns the time since the last call to start the
+     * timer.  If start has not been called, it returns a negative value.
+     * Method is declared a const as it does not change the state of the timer
+     **/
+    double stop() const { 
+      return start_time>0?stopWatch::timer()-start_time:start_time ;
+    }
   } ; // end of class stopWatch
   
 


### PR DESCRIPTION
Adding public accessor corrects issue in Loci/GGFS (and potentially other Loci-based codes) when having stopwatch calls in separate files. Effectively, every instantiate of stopWatch is not truly global, so the timing needs to be stored to correctly calculate cpu time per iteration, for example. This issue adds a public accessor startTime() to return the privately stored start_time = MPI.WTime().