### PR TITLE
Add cgns submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "ext/petsc"]
 	path = ext/petsc
 	url = https://github.com/petsc/petsc.git
+[submodule "ext/cgns"]
+	path = ext/cgns
+	url = https://github.com/CGNS/CGNS.git


### PR DESCRIPTION
I noticed that the CGNS submodule wasn't present in the repo, so I added it and pointed it to the v4.4.0 tag as I have tested that version locally and it seems to play nice with Loci.