### PR TITLE
EAL[#59] Fixed issue with javadoc comments causing bad strings in lpp…

### DIFF
--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -246,7 +246,11 @@ string cleanupComment(const string &s) {
       while(i+1<s.size() && spaceChar(s[i+1])) 
 	i++ ;
       cleancomment += ' ' ;
-    } else
+    } else if(s[i] == '\\') {
+      cleancomment += "\\\\" ;
+    } else if(s[i] == '"') {
+      cleancomment += "\\\"" ;
+    } else if(s[i] >= ' ' &&  s[i] <='~') // valid ascii character
       cleancomment += s[i] ;
   }
   return cleancomment ;


### PR DESCRIPTION
This fixes bug where lpp preprocessor could generate invalid c++ output files if javadoc comments contained quotes or backslash characters.