### PR TITLE
Cleanup of git configure system 

### DIFF
--- a/quickTest/FVM/main.loci
+++ b/quickTest/FVM/main.loci
@@ -57,31 +57,6 @@ namespace flowPsi {
 
   double StartTime = 0 ;
   
-  const char *revision_name = "$Name:  $" ;
-
-  std::string version() {
-    const char *p = revision_name;
-    while(*p!=':' && *p!='\0')
-      ++p ;
-    if(*p!= '\0')
-      ++p ;
-    while(*p!=' ' && *p!='\0')
-      ++p ;
-    if(*p!= '\0')
-      ++p ;
-    std::string rn ;
-    while(*p!='$' &&  *p!=' ' && *p!='\0') 
-      rn += *p++ ;
-    return rn ;
-  }
-
-  std::string date() {
-    std::string rn ;
-    rn += __DATE__ ;
-    rn += " " ;
-    rn += __TIME__ ;
-    return rn ;
-  }    
 }
 
 void pretty_print_string(string i,string s, ostream &o) {
@@ -202,8 +177,6 @@ int main(int ac, char *av[]) {
       ac -= 2 ;
       av += 2 ;
     } else if(ac >= 2 && !strcmp(av[1],"-v")) {
-      cout << "flowPsi version:  " << flowPsi::version() << " Compiled On "
-           << flowPsi::date() << endl ;
       cout << "Loci version: " << Loci::version() << endl ;
       if(ac == 2) {
         Loci::Finalize() ;
@@ -268,21 +241,15 @@ int main(int ac, char *av[]) {
   
 
   if(ac <= 1 && !input_desc && !output_doc) {
-    cout << "flowPsi version:  " << flowPsi::version() << " Date: "
-         << flowPsi::date() << endl ;
     cout << "Loci version: " << Loci::version() << endl ;
     Loci::Finalize() ;
     exit(0) ;
   }
 
   if(Loci::MPI_rank == 0) {
-    cout << "flowPsi version:  " << flowPsi::version() << " Date: "
-         << flowPsi::date() << endl ;
     cout << "Loci version: " << Loci::version() << endl ;
   }
   
-  Loci::debugout << "flowPsi version:  " << flowPsi::version() << " Date: "
-                 << flowPsi::date() << endl ;
   Loci::debugout << "Loci version: " << Loci::version() << endl ;
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,7 @@
 LOCI_BASE = $(shell pwd)
 LOCI_COMPILE = true
 include Loci.conf
+include version.conf
 
 
 DEFINES = $(DEBUG) $(SYSTEM_DEFINES) $(MACHINE_SPECIFIC)
@@ -55,13 +56,26 @@ SPRNG :
 
 .PHONY: FORCE
 
-Tools/libTools.$(LIB_SUFFIX): FORCE
+LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/")
+LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/")
+include/Config/version_info.h: FORCE
+	@echo \#ifndef CONFIG_LOCI_INFO_H > version_info.h
+	@echo \#define CONFIG_LOCI_INFO_H >> version_info.h
+	@echo \#define LOCI_VERSION \"$(GIT_INFO)\" >> version_info.h
+	@echo \#define LOCI_BRANCH \"$(GIT_BRANCH)\" >> version_info.h
+	@echo \#define LOCI_VERSION_MAJOR $(LOCI_MAJOR_VERSION) >> version_info.h
+	@echo \#define LOCI_VERSION_MINOR $(LOCI_MINOR_VERSION) >> version_info.h
+	@echo \#endif >> version_info.h
+	@# Only update version_info.h if it has changed.
+	@if [ -e $@ ]; then if ! cmp version_info.h $@; then mv version_info.h $@ ; else rm version_info.h ; fi ; else mv version_info.h $@ ; fi
+
+Tools/libTools.$(LIB_SUFFIX): include/Config/version_info.h FORCE
 	$(MAKE) -C Tools LOCI_BASE="$(LOCI_BASE)" libTools.$(LIB_SUFFIX)
 
-System/libLoci.$(LIB_SUFFIX): FORCE
+System/libLoci.$(LIB_SUFFIX): include/Config/version_info.h FORCE
 	$(MAKE) -C System LOCI_BASE="$(LOCI_BASE)" libLoci.$(LIB_SUFFIX)
 
-lpp: Tools/libTools.$(LIB_SUFFIX) FORCE
+lpp: Tools/libTools.$(LIB_SUFFIX) include/Config/version_info.h FORCE
 	$(MAKE) -C lpp LOCI_BASE="$(LOCI_BASE)" lpp
 
 FVMtools: library lpp FVMAdapt SPRNG FORCE

--- a/src/System/Loci_version.cc
+++ b/src/System/Loci_version.cc
@@ -22,22 +22,9 @@
 
 namespace Loci {
 
-  const char *revision_name = "$Name: " LOCI_BRANCH "-" LOCI_VERSION " $" ;
 
   std::string version() {
-    const char *p = revision_name;
-    while(*p!=':' && *p!='\0')
-      ++p ;
-    if(*p!= '\0')
-      ++p ;
-    while(*p!=' ' && *p!='\0')
-      ++p ;
-    if(*p!= '\0')
-      ++p ;
-    std::string rn ;
-    while(*p!='$' &&  *p!=' ' && *p!='\0')
-      rn += *p++ ;
-
+    std::string rn = std::string(LOCI_BRANCH)+"-"+std::string(LOCI_VERSION) ;
     rn += " Compiled On " ;
     rn += __DATE__ ;
     rn += " " ;

--- a/src/conf/Loci.conf
+++ b/src/conf/Loci.conf
@@ -35,7 +35,6 @@ DEFINES =    $(SYSTEM_DEFINES) \
              $(DEBUG_DEFINES) \
              -DLOCI_SYS_$(SYS_TYPE) \
              -DLOCI_ARCH_$(ARCH_TYPE) \
-             $(VERSION_FLAGS) \
              $(SPECIAL_DEFINES)
 
 LOCI_INCLUDES  = -I$(LOCI_BASE)/include

--- a/src/conf/version.conf
+++ b/src/conf/version.conf
@@ -1,9 +1,6 @@
 GIT_INFO   = unknown-version
 GIT_BRANCH = unknown-branch
 
-LOCI_REV = '$Name: ${GIT_BRANCH}-${GIT_INFO} $'
 COMP_NAME = $(shell echo $(CXX) | sed -e 's/ .*//' -e 's/.*\///')
-LOCI_REV1 = $(shell echo "$(LOCI_REV)"| sed -e 's/.*: *//' -e 's/ *\$$//' -e 's/ //g')
-LOCI_REVISION_NAME = $(shell if [ -n "$(LOCI_REV1)" ]; then echo "$(LOCI_REV1)"; else date +%m.%d.%y;fi)
+LOCI_REVISION_NAME = '${GIT_BRANCH}-${GIT_INFO}'
 
-VERSION_FLAGS = -DLOCI_VERSION="\"$(GIT_INFO)\"" -DLOCI_BRANCH="\"$(GIT_BRANCH)\""

--- a/src/include/Config/conf.h
+++ b/src/include/Config/conf.h
@@ -21,6 +21,8 @@
 #ifndef LOCI_CONFIGURATION_INCLUDE
 #define LOCI_CONFIGURATION_INCLUDE
 
+#include "Config/version_info.h"
+
 #define DYNAMICSCHEDULING
 
 #ifdef restrict

--- a/src/lpp/main.cc
+++ b/src/lpp/main.cc
@@ -27,22 +27,9 @@ list<string> include_dirs ;
 
 bool prettyOutput = false ;
 namespace {
-  const char *revision_name = "$Name: " LOCI_BRANCH "-" LOCI_VERSION " $" ;
 
   std::string version() {
-    const char *p = revision_name;
-    while(*p!=':' && *p!='\0')
-      ++p ;
-    if(*p!= '\0')
-      ++p ;
-    while(*p!=' ' && *p!='\0')
-      ++p ;
-    if(*p!= '\0')
-      ++p ;
-    std::string rn ;
-    while(*p!='$' &&  *p!=' ' && *p!='\0')
-      rn += *p++ ;
-
+    string rn = string(LOCI_BRANCH) + "-" + string(LOCI_VERSION) ;
     rn += " lpp compiled at " ;
     rn += __DATE__ ;
     rn += " " ;


### PR DESCRIPTION
This cleanup modifies the build system to create the file include/Config/version_info.h which contains automatically generated defines that can be used to control version dependent compilation of Loci applications.  Specifically it defines LOCI_VERSION, LOCI_BRANCH, LOCI_VERSION_MAJOR and LOCI_VERSION_MINOR.  The previous implementation defined LOCI_VERSION and LOCI_BRANCH on the command line, while this moves it into the include files.  The other two options defined the integer value for the major and minor version number which can be used to use macro directed compilation in Loci codes that want to be able to compile against multiple Loci versions.  In addition, this cleans up previous code that still used the $Name: syntax that was used to pass some of this information from the CVS version control system.  This is no longer needed as we are no longer using CVS and can directly access the LOCI_VERSION and LOCI_BRANCH macros to perform this feature.  This is one important step that needs to be completed before creating a branch for stabilizing beta testing.