### PR TITLE
RLF[#44]: removed #define Map and switched to using Loci::Map

### DIFF
--- a/src/include/Loci.h
+++ b/src/include/Loci.h
@@ -30,12 +30,7 @@ using Loci::interval ;
 
 // Here we use a #define to define Map because bastard MPI implementations fail
 // to keep Map in the MPI namespace !@#$^!@^^$%
-//using Loci::Map ;
-#ifdef Map
-#undef Map
-#endif
-#define Map Loci::Map
-
+using Loci::Map ;
 using Loci::const_Map ;
 using Loci::MapVec ;
 using Loci::const_MapVec ;

--- a/src/include/Loci.h
+++ b/src/include/Loci.h
@@ -28,8 +28,6 @@ using Loci::create_entitySet ;
 using Loci::EMPTY ;
 using Loci::interval ;
 
-// Here we use a #define to define Map because bastard MPI implementations fail
-// to keep Map in the MPI namespace !@#$^!@^^$%
 using Loci::Map ;
 using Loci::const_Map ;
 using Loci::MapVec ;


### PR DESCRIPTION
This issue will remove #define Map Loci::Map from the Loci.h header.

~From Tim:
Turning "Map" into a macro which is replaced by "Loci::Map" is a potentially dangerous workaround, as it's a pretty common term (e.g. it's used extensively in the Eigen library).

We haven't had any issues internally simply commenting out the preprocessor directives, and uncommenting the original using Loci::Map; line. This might not be a safe fix to commit back to Loci as the referenced MPI implementations causing the original issue could still be around, but it has also been 19 years so perhaps that's no longer a concern.

~From Ed:
I think it is pretty safe to get rid of that code. That was a problem with an early version of C++ bindings for MPI that have since been deprecated (and removed I believe) . I am pretty sure that this is no longer a problem. BTW, if you want to use Loci and avoid this problem just #include instead of <Loci.h> This includes everything but keeps it in the Loci namespace. Then you can decide exactly what wants to be pulled into the Loci namespace. Loci.h is just a convenience header for novice users. I think it would be a good idea to remove the #define, If loci compiles on relatively modern openMPI and MPICH versions of MPI then I think it should be good.