### PR TITLE
Fixed line number counter in lpp

### DIFF
--- a/src/FVMtools/vogCheck.loci
+++ b/src/FVMtools/vogCheck.loci
@@ -507,7 +507,6 @@ $type report param<bool> ;
 $type minVol param<real_t> ;
 $type maxTwist param<real_t> ;
 $type maxShearTwist param<real_t> ;
-$type modelName param<string> ;
 $type convexCell param<int> ;
 
 $rule singleton(report<-volRatio,maxCellAngle,minVol,maxTwist,maxShearTwist,topo,modelName,convexCell,topocheck),option(disable_threading) {


### PR DESCRIPTION
Sometimes lpp was losing count of lines as it processed loci files.  This resulted in error and documentation messages that had incorrect lines.  This was caused by the parser not accounting for lines processed when processing variables inside of rules that happened to be at the end of the line.  This patch fixes that bug.  Tests show that the line numbers are now correctly counted.  Tested with Loci and chem quickTest regression tests.