### PR TITLE
RLF[#30]: added --bounds-check directive and LOCI_DEBUG environment

### DIFF
--- a/configure
+++ b/configure
@@ -417,10 +417,10 @@ echo >> sys.conf
 echo NO_SUB_DIR=$NO_SUB_DIR >> sys.conf
 #setup MPI
 
-# ################################################################################
+# ##############################################################################
 # # Check for debug variable and print to screen. Set to 7 if doesn't exist.
-# ################################################################################
-if [ $LOCI_DEBUG ]; then
+# ##############################################################################
+if [ -v LOCI_DEBUG ] ; then
    echo -e "Compiling/configured in DEBUG Mode = $LOCI_DEBUG."
 fi
 

--- a/configure
+++ b/configure
@@ -98,6 +98,7 @@ METIS_LIBS=
 METIS_INCLUDE=
 USE_METIS=0
 NO_SUB_DIR=0
+BOUNDS_CHECK=0
 
 while [ $# -ne 0 ]; do 
     case "$1" in
@@ -237,7 +238,6 @@ while [ $# -ne 0 ]; do
 	    tmp=$1
 	    TEC360PATH=${tmp#--with-tec360\=}
 	    ;;
-
 	--mpi-dir)
 	    shift
 	    MPI_BASE=$1
@@ -254,7 +254,7 @@ while [ $# -ne 0 ]; do
 	    tmp=$1
 	    MPI_BASE=${tmp#--with-mpi\=}
 	    ;;
-        --no-mpi-driver)
+    --no-mpi-driver)
 	    NO_MPI_DRIVER=1
 	    ;;
 	--compiler)
@@ -281,6 +281,9 @@ while [ $# -ne 0 ]; do
 	--no-sub-dir)
 		NO_SUB_DIR=1
 		;;
+	--bounds-check)
+		BOUNDS_CHECK=1
+		;;
 	 --help)
 	    echo "configure usage:"
 	    echo "./configure <options>"
@@ -297,6 +300,7 @@ while [ $# -ne 0 ]; do
 	    echo "  --compiler <compiler name>      : tell configure what compiler to use"
 	    echo "  --obj-dir <OBJDIR name>         : tell configure where to put object files"
 	   	echo "  --no-sub-dir                    : tell configure to not add the build information after the prefix defintion"
+	  	echo "  --bounds-check                  : tell configure to add bounds checking to the compiler flags"
 	    echo "  --help                          : output this help information"
 	    exit -1
 	    ;;
@@ -413,6 +417,21 @@ echo >> sys.conf
 echo NO_SUB_DIR=$NO_SUB_DIR >> sys.conf
 #setup MPI
 
+# ################################################################################
+# # Check for debug variable and print to screen. Set to 7 if doesn't exist.
+# ################################################################################
+# if [[ ${LOCI_DEBUG-7} -eq 0 || ${LOCI_DEBUG-7} -eq 1 || ${LOCI_DEBUG-7} -eq 2 || \
+#       ${LOCI_DEBUG-7} -eq 3 ]]; then
+#   echo -e "Compiling in ${ESC}0;31;1m\"DEBUG\"${NC} Mode."
+# fi
+
+################################################################################
+# Push to sys.conf bounds checking if activated
+echo -e "BOUNDS_CHECK=$BOUNDS_CHECK" >>sys.conf
+
+################################################################################
+#setup MPI
+################################################################################
 HAS_MPI=1
 MPIEXEC=mpirun
 if [ $MPI_BASE == "/notselected" ]; then

--- a/configure
+++ b/configure
@@ -420,10 +420,9 @@ echo NO_SUB_DIR=$NO_SUB_DIR >> sys.conf
 # ################################################################################
 # # Check for debug variable and print to screen. Set to 7 if doesn't exist.
 # ################################################################################
-# if [[ ${LOCI_DEBUG-7} -eq 0 || ${LOCI_DEBUG-7} -eq 1 || ${LOCI_DEBUG-7} -eq 2 || \
-#       ${LOCI_DEBUG-7} -eq 3 ]]; then
-#   echo -e "Compiling in ${ESC}0;31;1m\"DEBUG\"${NC} Mode."
-# fi
+if [ $LOCI_DEBUG ]; then
+   echo -e "Compiling/configured in DEBUG Mode = $LOCI_DEBUG."
+fi
 
 ################################################################################
 # Push to sys.conf bounds checking if activated

--- a/install.txt
+++ b/install.txt
@@ -66,6 +66,33 @@ and the <install_directory>/Loci-*/lib subdirectory to your
 LD_LIBRARY_PATH environment.  Also, you will need to set the LOCI_BASE
 environment variable to <install_directory>/Loci-*
 
+--------------------------------------------------------------------------------
+Notes for Debug Builds
+
+When debugging of Loci or associated codes is necessary, the user has two options.
+At configure time, one can include the following flag:
+
+./configure --prefix<install_directory> --bounds-check
+
+which enables compiler-specific directives to enable bound checking of vectors/arrays.
+
+To generate debugging information in the compiled object files, set the environment
+variable (for bash)
+
+export LOCI_DEBUG=<0,1,2,3>
+
+LOCI_DEBUG can be added to an environment module as well.
+LOCI_DEBUG will do two things: 
+   1. Enable debug compiler flags (-Wall -g3, and for gnu compilers, -ggdb and -fno-eliminate-unused-debug-symbols)
+   2. Change the optimization level of the compiled code:
+      a. LOCI_DEBUG=0: -O0
+      b. LOCI_DEBUG=1: -O1
+      c. LOCI_DEBUG=2: -O2
+      d. LOCI_DEBUG=3: -O3
+
+For gnu compilers, -ggdb should enable automatic traceback and reporting upon 
+code termination.
+
 -------------------------------------------------------------------------------
 Notes on installing packages required by Loci
 

--- a/src/conf/Loci.conf
+++ b/src/conf/Loci.conf
@@ -32,10 +32,10 @@ else
 LIB_SUFFIX=so
 endif
 
-
 DEFINES =    $(SYSTEM_DEFINES) \
              $(MACHINE_SPECIFIC) \
              $(DEBUG) \
+			 $(DEBUG_DEFINES)	\
              -DLOCI_SYS_$(SYS_TYPE) \
              -DLOCI_ARCH_$(ARCH_TYPE) \
              $(SPECIAL_DEFINES)

--- a/src/conf/gcc.conf
+++ b/src/conf/gcc.conf
@@ -41,9 +41,11 @@ ifeq ($(BOUNDS_CHECK), 1)
 else
 	BOUND_DEFINES =
 endif
+
+# always include -Wall (all warnings) even in standard compilation mode
+DEBUG = -Wall
 ifneq ($(LOCI_DEBUG),)
-	DEBUG			=	-Wall \
-						-g3   \
+	DEBUG			+=	-g3   \
 						-ggdb \
 						-fno-eliminate-unused-debug-symbols
 	DEBUG_DEFINES	=	-DDEBUG

--- a/src/conf/gcc.conf
+++ b/src/conf/gcc.conf
@@ -26,14 +26,38 @@ LDBSL = g++
 # Dependency Compiler
 MAKEDEPEND = $(CXX) -M
 
+################################################################################
+# Default Optimization Flags
+################################################################################
+OPT0	=	-O0
+OPT1	=	-O1
+OPT2	=	-O2
+OPT3	=	-O3
+OPTL    =   $(OPT1)
 
-DEBUG   = -Wall #-DDEBUG -DBOUNDS_CHECK 
+# Check for Debug Environment Variable
+ifeq ($(BOUNDS_CHECK), 1)
+	BOUND_DEFINES 	= -DBOUNDS_CHECK
+else
+	BOUND_DEFINES =
+endif
+ifneq ($(LOCI_DEBUG),)
+	DEBUG			=	-Wall \
+						-g3   \
+						-ggdb \
+						-fno-eliminate-unused-debug-symbols
+	DEBUG_DEFINES	=	-DDEBUG
+ifeq ($(LOCI_DEBUG), 0)
+	OPT3	=	$(OPT0)
+	OPTL    =   $(OPT0)
+else ifeq ($(LOCI_DEBUG), 1)
+	OPT3	=	$(OPT1)
+else ifeq ($(LOCI_DEBUG), 2)
+	OPT3	=	$(OPT2)
+endif #otherwise, use -O3
+endif
 
-SYSTEM_DEFINES = 
-
-
-#Compiler option used to include debugging information
-CC_DEBUG = #-g
+SYSTEM_DEFINES = $(BOUNDS_DEFINES)
 
 ARCH_FLAGS_i686 =  -march=pentium3 -fno-math-errno -fno-trapping-math -ffinite-math-only -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer
 
@@ -46,16 +70,17 @@ ARCH_FLAGS_arm64 = -fno-math-errno -fno-trapping-math -ffinite-math-only -fno-si
 endif
 
 #Compiler option used to perform maximum optimization
-CC_OPTIMIZE = -O3 $(ARCH_FLAGS_$(ARCH_TYPE))
+# Modify based on the 
+CC_OPTIMIZE = $(OPT3) $(ARCH_FLAGS_$(ARCH_TYPE))
 
 #Compiler Option for reasonable compile times of less performace critical modules.
-CC_OPTIMIZE_LOWER = -O1 
+CC_OPTIMIZE_LOWER = $(OPTL)
 CC_OPT1   = $(CC_OPTIMIZE_LOWER)
 CC_OPT    = $(CC_OPTIMIZE) 
 CC_LIB_FLAGS = 
 
 #Optimizer flags for the C compiler
-C_OPT = -O3 
+C_OPT = $(OPT3)
 
 LD       = $(CXX)
 ifeq ($(SYS_TYPE), SunOS)

--- a/src/conf/icc.conf
+++ b/src/conf/icc.conf
@@ -30,9 +30,36 @@ MAKEDEPEND = $(CXX) -M
 # Turn ON/Off extra debugging error checking (usually off for optimized code)
 # Also turn on array bounds checking (really slows things down)
 # -DENTITY turns on type distinction between entity and integer.
-DEBUG   = #-DDEBUG -DBOUNDS_CHECK 
+# Check for Debug Environment Variable
+################################################################################
+# Default Optimization Flags
+################################################################################
+OPT0	=	-O0
+OPT1	=	-O1
+OPT2	=	-O2
+OPT3	=	-O3
+OPTL    =   $(OPT1)
 
-SYSTEM_DEFINES = 
+ifeq ($(BOUNDS_CHECK), 1)
+	BOUND_DEFINES 	= -DBOUNDS_CHECK
+else
+	BOUND_DEFINES =
+endif
+ifneq ($(LOCI_DEBUG),)
+	DEBUG			=	-Wall \
+						-g3
+	DEBUG_DEFINES	=	-DDEBUG
+ifeq ($(LOCI_DEBUG), 0)
+	OPT3	=	$(OPT0)
+	OPTL    =   $(OPT0)
+else ifeq ($(LOCI_DEBUG), 1)
+	OPT3	=	$(OPT1)
+else ifeq ($(LOCI_DEBUG), 2)
+	OPT3	=	$(OPT2)
+endif
+endif
+
+SYSTEM_DEFINES = BOUNDS_DEFINES
 
 
 #Compiler option used to include debugging information
@@ -43,9 +70,9 @@ ARCH_FLAGS_i686 = -xN -axN
 #Westmere or SandyBridge nodes
 ARCH_FLAGS_x86_64 =  -axAVX -xSSE4.1
 #Compiler option used to perform maximum optimization
-CC_OPTIMIZE = -O3 -restrict -no-prec-div -inline-factor=150 -diag-disable cpu-dispatch -ansi_alias -ip $(ARCH_FLAGS_$(ARCH_TYPE))
+CC_OPTIMIZE = $(OPT3) -restrict -no-prec-div -inline-factor=150 -diag-disable cpu-dispatch -ansi_alias -ip $(ARCH_FLAGS_$(ARCH_TYPE))
 #Compiler Option for reasonable compile times of less performace critical modules.
-CC_OPTIMIZE_LOWER = -O1 -ansi_alias -fp-model precise
+CC_OPTIMIZE_LOWER = $(OPTL) -ansi_alias -fp-model precise
 
 CC_OPT1   = $(CC_OPTIMIZE_LOWER)
 CC_OPT    = $(CC_OPTIMIZE) 

--- a/src/conf/icc.conf
+++ b/src/conf/icc.conf
@@ -45,6 +45,9 @@ ifeq ($(BOUNDS_CHECK), 1)
 else
 	BOUND_DEFINES =
 endif
+
+# always include -Wall (all warnings) even in standard compilation mode
+DEBUG = -Wall
 ifneq ($(LOCI_DEBUG),)
 	DEBUG			=	-Wall \
 						-g3


### PR DESCRIPTION
This feature will pull the LOCI_DEBUG environment variable from the CFD Research's https://github.com/rlfontenot/loci/pull/4 (dev) branch to enable file or code-wide debugging features from module/environment at compile time. It will also add the bounds check feature to the configuration step to ensure there isn't a mangling of bound-check and non-bound-checked files. The install.txt was also updated to inform users of the change and how to use the new features.