### PR TITLE
Fixed issue with finding Loci libraries on unit tests.

### DIFF
--- a/quickTest/FVMModUnitTests/tests/Makefile
+++ b/quickTest/FVMModUnitTests/tests/Makefile
@@ -16,7 +16,9 @@ TestResults: $(TEST_FILES) FRC
 
 
 %.test : %.vars
-	../FVMModUnitTest $*.vars >& $*.test
+	@echo Test $*
+	@DYLD_LIBRARY_PATH=$(LOCI_BASE)/lib:$DYLD_LIBRARY_PATH LD_LIBRARY_PATH=$(LOCI_BASE)/lib:$LD_LIBRARY_PATH ../FVMModUnitTest $*.vars >& $*.test
+	@grep TEST $*.test
 
 
 clean:


### PR DESCRIPTION
The test option of make was failing on MacOS machines because the unit test executable was not finding the Loci libraries. This patch fixes this problem by adding defining both LD_LIBRARY_PATH and DYLD_LIBRARY_PATH on the execution lines from the makefile.  Also added a bit more output information from the makefile to output the result of tests.