### PR TITLE
62 clang warning clear

### DIFF
--- a/quickTest/FVM/IOplot.loci
+++ b/quickTest/FVM/IOplot.loci
@@ -184,10 +184,10 @@ $rule pointwise(boundary::cell2nodeD(X)<-boundary_scalar_sumD(X),boundary_nodalw
     $c2nD_v3d_sum(X) = vector3d<double>(0.,0.,0.) ;
   }
 
-  $type X store<vect3d> ;
+  $type V store<vect3d> ;
   
-  $rule apply((upper,lower,boundary_map)->face2node->c2nD_v3d_sum(X)<-
-	      X,cellcenter,(upper,lower,boundary_map)->face2node->pos)[Loci::Summation],
+  $rule apply((upper,lower,boundary_map)->face2node->c2nD_v3d_sum(V)<-
+	      V,cellcenter,(upper,lower,boundary_map)->face2node->pos)[Loci::Summation],
     constraint(geom_cells) {
     int sztot = 0 ;
     
@@ -217,42 +217,42 @@ $rule pointwise(boundary::cell2nodeD(X)<-boundary_scalar_sumD(X),boundary_nodalw
     for(vector<int>::iterator vi = ns;vi!=ne;++vi) {
       int nd = *vi ;
       const real weight = 1./norm($*pos[nd]-$cellcenter) ;
-      vector3d<double> v(realToDouble($X.x*weight),
-			realToDouble($X.y*weight),
-			realToDouble($X.z*weight)) ;
-      join($*c2nD_v3d_sum(X)[nd],v) ;
+      vector3d<double> v(realToDouble($V.x*weight),
+			realToDouble($V.y*weight),
+			realToDouble($V.z*weight)) ;
+      join($*c2nD_v3d_sum(V)[nd],v) ;
     }
   }
 
-  $type cell2nodeD_v3d(X) store<vector3d<double> > ;
-  $rule pointwise(cell2nodeD_v3d(X)<-c2nD_v3d_sum(X),nodalw_sumD) {
+  $type cell2nodeD_v3d(V) store<vector3d<double> > ;
+  $rule pointwise(cell2nodeD_v3d(V)<-c2nD_v3d_sum(V),nodalw_sumD) {
     double rsum = 1./(double($nodalw_sumD)+1e-20) ;
-    $cell2nodeD_v3d(X) = $c2nD_v3d_sum(X)*rsum ;
+    $cell2nodeD_v3d(V) = $c2nD_v3d_sum(V)*rsum ;
   }
-  $type boundary_v3d_sumD(X) store<vector3d<double> > ;
+  $type boundary_v3d_sumD(V) store<vector3d<double> > ;
   
-  $rule unit(boundary_v3d_sumD(X)),constraint(pos) {
-    $boundary_v3d_sumD(X) = vector3d<double>(0.0,0.0,0.0) ;
+  $rule unit(boundary_v3d_sumD(V)),constraint(pos) {
+    $boundary_v3d_sumD(V) = vector3d<double>(0.0,0.0,0.0) ;
   }
 
-  $type X_f store<vect3d> ;
+  $type V_f store<vect3d> ;
   
-  $rule apply(face2node->boundary_v3d_sumD(X)<-face2node->pos,X_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
+  $rule apply(face2node->boundary_v3d_sumD(V)<-face2node->pos,V_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
     int fsz = $face2node.size();
     for(int i=0;i<fsz;++i) {
       const real weight = 1./norm($face2node[i]->$pos-$facecenter) ;
-      vector3d<double> v(realToDouble($X_f.x*weight),
-			realToDouble($X_f.y*weight),
-			realToDouble($X_f.z*weight)) ;
-      $face2node[i]->$boundary_v3d_sumD(X) += v ;
+      vector3d<double> v(realToDouble($V_f.x*weight),
+			realToDouble($V_f.y*weight),
+			realToDouble($V_f.z*weight)) ;
+      $face2node[i]->$boundary_v3d_sumD(V) += v ;
     }
   }
 
-  $rule pointwise(boundary::cell2nodeD_v3d(X)<-
-		  boundary_v3d_sumD(X),boundary_nodalw_sumD),
+  $rule pointwise(boundary::cell2nodeD_v3d(V)<-
+		  boundary_v3d_sumD(V),boundary_nodalw_sumD),
     constraint(boundary_node) {
       double rsum = 1./(double($boundary_nodalw_sumD)+1e-20) ;
-      $cell2nodeD_v3d(X) = $boundary_v3d_sumD(X)*rsum ;
+      $cell2nodeD_v3d(V) = $boundary_v3d_sumD(V)*rsum ;
   }
 
 

--- a/quickTest/FVM/tests/Makefile
+++ b/quickTest/FVM/tests/Makefile
@@ -13,7 +13,7 @@ TestResults: $(TEST_FILES) FRC
 FRC:
 
 %.test : %.vars
-	FLOWTEST="$(FLOWTEST)" EXTRACT="$(EXTRACT)" NDIFF=../ndiff ./tests.sh $*.vars
+	FLOWTEST="$(FLOWTEST)" EXTRACT="$(EXTRACT)" NDIFF=../ndiff LOCI_BASE=$(LOCI_BASE) ./tests.sh $*.vars
 
 clean:
 	rm -fr TEST_* TestResults $(TEST_FILES)

--- a/src/FVMAdapt/write_vog_module.loci
+++ b/src/FVMAdapt/write_vog_module.loci
@@ -138,10 +138,13 @@ public:
        
       hid_t attr = H5Aopen_name(group_id,"numNodes");
       //data type and variable has to match
-      hid_t ret  = H5Aread(attr, H5T_NATIVE_LLONG, &tmp_numNodes);
+//      hid_t ret  =
+      H5Aread(attr, H5T_NATIVE_LLONG, &tmp_numNodes);
        
-      ret =  H5Aclose(attr);
-      ret = H5Gclose(group_id);
+//      ret =
+      H5Aclose(attr);
+//      ret =
+      H5Gclose(group_id);
       numNodes = tmp_numNodes;
     }
     

--- a/src/FVMtools/Makefile
+++ b/src/FVMtools/Makefile
@@ -51,8 +51,8 @@ $(LOCI_BASE)/lib/libsprng.${LIB_SUFFIX}:
 
 extract: $(OBJS) $(DEPS)
 	$(LD) -o extract $(OBJS) $(TEC360LIB) $(LOCAL_LIBS) $(LIBS) $(LDFLAGS)
-
-libadf/libadf.a:
+.PHONY: FORCE
+libadf/libadf.a: FORCE
 	$(MAKE) -C libadf libadf.a
 
 extruder: extruder.o $(DEPS)

--- a/src/FVMtools/libadf/ADF_interface.c
+++ b/src/FVMtools/libadf/ADF_interface.c
@@ -137,6 +137,7 @@ static char	data_chunk_start_tag[] = "DaTa" ;
 #endif
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wsometimes-uninitialized"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 /***********************************************************************
     Error strings

--- a/src/FVMtools/libadf/ADF_interface.c
+++ b/src/FVMtools/libadf/ADF_interface.c
@@ -135,8 +135,9 @@ static char	data_chunk_start_tag[] = "DaTa" ;
 #ifndef __clang__
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #endif
-
+#ifdef __clang__
 #pragma GCC diagnostic ignored "-Wsometimes-uninitialized"
+#endif
 /***********************************************************************
     Error strings
     These strings must be kept in sync with the error defines in ADF.h.

--- a/src/FVMtools/libadf/ADF_interface.c
+++ b/src/FVMtools/libadf/ADF_interface.c
@@ -132,9 +132,11 @@ static char	data_chunk_start_tag[] = "DaTa" ;
 #endif
 #endif
 
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
 
-
+#pragma GCC diagnostic ignored "-Wsometimes-uninitialized"
 /***********************************************************************
     Error strings
     These strings must be kept in sync with the error defines in ADF.h.

--- a/src/FVMtools/libadf/ADF_internals.c
+++ b/src/FVMtools/libadf/ADF_internals.c
@@ -248,7 +248,9 @@ bytes	start	end   description      range / format
 #include "ADF.h"
 #include "ADF_internals.h"
 
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
 
 #if defined (_WIN64) || defined(_WIN32)
 typedef __int64 file_offset_t;

--- a/src/Makefile
+++ b/src/Makefile
@@ -64,7 +64,7 @@ System/libLoci.$(LIB_SUFFIX): FORCE
 lpp: Tools/libTools.$(LIB_SUFFIX) FORCE
 	$(MAKE) -C lpp LOCI_BASE="$(LOCI_BASE)" lpp
 
-FVMtools: library lpp FVMAdapt FORCE
+FVMtools: library lpp FVMAdapt SPRNG FORCE
 	$(MAKE) -C FVMtools LOCI_BASE="$(LOCI_BASE)" default
 
 FVMMod: lpp FORCE
@@ -79,7 +79,7 @@ FVMOverset: lpp FORCE
 JUNK =
 
 .PHONY: test
-test:
+test: default
 	$(MAKE) -C quickTest LOCI_BASE="$(LOCI_BASE)"
 
 .PHONY: clean

--- a/src/Tools/expr.cc
+++ b/src/Tools/expr.cc
@@ -1106,10 +1106,10 @@ namespace Loci {
     This method is not recursive. While loops are used to reduce the amount of
     function calling overhead.
   */
-#if defined(__GNUC__) && !defined(__clang__)
+  //#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
+  //#endif
   void expression::compile_expr(compiled_expr &c_expr, int dnum)
   {
     //a pointer to the expression being compiled
@@ -1423,9 +1423,9 @@ namespace Loci {
       }
   }
 
-#if defined(__GNUC__) && !defined(__clang__)
+  //#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
+  //#endif
 
 
   double expression::evaluate(const std::map<std::string, double> &varmap) const

--- a/src/include/store_impl.h
+++ b/src/include/store_impl.h
@@ -319,14 +319,14 @@ namespace Loci {
     // Get the sum of each object size and maximum size of object in the
     // container for allocation purpose
     //-------------------------------------------------------------------
-    size_t  incount = 0;
+    //    size_t  incount = 0;
     int     stateSize, maxStateSize = 0;
     typedef data_schema_traits<T> schema_traits ;
     T *base_ptr = get_base_ptr() ;
     for( ci = ecommon.begin(); ci != ecommon.end(); ++ci) {
       typename schema_traits::Converter_Type cvtr( base_ptr[*ci] );
       stateSize    = cvtr.getSize();
-      incount     += stateSize;
+      //      incount     += stateSize;
       maxStateSize = max( maxStateSize, stateSize );
     }
 

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -276,10 +276,8 @@ public:
     return s ;
   }
 } ;
-#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 template<class T> class funclist : public parsebase {
 public:
   list<T> flist ;
@@ -328,9 +326,8 @@ public:
   }
 } ;
   
-#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
+
 template<class T> class templlist : public parsebase {
 public:
   list<T> flist ;

--- a/src/sprng/cmrg.c
+++ b/src/sprng/cmrg.c
@@ -131,10 +131,7 @@ int NGENS=0;		  /* number of random streams in current process */
 
 
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 
 /* Initialize random number stream */
 
@@ -681,7 +678,4 @@ int *igen;
   return 1;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 

--- a/src/sprng/lcg64.c
+++ b/src/sprng/lcg64.c
@@ -125,10 +125,7 @@ int NGENS=0;		  /* number of random streams in current process */
 
 
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 
 /* Initialize random number stream */
 
@@ -616,6 +613,3 @@ int *igen;
   return 1;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif

--- a/src/sprng/mlfg.c
+++ b/src/sprng/mlfg.c
@@ -249,10 +249,7 @@ static void si_double(uint64 *a,  uint64 *b, int length)
 }
 
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 
 static void pow3(uint64 n, uint64 *ui)		/* return 3^n (mod 2^BITS) */
 {
@@ -830,7 +827,3 @@ int *igen;
   return 1;
 }
 
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
This patch fixes spurious warning issues under clang compiles on MacOS.  Some dependency faults in Makefiles were also uncovered and fixed during the testing.