### PR TITLE
Updated README.md to use the proper repo link for Loci in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ submodules:
 
 ```bash
 cd $HOME/code
-git clone https://github.com/rlfontenot/loci.git
+git clone https://github.com/EdwardALuke/loci.git
 cd loci
 git submodule init
 ```


### PR DESCRIPTION
In the current README.md file the example text for how to clone the loci repo uses a non-existent repo. I updated the link in the example to point to this Github repo.