### PR TITLE
Fix for array bounds checking diagnostic

### DIFF
--- a/src/conf/gcc.conf
+++ b/src/conf/gcc.conf
@@ -37,9 +37,9 @@ OPTL    =   $(OPT1)
 
 # Check for Debug Environment Variable
 ifeq ($(BOUNDS_CHECK), 1)
-	BOUND_DEFINES 	= -DBOUNDS_CHECK
+	BOUNDS_DEFINES 	= -DBOUNDS_CHECK
 else
-	BOUND_DEFINES =
+	BOUNDS_DEFINES =
 endif
 
 # always include -Wall (all warnings) even in standard compilation mode

--- a/src/conf/icc.conf
+++ b/src/conf/icc.conf
@@ -41,9 +41,9 @@ OPT3	=	-O3
 OPTL    =   $(OPT1)
 
 ifeq ($(BOUNDS_CHECK), 1)
-	BOUND_DEFINES 	= -DBOUNDS_CHECK
+	BOUNDS_DEFINES 	= -DBOUNDS_CHECK
 else
-	BOUND_DEFINES =
+	BOUNDS_DEFINES =
 endif
 
 # always include -Wall (all warnings) even in standard compilation mode

--- a/src/conf/llvm.conf
+++ b/src/conf/llvm.conf
@@ -37,9 +37,9 @@ OPTL    =   $(OPT1)
 
 # Check for Debug Environment Variable
 ifeq ($(BOUNDS_CHECK), 1)
-	BOUND_DEFINES 	= -DBOUNDS_CHECK
+	BOUNDS_DEFINES 	= -DBOUNDS_CHECK
 else
-	BOUND_DEFINES =
+	BOUNDS_DEFINES =
 endif
 
 # Turn ON/Off extra debugging error checking (usually off for optimized code)


### PR DESCRIPTION
A bug in the compiler configure files caused the --bounds-check option to the configure script to not actually enable bounds checking.  This fixes the compiler scripts to correct the typo that caused the problem.