### PR TITLE
Fixed problem with codes failing to stop on nan

### DIFF
--- a/src/conf/gcc.conf
+++ b/src/conf/gcc.conf
@@ -61,14 +61,14 @@ endif
 
 SYSTEM_DEFINES = $(BOUNDS_DEFINES)
 
-ARCH_FLAGS_i686 =  -march=pentium3 -fno-math-errno -fno-trapping-math -ffinite-math-only -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer
+ARCH_FLAGS_i686 =  -march=pentium3 -fno-math-errno -fno-trapping-math -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer
 
 ifeq ($(SYS_TYPE), Darwin)
-ARCH_FLAGS_x86_64 = -fno-math-errno -fno-trapping-math -ffinite-math-only -fstrict-aliasing -fomit-frame-pointer 
-ARCH_FLAGS_arm64 = -fno-math-errno -fno-trapping-math -ffinite-math-only -fstrict-aliasing -fomit-frame-pointer 
+ARCH_FLAGS_x86_64 = -fno-math-errno -fno-trapping-math -fstrict-aliasing -fomit-frame-pointer 
+ARCH_FLAGS_arm64 = -fno-math-errno -fno-trapping-math -fstrict-aliasing -fomit-frame-pointer 
 else
-ARCH_FLAGS_x86_64 = -fno-math-errno -fno-trapping-math -ffinite-math-only -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer 
-ARCH_FLAGS_arm64 = -fno-math-errno -fno-trapping-math -ffinite-math-only -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer 
+ARCH_FLAGS_x86_64 = -fno-math-errno -fno-trapping-math -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer 
+ARCH_FLAGS_arm64 = -fno-math-errno -fno-trapping-math -fno-signaling-nans -fstrict-aliasing -fomit-frame-pointer 
 endif
 
 #Compiler option used to perform maximum optimization


### PR DESCRIPTION
The gcc configuration flag included a -ffinite-math-only flag which caused the std::isnan() function to fail. This means that tests for a nan residual were no longer causing codes to terminate execution on non-productive computaitons.