### PR TITLE
Ignore library hints from cmake-built HDF5.

### DIFF
--- a/configure
+++ b/configure
@@ -608,8 +608,12 @@ H5SUPPORTLIBS=-lz
 H5SUPPORTLIBSPATHS=
 
 if [ -e $H5PATH/lib/libhdf5.settings ]; then
-    H5SUPPORTLIBS=`grep "Extra libraries" $H5PATH/lib/libhdf5.settings | sed "s/.*://"`
-    H5SUPPORTLIBSPATHS=`grep "AM_LDFLAGS" $H5PATH/lib/libhdf5.settings | sed "s/.*://"`
+    # Detect if cmake build system was used to build hdf5, and parse settings file if not.
+    TMP=`grep "Extra libraries" $H5PATH/lib/libhdf5.settings | sed "s/.*://"`
+    if [[ $TMP != *";"* ]]; then
+        H5SUPPORTLIBS=$TMP
+        H5SUPPORTLIBSPATHS=`grep "AM_LDFLAGS" $H5PATH/lib/libhdf5.settings | sed "s/.*://"`
+    fi
 fi
 
 echo \# HDF5 File I/O Libraries Setup >> sys.conf


### PR DESCRIPTION
Closes #51. This is a simple workaround for a bug in the configure script where the format of the "Extra libraries" line in libhdf5.settings is incompatible with the build process when HDF5 was built using the cmake infrastructure instead of autotools. The fix is simply to ignore the line if a semicolon is detected within it. It seems that these flags are not necessary in general, and could likely be safely removed.