### PR TITLE
Memory bug fix that caused the rule manager to allocate excess memory

### DIFF
--- a/src/System/Initialize.cc
+++ b/src/System/Initialize.cc
@@ -939,6 +939,14 @@ namespace Loci {
 
   void Finalize() {
     call_closing_functions(0) ;
+    register_rule_list.clear() ;
+    global_rule_list.clear() ;
+    rule::rdb_cleanup() ;
+    register_key_space_list.clear() ;
+    global_key_space_list.clear() ;
+    //    storeAllocateData.clear() ;
+    //    GPUstoreAllocateData.clear() ;
+    exec_current_fact_db = 0 ;
 #ifdef USE_PETSC
     PetscFinalize() ;
 #else

--- a/src/System/rule.cc
+++ b/src/System/rule.cc
@@ -1447,14 +1447,13 @@ namespace Loci {
   void
   rule::rename(const std::string& s) {
     // get the rule info.
-    rule::info& info = rdb->fiv[-(id+1)] ;
+    rule::info info = rdb->fiv[-(id+1)] ;
     // save the old name
     std::string old_name = info.name() ;
     // replace the "rule_ident" inside ;
     info.rule_ident = s ;
-    // then replace the rdb->fmap
-    rdb->fmap.erase(old_name) ;
-    rdb->fmap[s] = id ;
+    // Get new id
+    id = rdb->get_id(info) ;
   }
 
   rule rule::get_rule_by_name(std::string &name) {

--- a/src/include/mod_db.h
+++ b/src/include/mod_db.h
@@ -81,6 +81,7 @@ namespace Loci {
     } ;
   
     static mod_db *mdb ;
+    static void cleanup_db() { if(mdb) delete mdb ; }
     void create_mod_db() {if(0==mdb) mdb = new mod::mod_db ; }
   public:
     mod(const std::string& name) {

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -877,12 +877,18 @@ namespace Loci {
     struct rule_db {
       std::vector<info> fiv ;
       std::map<std::string,int> fmap ;
+      rule_db() {
+        info no_rule ;
+        fiv.push_back(no_rule) ;
+        fmap[no_rule.name()] = -1 ;
+      }
       int get_id(const info &fi) {
         std::map<std::string,int>::iterator fmi ;
-        if((fmi = fmap.find(fi.name())) == fmap.end()) {
+        std::string fname = fi.name() ;
+        if((fmi = fmap.find(fname)) == fmap.end()) {
           fiv.push_back(fi) ;
-          int id = - fiv.size() ;
-          fmap[fi.name()] = id ;
+          int id = - int(fiv.size()) ;
+          fmap.insert(std::pair<std::string,int>(fname,id)) ;
           return id ;
         }
         return fmi->second ;
@@ -910,6 +916,9 @@ namespace Loci {
     rule(const rule::info& ri)
       { create_rdb(); id = rdb->get_id(ri) ; }
   public:
+    static void rdb_cleanup() { if(rdb) { delete rdb ; rdb = 0; } }
+    static int rdb_size()
+    { WARN(rdb->fiv.size() != rdb->fmap.size()) ; return rdb->fiv.size() ; }
     rule() { create_rdb() ; id = rdb->get_id(info()) ;}
     explicit rule(int i)
       { create_rdb(); id = i ; }


### PR DESCRIPTION
This fix resolves an issue where repeated queries would result in a slowly increasing baseline memory allocation.  This allocation had to do with the internals of how rules were associated with integer indices which resulted in non-unique assignment of indices.  Ultimately this meant that rule information was stored many redundant times after repeated queries.  This fixes this bug.  The code was tested against the Loci and chem quicktest suites.  The changes should not change the behavior of Loci with the exception of the memory behavior described above.  Just for safe measure, it should be tested against the CFDRC codes.