### PR TITLE
EAL[#48] Fixed issue with memory profiling option where real memory w…

### DIFF
--- a/src/System/comp_chomp.cc
+++ b/src/System/comp_chomp.cc
@@ -47,12 +47,6 @@ namespace Loci {
   extern double LociAppFreeRequestBeanCounting ;
   extern double LociAppPeakMemoryBeanCounting ;
   extern double LociAppPMTemp ;
-  namespace {
-    // memory profile function
-    int currentMem(void) {
-      return ::Loci::getmaxrss() ;
-    }
-  }
 
   extern bool in_internal_query;
   extern bool threading_chomping;

--- a/src/System/comp_tools.cc
+++ b/src/System/comp_tools.cc
@@ -46,13 +46,6 @@ using std::ostringstream ;
 #include "loci_globs.h"
 
 
-namespace {
-    // memory profile function
-  double currentMem(void) {
-    return ::Loci::getmaxrss() ;
-  }
-}
-
 //#define VERBOSE
 
 namespace Loci {
@@ -2694,10 +2687,10 @@ namespace Loci {
       //cerr<<"memory profiling (allocation) on: "<<*vi<<endl;
       storeRepP srp = facts.get_variable(*vi) ;
       entitySet alloc_dom = srp->domain() ;
-
-      double currmen = currentMem() ;
-      if(currmen > LociAppPeakMemory)
-        LociAppPeakMemory = currmen ;
+      LociAppPeakMemory = max(LociAppPeakMemory,currentMem()) ;
+      //      Loci::debugout << "LociAppPeakMemory="<< LociAppPeakMemory
+      //                     << ", mem=" << mem
+      //                     << endl ;
 
       int packsize = srp->pack_size(alloc_dom) ;
       LociAppAllocRequestBeanCounting += packsize ;

--- a/src/System/comp_tools.h
+++ b/src/System/comp_tools.h
@@ -719,11 +719,7 @@ namespace Loci {
     execute_memProfileAlloc(const variableSet& vars): vars(vars) {}
     virtual void execute(fact_db &facts, sched_db &scheds) ;
     virtual void Print(std::ostream &s) const ;
-	virtual string getName() {return "execute_memProfileAlloc";};	
-    // memory profile function
-    int currentMem(void) {
-      return ::Loci::getmaxrss() ;
-    }    
+    virtual string getName() {return "execute_memProfileAlloc";};	
     virtual void dataCollate(collectData &data_collector) const ;
   } ;
 
@@ -733,11 +729,7 @@ namespace Loci {
     execute_memProfileFree(const variableSet& vars) : vars(vars) {}
     virtual void execute(fact_db &facts, sched_db& scheds) ;
     virtual void Print(std::ostream &s) const ;
-	virtual string getName() {return "execute_memProfileFree";};
-    // memory profile function
-    int currentMem(void) {
-      return ::Loci::getmaxrss() ;
-    }    
+    virtual string getName() {return "execute_memProfileFree";};
     virtual void dataCollate(collectData &data_collector) const ;
   } ;
 

--- a/src/System/scheduler.cc
+++ b/src/System/scheduler.cc
@@ -1944,21 +1944,58 @@ bool operator <(const timingData &d) const {
                         1, MPI_DOUBLE,
                         MPI_MAX,MPI_COMM_WORLD) ;
 
+          double totalPeakMemory = 0 ;
+          MPI_Allreduce(&LociAppPeakMemory,
+                        &totalPeakMemory,
+                        1, MPI_DOUBLE,
+                        MPI_SUM,MPI_COMM_WORLD) ;
+          double avgPeakMemory = totalPeakMemory/MPI_processes ;
+
           double LargestPeakMemoryBeanCounting = 0 ;
           MPI_Allreduce(&LociAppPeakMemoryBeanCounting,
                         &LargestPeakMemoryBeanCounting,
                         1, MPI_DOUBLE,
                         MPI_MAX,MPI_COMM_WORLD) ;
 
+          double totalPeakMemoryBeanCounting = 0 ;
+          MPI_Allreduce(&LociAppPeakMemoryBeanCounting,
+                        &totalPeakMemoryBeanCounting,
+                        1, MPI_DOUBLE,
+                        MPI_SUM,MPI_COMM_WORLD) ;
+          double avgPeakMemoryBeanCounting = totalPeakMemoryBeanCounting/MPI_processes ;
+
           Loci::debugout << endl ;
           Loci::debugout << "The global largest Peak Memory: "
                          << LargestPeakMemory << " bytes ("
                          << LargestPeakMemory/(1024*1024) << "MB)"
                          << endl ;
+          Loci::debugout << "The global mean Peak Memory: "
+                         << avgPeakMemory << " bytes ("
+                         << avgPeakMemory/(1024*1024) << "MB)"
+                         << ", imbalance="
+                         << 100*(LargestPeakMemory-avgPeakMemory)/avgPeakMemory
+                         << "%" << endl ;
           Loci::debugout << "The global largest Peak Memory in bean counting: "
                          << LargestPeakMemoryBeanCounting << " bytes ("
                          << LargestPeakMemoryBeanCounting/(1024*1024) << "MB)"
                          << endl ;
+          Loci::debugout << "The global mean Peak Memory in bean counting: "
+                         << avgPeakMemoryBeanCounting << " bytes ("
+                         << avgPeakMemoryBeanCounting/(1024*1024) << "MB)"
+                         << ", imbalance="
+                         << 100*(LargestPeakMemoryBeanCounting-avgPeakMemoryBeanCounting)/avgPeakMemoryBeanCounting
+                         << "%" << endl ;
+          // Reset flags for next run
+          LociAppPeakMemory = 0 ;
+          LociAppAllocRequestBeanCounting = 0 ;
+          LociAppFreeRequestBeanCounting = 0 ;
+          LociAppPeakMemoryBeanCounting = 0 ;
+          LociAppLargestAlloc = 0 ;
+          LociAppLargestAllocVar= variable("EMPTY") ;
+          LociAppLargestFree = 0 ;
+          LociAppLargestFreeVar= variable("EMPTY") ;
+          LociAppPMTemp = 0 ;
+          LociInputVarsSize = 0 ;
         }
       }
 

--- a/src/include/Tools/debug.h
+++ b/src/include/Tools/debug.h
@@ -88,6 +88,8 @@ using std::abort ;
 
 namespace Loci {
   long getmaxrss() ;
+  // memory profile function
+  inline double currentMem(void) { return ::Loci::getmaxrss()*1024.0 ;  }    
 }
 
 #ifdef MEMDEBUG


### PR DESCRIPTION
This fixes an issue with the memory profiling option where real memory was reported as bytes, but was actually kbytes.  Also added some extra output to write out memory imbalance and improve diagnostics for multiple query runs.