### PR TITLE
Fixed issue with lpp segfaulting when errors were reported

### DIFF
--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -2932,7 +2932,6 @@ void parseFile::processFile(string file, ostream &outputFile,
           } else if(key == "include") {
             killsp() ;
             if(!is_string(is)) {
-	      parseInfo.fileNameStack.pop_back() ;
               throw parseError("syntax error") ;
 	    }
             string newfile = get_string(is) ;
@@ -2961,11 +2960,9 @@ void parseFile::processFile(string file, ostream &outputFile,
 	    }
             
           } else {
-	    parseInfo.fileNameStack.pop_back() ;
             throw parseError("syntax error: unknown key") ;
           }
         } else {
-	  parseInfo.fileNameStack.pop_back() ;
           throw parseError("unable to process '$' command") ;
         }
       } else {


### PR DESCRIPTION
The Loci preprocessor was segfaulting after providing errors about untyped variables.  The issue was caused by incorrect exception management of the stack of files under process.  This fix corrects the problem by moving the file stack code to the appropriate catch block.