### PR TITLE
RLF[#97]: changed X to S, V, and M in limiters. Passed Tests

### DIFF
--- a/src/FVMMod/limiters/barth.loci
+++ b/src/FVMMod/limiters/barth.loci
@@ -31,33 +31,33 @@ namespace Loci {
 
   $type B_limiter Constraint ;  
   $type firstOrderCells store<char> ;
-  $type X store<real> ;
-  $type X_f store<real> ;
-  $rule pointwise(limiters(X)<-cellcenter,X,grads(X),firstOrderCells,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+  $type S store<real> ;
+  $type S_f store<real> ;
+  $rule pointwise(limiters(S)<-cellcenter,S,grads(S),firstOrderCells,
+		  upper->cr->S,upper->facecenter,
+		  lower->cl->S,lower->facecenter,
+		  boundary_map->S_f,boundary_map->facecenter),
       constraint(geom_cells,B_limiter) {
-    const real Xcc = $X ;
+    const real Xcc = $S ;
     real qmax = Xcc ;
     real qmin = qmax ;
-    const vect3d Xgr = $grads(X) ;
+    const vect3d Xgr = $grads(S) ;
 
     const int usz = $upper.size() ;
     for(int i=0;i<usz;++i) {
-      const real Xi = $upper[i]->$cr->$X ;
+      const real Xi = $upper[i]->$cr->$S ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
     }
     const int lsz= $lower.size() ;
     for(int i=0;i<lsz;++i) {
-      const real Xi = $lower[i]->$cl->$X ;
+      const real Xi = $lower[i]->$cl->$S ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
     }
     const int bsz = $boundary_map.size() ;
     for(int i=0;i<bsz;++i) {
-      const real Xi = $boundary_map[i]->$X_f ;
+      const real Xi = $boundary_map[i]->$S_f ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
     }      
@@ -84,27 +84,25 @@ namespace Loci {
         limi = min(limi,(qmin-Xcc)/(qdif-1e-100)) ;
     }
     
-    $limiters(X) = realToDouble(limi) ;
+    $limiters(S) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X store<vect3d> ;
-  $type X_f store<vect3d> ;
+  $type V store<vect3d> ;
+  $type V_f store<vect3d> ;
 
-  $rule pointwise(limiterv3d(X)<-cellcenter,X,gradv3d(X),firstOrderCells,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+  $rule pointwise(limiterv3d(V)<-cellcenter,V,gradv3d(V),firstOrderCells,
+		  upper->cr->V,upper->facecenter,
+		  lower->cl->V,lower->facecenter,
+		  boundary_map->V_f,boundary_map->facecenter),
       constraint(geom_cells,B_limiter) {
-    const vect3d Xcc = $X ;
+    const vect3d Xcc = $V ;
     vect3d qmax = Xcc ;
     vect3d qmin = qmax ;
-    const tens3d Xgr = $gradv3d(X) ;
+    const tens3d Xgr = $gradv3d(V) ;
 
     const int usz = $upper.size() ;
     for(int i=0;i<usz;++i) {
-      const vect3d Xi = $upper[i]->$cr->$X ;
+      const vect3d Xi = $upper[i]->$cr->$V ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
       qmin.y = min(qmin.y,Xi.y) ;
@@ -114,7 +112,7 @@ namespace Loci {
     }
     const int lsz= $lower.size() ;
     for(int i=0;i<lsz;++i) {
-      const vect3d Xi = $lower[i]->$cl->$X ;
+      const vect3d Xi = $lower[i]->$cl->$V ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
       qmin.y = min(qmin.y,Xi.y) ;
@@ -124,7 +122,7 @@ namespace Loci {
     }
     const int bsz = $boundary_map.size() ;
     for(int i=0;i<bsz;++i) {
-      const vect3d Xi = $boundary_map[i]->$X_f ;
+      const vect3d Xi = $boundary_map[i]->$V_f ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
       qmin.y = min(qmin.y,Xi.y) ;
@@ -181,42 +179,40 @@ namespace Loci {
         limi.z = min(limi.z,(qmin.z-Xcc.z)/(qdifz-1e-100)) ;
     }
     
-    $limiterv3d(X) = realToDouble(limi) ;
+    $limiterv3d(V) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X storeVec<real> ;
-  $type X_f storeVec<real> ;
-  $rule pointwise(limiterv(X)<-cellcenter,X,gradv(X),firstOrderCells,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+  $type M storeVec<real> ;
+  $type M_f storeVec<real> ;
+  $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
+		  upper->cr->M,upper->facecenter,
+		  lower->cl->M,lower->facecenter,
+		  boundary_map->M_f,boundary_map->facecenter),
     constraint(geom_cells,B_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    const int vs = $*X.vecSize() ;
+    const int vs = $*M.vecSize() ;
     for(int j=0;j<vs;++j) {
-      const real Xcc = $X[j] ;
+      const real Xcc = $M[j] ;
       real qmax = Xcc ;
       real qmin = qmax ;
-      const vect3d Xgr = $gradv(X)[j] ;
+      const vect3d Xgr = $gradv(M)[j] ;
 
       const int usz = $upper.size() ;
       for(int i=0;i<usz;++i) {
-	const real Xi = $upper[i]->$cr->$X[j] ;
+	const real Xi = $upper[i]->$cr->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int lsz= $lower.size() ;
       for(int i=0;i<lsz;++i) {
-	const real Xi = $lower[i]->$cl->$X[j] ;
+	const real Xi = $lower[i]->$cl->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int bsz = $boundary_map.size() ;
       for(int i=0;i<bsz;++i) {
-	const real Xi = $boundary_map[i]->$X_f[j] ;
+	const real Xi = $boundary_map[i]->$M_f[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }      
@@ -243,7 +239,7 @@ namespace Loci {
 	  limi = min(limi,(qmin-Xcc)/(qdif-1e-100)) ;
       }
     
-      $limiterv(X)[j] = realToDouble(limi) ;
+      $limiterv(M)[j] = realToDouble(limi) ;
     }
   }
 }

--- a/src/FVMMod/limiters/nodal_barth.loci
+++ b/src/FVMMod/limiters/nodal_barth.loci
@@ -38,59 +38,58 @@ namespace Loci {
   //==========================================================================
   $type NB_limiter Constraint ;
   $type firstOrderCells store<char> ;
-  $type NGTNodalMax(X) store<real_t> ;
-  $type NGTNodalMin(X) store<real_t> ;
-  $type X store<real_t> ;
-  $type X_f store<real_t> ;
+  $type S store<real_t> ;
+  $type S_f store<real_t> ;
+  $type NGTNodalMax(S) store<real_t> ;
+  $type NGTNodalMin(S) store<real_t> ;
 
   using std::max ;
   using std::min ;
   using std::cout ;
   
-  $rule unit(NGTNodalMax(X)), constraint(pos) {
-    $NGTNodalMax(X) = -std::numeric_limits<real_t>::max() ;
+  $rule unit(NGTNodalMax(S)), constraint(pos) {
+    $NGTNodalMax(S) = -std::numeric_limits<real_t>::max() ;
   }
-  $rule apply(face2node->NGTNodalMax(X)<-cl->X)[Loci::Maximum] {
+  $rule apply(face2node->NGTNodalMax(S)<-cl->S)[Loci::Maximum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalMax(X),$cl->$X) ;
+      join($face2node[i]->$NGTNodalMax(S),$cl->$S) ;
   }
-  $rule apply(face2node->NGTNodalMax(X)<-cr->X)[Loci::Maximum] {
+  $rule apply(face2node->NGTNodalMax(S)<-cr->S)[Loci::Maximum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalMax(X),$cr->$X) ;
+      join($face2node[i]->$NGTNodalMax(S),$cr->$S) ;
   }
-  $rule apply(face2node->NGTNodalMax(X)<-X_f)[Loci::Maximum],constraint(ci->X) {
+  $rule apply(face2node->NGTNodalMax(S)<-S_f)[Loci::Maximum],constraint(ci->S) {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalMax(X),$X_f) ;
+      join($face2node[i]->$NGTNodalMax(S),$S_f) ;
   }
 
-  $rule unit(NGTNodalMin(X)), constraint(pos) {
-    $NGTNodalMin(X) = std::numeric_limits<real_t>::max() ;
+  $rule unit(NGTNodalMin(S)), constraint(pos) {
+    $NGTNodalMin(S) = std::numeric_limits<real_t>::max() ;
   }
-  $rule apply(face2node->NGTNodalMin(X)<-cl->X)[Loci::Minimum] {
+  $rule apply(face2node->NGTNodalMin(S)<-cl->S)[Loci::Minimum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalMin(X),$cl->$X) ;
+      join($face2node[i]->$NGTNodalMin(S),$cl->$S) ;
   }
-  $rule apply(face2node->NGTNodalMin(X)<-cr->X)[Loci::Minimum] {
+  $rule apply(face2node->NGTNodalMin(S)<-cr->S)[Loci::Minimum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalMin(X),$cr->$X) ;
+      join($face2node[i]->$NGTNodalMin(S),$cr->$S) ;
   }
-  $rule apply(face2node->NGTNodalMin(X)<-X_f)[Loci::Minimum],constraint(ci->X) {
+  $rule apply(face2node->NGTNodalMin(S)<-S_f)[Loci::Minimum],constraint(ci->S) {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalMin(X),$X_f) ;
+      join($face2node[i]->$NGTNodalMin(S),$S_f) ;
   }
 
-  $type NGTNodalv3dMax(X) store<vector3d<real_t> > ;
-  $type NGTNodalv3dMin(X) store<vector3d<real_t> > ;
-  $untype X ;
-  $untype X_f ;
-  $type X store<vector3d<real_t> > ;
-  $type X_f store<vector3d<real_t> > ;
+  $type V store<vector3d<real_t> > ;
+  $type V_f store<vector3d<real_t> > ;
+  $type NGTNodalv3dMax(V) store<vector3d<real_t> > ;
+  $type NGTNodalv3dMin(V) store<vector3d<real_t> > ;
+
 
   inline vector3d<real_t> max(const vector3d<real_t> &v1,
                               const vector3d<real_t> &v2) {
@@ -107,111 +106,107 @@ namespace Loci {
   }
   
 
-  $rule unit(NGTNodalv3dMax(X)), constraint(pos) {
+  $rule unit(NGTNodalv3dMax(V)), constraint(pos) {
     const real_t mn = -std::numeric_limits<real_t>::max() ;
-    $NGTNodalv3dMax(X) = vector3d<real_t>(mn,mn,mn) ;
+    $NGTNodalv3dMax(V) = vector3d<real_t>(mn,mn,mn) ;
   }
-  $rule apply(face2node->NGTNodalv3dMax(X)<-cl->X)[Loci::Maximum] {
+  $rule apply(face2node->NGTNodalv3dMax(V)<-cl->V)[Loci::Maximum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalv3dMax(X),$cl->$X) ;
+      join($face2node[i]->$NGTNodalv3dMax(V),$cl->$V) ;
   }
-  $rule apply(face2node->NGTNodalv3dMax(X)<-cr->X)[Loci::Maximum] {
+  $rule apply(face2node->NGTNodalv3dMax(V)<-cr->V)[Loci::Maximum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalv3dMax(X),$cr->$X) ;
+      join($face2node[i]->$NGTNodalv3dMax(V),$cr->$V) ;
   }
-  $rule apply(face2node->NGTNodalv3dMax(X)<-X_f)[Loci::Maximum],constraint(ci->X) {
+  $rule apply(face2node->NGTNodalv3dMax(V)<-V_f)[Loci::Maximum],constraint(ci->V) {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalv3dMax(X),$X_f) ;
+      join($face2node[i]->$NGTNodalv3dMax(V),$V_f) ;
   }
 
-  $rule unit(NGTNodalv3dMin(X)), constraint(pos) {
+  $rule unit(NGTNodalv3dMin(V)), constraint(pos) {
     const real_t mx = std::numeric_limits<real_t>::max() ;
-    $NGTNodalv3dMin(X) = vector3d<real_t>(mx,mx,mx) ;
+    $NGTNodalv3dMin(V) = vector3d<real_t>(mx,mx,mx) ;
   }
-  $rule apply(face2node->NGTNodalv3dMin(X)<-cl->X)[Loci::Minimum] {
+  $rule apply(face2node->NGTNodalv3dMin(V)<-cl->V)[Loci::Minimum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalv3dMin(X),$cl->$X) ;
+      join($face2node[i]->$NGTNodalv3dMin(V),$cl->$V) ;
   }
-  $rule apply(face2node->NGTNodalv3dMin(X)<-cr->X)[Loci::Minimum] {
+  $rule apply(face2node->NGTNodalv3dMin(V)<-cr->V)[Loci::Minimum] {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalv3dMin(X),$cr->$X) ;
+      join($face2node[i]->$NGTNodalv3dMin(V),$cr->$V) ;
   }
-  $rule apply(face2node->NGTNodalv3dMin(X)<-X_f)[Loci::Minimum],constraint(ci->X) {
+  $rule apply(face2node->NGTNodalv3dMin(V)<-V_f)[Loci::Minimum],constraint(ci->V) {
     int nsz = $face2node.size() ;
     for(int i=0;i<nsz;++i)
-      join($face2node[i]->$NGTNodalv3dMin(X),$X_f) ;
+      join($face2node[i]->$NGTNodalv3dMin(V),$V_f) ;
   }
 
 
-
-  $type NGTNodalvMax(X) storeVec<real_t> ;
-  $type NGTNodalvMin(X) storeVec<real_t> ;
-  $untype X ;
-  $untype X_f ;
-  $type X storeVec<real_t> ;
-  $type X_f storeVec<real_t> ;
-  $type vecSize(X) param<int> ;
+  $type M storeVec<real_t> ;
+  $type M_f storeVec<real_t> ;
+  $type NGTNodalvMax(M) storeVec<real_t> ;
+  $type NGTNodalvMin(M) storeVec<real_t> ;
+  $type vecSize(M) param<int> ;
 
 
-  $rule unit(NGTNodalvMax(X)<-vecSize(X)), constraint(pos), prelude {
-    $NGTNodalvMax(X).setVecSize(*$vecSize(X)) ;
+  $rule unit(NGTNodalvMax(M)<-vecSize(M)), constraint(pos), prelude {
+    $NGTNodalvMax(M).setVecSize(*$vecSize(M)) ;
   } compute {
-    $NGTNodalvMax(X) = mk_Scalar(-std::numeric_limits<real_t>::max()) ;
+    $NGTNodalvMax(M) = mk_Scalar(-std::numeric_limits<real_t>::max()) ;
   }
-  $rule apply(face2node->NGTNodalvMax(X)<-cl->X)[Loci::Maximum] {
+  $rule apply(face2node->NGTNodalvMax(M)<-cl->M)[Loci::Maximum] {
     const int sz = $face2node.size() ;
     for(int i=0;i<sz;++i)
-      join($face2node[i]->$NGTNodalvMax(X),$cl->$X) ;
+      join($face2node[i]->$NGTNodalvMax(M),$cl->$M) ;
   }
-  $rule apply(face2node->NGTNodalvMax(X)<-cr->X)[Loci::Maximum] {
+  $rule apply(face2node->NGTNodalvMax(M)<-cr->M)[Loci::Maximum] {
     const int sz = $face2node.size() ;
     for(int i=0;i<sz;++i)
-      join($face2node[i]->$NGTNodalvMax(X),$cr->$X) ;
+      join($face2node[i]->$NGTNodalvMax(M),$cr->$M) ;
   }
-  $rule apply(face2node->NGTNodalvMax(X)<-X_f)[Loci::Maximum],
-    constraint(ci->X) {
+  $rule apply(face2node->NGTNodalvMax(M)<-M_f)[Loci::Maximum],
+    constraint(ci->M) {
     const int sz = $face2node.size() ;
     for(int i=0;i<sz;++i)
-      join($face2node[i]->$NGTNodalvMax(X),$X_f) ;
+      join($face2node[i]->$NGTNodalvMax(M),$M_f) ;
   }
 
-  $rule unit(NGTNodalvMin(X)<-vecSize(X)), constraint(pos), prelude {
-    $NGTNodalvMin(X).setVecSize(*$vecSize(X)) ;
+  $rule unit(NGTNodalvMin(M)<-vecSize(M)), constraint(pos), prelude {
+    $NGTNodalvMin(M).setVecSize(*$vecSize(M)) ;
   } compute {
-    $NGTNodalvMin(X) = mk_Scalar(std::numeric_limits<real_t>::max()) ;
+    $NGTNodalvMin(M) = mk_Scalar(std::numeric_limits<real_t>::max()) ;
   }
-  $rule apply(face2node->NGTNodalvMin(X)<-cl->X)[Loci::Minimum] {
+  $rule apply(face2node->NGTNodalvMin(M)<-cl->M)[Loci::Minimum] {
     const int sz = $face2node.size() ;
     for(int i=0;i<sz;++i)
-      join($face2node[i]->$NGTNodalvMin(X),$cl->$X) ;
+      join($face2node[i]->$NGTNodalvMin(M),$cl->$M) ;
   }
-  $rule apply(face2node->NGTNodalvMin(X)<-cr->X)[Loci::Minimum] {
+  $rule apply(face2node->NGTNodalvMin(M)<-cr->M)[Loci::Minimum] {
     const int sz = $face2node.size() ;
     for(int i=0;i<sz;++i)
-      join($face2node[i]->$NGTNodalvMin(X),$cr->$X) ;
+      join($face2node[i]->$NGTNodalvMin(M),$cr->$M) ;
   }
-  $rule apply(face2node->NGTNodalvMin(X)<-X_f)[Loci::Minimum],
-    constraint(ci->X) {
+  $rule apply(face2node->NGTNodalvMin(M)<-M_f)[Loci::Minimum],
+    constraint(ci->M) {
     const int sz = $face2node.size() ;
     for(int i=0;i<sz;++i)
-      join($face2node[i]->$NGTNodalvMin(X),$X_f) ;
+      join($face2node[i]->$NGTNodalvMin(M),$M_f) ;
   }
 
 
-  $untype X ;
-  $type X store<real> ;
-  $rule pointwise(limiters(X)<-cellcenter,X,grads(X),firstOrderCells,
-		  upper->face2node->(pos,NGTNodalMax(X),NGTNodalMin(X)),
-		  lower->face2node->(pos,NGTNodalMax(X),NGTNodalMin(X)),
-		  boundary_map->face2node->(pos,NGTNodalMax(X),NGTNodalMin(X))),
+  $type S store<real> ;
+  $rule pointwise(limiters(S)<-cellcenter,S,grads(S),firstOrderCells,
+		  upper->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S)),
+		  lower->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S)),
+		  boundary_map->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S))),
   constraint(geom_cells,NB_limiter) {
-    const real Xcc = $X ;
-    const vect3d Xgr = $grads(X) ;
+    const real Xcc = $S ;
+    const vect3d Xgr = $grads(S) ;
     const vect3d cent = $cellcenter ;
 
     real limi = ($firstOrderCells != 0)?0.0:1.0 ;
@@ -223,9 +218,9 @@ namespace Loci {
 	const real Xf = Xcc + dot(Xgr,drl) ;
 	const real qdif = Xf-Xcc ;
 	if(qdif > 0)
-	  limi = min(limi,($upper[i]->$face2node[f]->$NGTNodalMax(X)-Xcc)/(qdif+1e-100)) ;
+	  limi = min(limi,($upper[i]->$face2node[f]->$NGTNodalMax(S)-Xcc)/(qdif+1e-100)) ;
 	if(qdif < 0)
-	  limi = min(limi,($upper[i]->$face2node[f]->$NGTNodalMin(X)-Xcc)/(qdif-1e-100)) ;
+	  limi = min(limi,($upper[i]->$face2node[f]->$NGTNodalMin(S)-Xcc)/(qdif-1e-100)) ;
       }
     }
 
@@ -237,24 +232,23 @@ namespace Loci {
 	const real Xf = Xcc + dot(Xgr,drl) ;
 	const real qdif = Xf-Xcc ;
 	if(qdif > 0)
-	  limi = min(limi,($lower[i]->$face2node[f]->$NGTNodalMax(X)-Xcc)/(qdif+1e-100)) ;
+	  limi = min(limi,($lower[i]->$face2node[f]->$NGTNodalMax(S)-Xcc)/(qdif+1e-100)) ;
 	if(qdif < 0)
-	  limi = min(limi,($lower[i]->$face2node[f]->$NGTNodalMin(X)-Xcc)/(qdif-1e-100)) ;
+	  limi = min(limi,($lower[i]->$face2node[f]->$NGTNodalMin(S)-Xcc)/(qdif-1e-100)) ;
       }
     }
 
-    $limiters(X) = realToDouble(limi) ;
+    $limiters(S) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $type X store<vect3d> ;
-  $rule pointwise(limiterv3d(X)<-cellcenter,X,gradv3d(X),firstOrderCells,
-		  upper->face2node->(pos,NGTNodalv3dMax(X),NGTNodalv3dMin(X)),
-		  lower->face2node->(pos,NGTNodalv3dMax(X),NGTNodalv3dMin(X)),
-		  boundary_map->face2node->(pos,NGTNodalv3dMax(X),NGTNodalv3dMin(X))),
+  $type V store<vect3d> ;
+  $rule pointwise(limiterv3d(V)<-cellcenter,V,gradv3d(V),firstOrderCells,
+		  upper->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
+		  lower->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
+		  boundary_map->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V))),
   constraint(geom_cells,NB_limiter) {
-    const vect3d Xcc = $X ;
-    const tens3d Xgr = $gradv3d(X) ;
+    const vect3d Xcc = $V ;
+    const tens3d Xgr = $gradv3d(V) ;
     const vect3d cent = $cellcenter ;
 
     real limix = ($firstOrderCells != 0)?0.0:1.0 ;
@@ -268,21 +262,21 @@ namespace Loci {
 	const real Xfx = Xcc.x + dot(Xgr.x,drl) ;
 	const real qdifx = Xfx-Xcc.x ;
 	if(qdifx > 0)
-	  limix = min(limix,($upper[i]->$face2node[f]->$NGTNodalv3dMax(X).x-Xcc.x)/(qdifx+1e-100)) ;
+	  limix = min(limix,($upper[i]->$face2node[f]->$NGTNodalv3dMax(V).x-Xcc.x)/(qdifx+1e-100)) ;
 	if(qdifx < 0)
-	  limix = min(limix,($upper[i]->$face2node[f]->$NGTNodalv3dMin(X).x-Xcc.x)/(qdifx-1e-100)) ;
+	  limix = min(limix,($upper[i]->$face2node[f]->$NGTNodalv3dMin(V).x-Xcc.x)/(qdifx-1e-100)) ;
 	const real Xfy = Xcc.y + dot(Xgr.y,drl) ;
 	const real qdify = Xfy-Xcc.y ;
 	if(qdify > 0)
-	  limiy = min(limiy,($upper[i]->$face2node[f]->$NGTNodalv3dMax(X).y-Xcc.y)/(qdify+1e-100)) ;
+	  limiy = min(limiy,($upper[i]->$face2node[f]->$NGTNodalv3dMax(V).y-Xcc.y)/(qdify+1e-100)) ;
 	if(qdify < 0)
-	  limiy = min(limiy,($upper[i]->$face2node[f]->$NGTNodalv3dMin(X).y-Xcc.y)/(qdify-1e-100)) ;
+	  limiy = min(limiy,($upper[i]->$face2node[f]->$NGTNodalv3dMin(V).y-Xcc.y)/(qdify-1e-100)) ;
 	const real Xfz = Xcc.z + dot(Xgr.z,drl) ;
 	const real qdifz = Xfz-Xcc.z ;
 	if(qdifz > 0)
-	  limiz = min(limiz,($upper[i]->$face2node[f]->$NGTNodalv3dMax(X).z-Xcc.z)/(qdifz+1e-100)) ;
+	  limiz = min(limiz,($upper[i]->$face2node[f]->$NGTNodalv3dMax(V).z-Xcc.z)/(qdifz+1e-100)) ;
 	if(qdifz < 0)
-	  limiz = min(limiz,($upper[i]->$face2node[f]->$NGTNodalv3dMin(X).z-Xcc.z)/(qdifz-1e-100)) ;
+	  limiz = min(limiz,($upper[i]->$face2node[f]->$NGTNodalv3dMin(V).z-Xcc.z)/(qdifz-1e-100)) ;
       }
     }
 
@@ -294,62 +288,60 @@ namespace Loci {
 	const real Xfx = Xcc.x + dot(Xgr.x,drl) ;
 	const real qdifx = Xfx-Xcc.x ;
 	if(qdifx > 0)
-	  limix = min(limix,($lower[i]->$face2node[f]->$NGTNodalv3dMax(X).x-Xcc.x)/(qdifx+1e-100)) ;
+	  limix = min(limix,($lower[i]->$face2node[f]->$NGTNodalv3dMax(V).x-Xcc.x)/(qdifx+1e-100)) ;
 	if(qdifx < 0)
-	  limix = min(limix,($lower[i]->$face2node[f]->$NGTNodalv3dMin(X).x-Xcc.x)/(qdifx-1e-100)) ;
+	  limix = min(limix,($lower[i]->$face2node[f]->$NGTNodalv3dMin(V).x-Xcc.x)/(qdifx-1e-100)) ;
 	const real Xfy = Xcc.y + dot(Xgr.y,drl) ;
 	const real qdify = Xfy-Xcc.y ;
 	if(qdify > 0)
-	  limiy = min(limiy,($lower[i]->$face2node[f]->$NGTNodalv3dMax(X).y-Xcc.y)/(qdify+1e-100)) ;
+	  limiy = min(limiy,($lower[i]->$face2node[f]->$NGTNodalv3dMax(V).y-Xcc.y)/(qdify+1e-100)) ;
 	if(qdify < 0)
-	  limiy = min(limiy,($lower[i]->$face2node[f]->$NGTNodalv3dMin(X).y-Xcc.y)/(qdify-1e-100)) ;
+	  limiy = min(limiy,($lower[i]->$face2node[f]->$NGTNodalv3dMin(V).y-Xcc.y)/(qdify-1e-100)) ;
 	const real Xfz = Xcc.z + dot(Xgr.z,drl) ;
 	const real qdifz = Xfz-Xcc.z ;
 	if(qdifz > 0)
-	  limiz = min(limiz,($lower[i]->$face2node[f]->$NGTNodalv3dMax(X).z-Xcc.z)/(qdifz+1e-100)) ;
+	  limiz = min(limiz,($lower[i]->$face2node[f]->$NGTNodalv3dMax(V).z-Xcc.z)/(qdifz+1e-100)) ;
 	if(qdifz < 0)
-	  limiz = min(limiz,($lower[i]->$face2node[f]->$NGTNodalv3dMin(X).z-Xcc.z)/(qdifz-1e-100)) ;
+	  limiz = min(limiz,($lower[i]->$face2node[f]->$NGTNodalv3dMin(V).z-Xcc.z)/(qdifz-1e-100)) ;
       }
     }
 
-    $limiterv3d(X) = vect3d(realToDouble(limix),
+    $limiterv3d(V) = vect3d(realToDouble(limix),
                             realToDouble(limiy),
                             realToDouble(limiz));
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X storeVec<real> ;
-  $type X_f storeVec<real> ;
-  $rule pointwise(limiterv(X)<-cellcenter,X,gradv(X),firstOrderCells,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+  $type M storeVec<real> ;
+  $type M_f storeVec<real> ;
+  $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
+		  upper->cr->M,upper->facecenter,
+		  lower->cl->M,lower->facecenter,
+		  boundary_map->M_f,boundary_map->facecenter),
     constraint(geom_cells,NB_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    const int vs = $*X.vecSize() ;
+    const int vs = $*M.vecSize() ;
     for(int j=0;j<vs;++j) {
-      const real Xcc = $X[j] ;
+      const real Xcc = $M[j] ;
       real qmax = Xcc ;
       real qmin = qmax ;
-      const vect3d Xgr = $gradv(X)[j] ;
+      const vect3d Xgr = $gradv(M)[j] ;
 
       const int usz = $upper.size() ;
       for(int i=0;i<usz;++i) {
-	const real Xi = $upper[i]->$cr->$X[j] ;
+	const real Xi = $upper[i]->$cr->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int lsz= $lower.size() ;
       for(int i=0;i<lsz;++i) {
-	const real Xi = $lower[i]->$cl->$X[j] ;
+	const real Xi = $lower[i]->$cl->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int bsz = $boundary_map.size() ;
       for(int i=0;i<bsz;++i) {
-	const real Xi = $boundary_map[i]->$X_f[j] ;
+	const real Xi = $boundary_map[i]->$M_f[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }      
@@ -376,7 +368,7 @@ namespace Loci {
 	  limi = min(limi,(qmin-Xcc)/(qdif-1e-100)) ;
       }
     
-      $limiterv(X)[j] = realToDouble(limi) ;
+      $limiterv(M)[j] = realToDouble(limi) ;
     }
   }
 }

--- a/src/FVMMod/limiters/none.loci
+++ b/src/FVMMod/limiters/none.loci
@@ -30,24 +30,22 @@ namespace Loci {
   typedef real_t real ;
 
   $type N_limiter Constraint;
-  $type X store<real> ;
+  $type S store<real> ;
 
-  $rule pointwise(limiters(X)<-X),constraint(geom_cells,N_limiter) {
+  $rule pointwise(limiters(S)<-S),constraint(geom_cells,N_limiter) {
     $limiters(X) = 1.0 ;
   }
 
-  $untype X ;
-  $type X store<vect3d> ;
+  $type V store<vect3d> ;
   
-  $rule pointwise(limiterv3d(X)<-X),constraint(geom_cells,N_limiter) {
-    $limiterv3d(X) = vect3d(1.0,1.0,1.0) ;
+  $rule pointwise(limiterv3d(V)<-V),constraint(geom_cells,N_limiter) {
+    $limiterv3d(V) = vect3d(1.0,1.0,1.0) ;
   }
 
-  $untype X ;
-  $type X storeVec<real> ;
-  $rule pointwise(limiterv(X)<-X),constraint(geom_cells,N_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+  $type M storeVec<real> ;
+  $rule pointwise(limiterv(M)<-M),constraint(geom_cells,N_limiter),prelude {
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    $limiterv(X) = mk_Scalar(1.) ;
+    $limiterv(M) = mk_Scalar(1.) ;
   }
 }

--- a/src/FVMMod/limiters/none.loci
+++ b/src/FVMMod/limiters/none.loci
@@ -33,7 +33,7 @@ namespace Loci {
   $type S store<real> ;
 
   $rule pointwise(limiters(S)<-S),constraint(geom_cells,N_limiter) {
-    $limiters(X) = 1.0 ;
+    $limiters(S) = 1.0 ;
   }
 
   $type V store<vect3d> ;

--- a/src/FVMMod/limiters/venkatakrishnan.loci
+++ b/src/FVMMod/limiters/venkatakrishnan.loci
@@ -53,15 +53,15 @@ namespace Loci {
     return (num+e)/(den+e) ;
   }
 
-  $type X store<real> ;
-  $type X_f store<real> ;
-  $rule pointwise(limiters(X)<-cellcenter,X,grads(X),firstOrderCells,
+  $type S store<real> ;
+  $type S_f store<real> ;
+  $rule pointwise(limiters(S)<-cellcenter,S,grads(S),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+		  upper->cr->S,upper->facecenter,
+		  lower->cl->S,lower->facecenter,
+		  boundary_map->S_f,boundary_map->facecenter),
       constraint(geom_cells,V_limiter) {
-    const real Xcc = $X ;
+    const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
     real refsq = Xcc*Xcc ;
@@ -69,12 +69,12 @@ namespace Loci {
     
     real qmax = Xcc ;
     real qmin = qmax ;
-    const vect3d Xgr = $grads(X) ;
+    const vect3d Xgr = $grads(S) ;
 
     const int usz = $upper.size() ;
     numrefs += usz ;
     for(int i=0;i<usz;++i) {
-      const real Xi = $upper[i]->$cr->$X ;
+      const real Xi = $upper[i]->$cr->$S ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -82,7 +82,7 @@ namespace Loci {
     const int lsz= $lower.size() ;
     numrefs += lsz ;
     for(int i=0;i<lsz;++i) {
-      const real Xi = $lower[i]->$cl->$X ;
+      const real Xi = $lower[i]->$cl->$S ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -90,7 +90,7 @@ namespace Loci {
     const int bsz = $boundary_map.size() ;
     numrefs += bsz ;
     for(int i=0;i<bsz;++i) {
-      const real Xi = $boundary_map[i]->$X_f ;
+      const real Xi = $boundary_map[i]->$S_f ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -114,31 +114,29 @@ namespace Loci {
       limi = min(limi,vlimit(Xcc,qmin,qmax,qdif,epsilon2,ref)) ;
     }
     
-    $limiters(X) = realToDouble(limi) ;
+    $limiters(S) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X store<vect3d> ;
-  $type X_f store<vect3d> ;
+  $type V store<vect3d> ;
+  $type V_f store<vect3d> ;
   
-  $rule pointwise(limiterv3d(X)<-cellcenter,X,gradv3d(X),firstOrderCells,
+  $rule pointwise(limiterv3d(V)<-cellcenter,V,gradv3d(V),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+		  upper->cr->V,upper->facecenter,
+		  lower->cl->V,lower->facecenter,
+		  boundary_map->V_f,boundary_map->facecenter),
       constraint(geom_cells,V_limiter) {
-    const vect3d Xcc = $X ;
+    const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
     int numrefs = 1 ;
     vect3d qmax = Xcc ;
     vect3d qmin = qmax ;
-    const tens3d Xgr = $gradv3d(X) ;
+    const tens3d Xgr = $gradv3d(V) ;
 
     const int usz = $upper.size() ;
     numrefs += usz ;
     for(int i=0;i<usz;++i) {
-      const vect3d Xi = $upper[i]->$cr->$X ;
+      const vect3d Xi = $upper[i]->$cr->$V ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -150,7 +148,7 @@ namespace Loci {
     const int lsz= $lower.size() ;
     numrefs += lsz ;
     for(int i=0;i<lsz;++i) {
-      const vect3d Xi = $lower[i]->$cl->$X ;
+      const vect3d Xi = $lower[i]->$cl->$V ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -162,7 +160,7 @@ namespace Loci {
     const int bsz = $boundary_map.size() ;
     numrefs += bsz ;
     for(int i=0;i<bsz;++i) {
-      const vect3d Xi = $boundary_map[i]->$X_f ;
+      const vect3d Xi = $boundary_map[i]->$V_f ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -198,50 +196,49 @@ namespace Loci {
       limi.z = min(limi.z,vlimit(Xcc.z,qmin.z,qmax.z,qdifz,epsilon2,ref)) ;
     }
     
-    $limiterv3d(X) = realToDouble(limi) ;
+    $limiterv3d(V) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X storeVec<real> ;
-  $type X_f storeVec<real> ;
-  $rule pointwise(limiterv(X)<-cellcenter,X,gradv(X),firstOrderCells,
+
+  $type M storeVec<real> ;
+  $type M_f storeVec<real> ;
+  $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  upper->cr->X,upper->facecenter,
-		  lower->cl->X,lower->facecenter,
-		  boundary_map->X_f,boundary_map->facecenter),
+		  upper->cr->M,upper->facecenter,
+		  lower->cl->M,lower->facecenter,
+		  boundary_map->M_f,boundary_map->facecenter),
     constraint(geom_cells,V_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    const int vs = $*X.vecSize() ;
+    const int vs = $*M.vecSize() ;
     real ref = 0.0 ;
     for(int j=0;j<vs;++j)
-      ref += fabs($X[j]) ;
+      ref += fabs($M[j]) ;
     ref = max(ref,real_t(1e-5)) ;
     const real Kl3 = $Kl*$Kl*$Kl*6./(M_PI*$grid_vol) ;
     const real epsilon2 = Kl3*$vol*ref*ref ;
     
     for(int j=0;j<vs;++j) {
-      const real Xcc = $X[j] ;
+      const real Xcc = $M[j] ;
       real qmax = Xcc ;
       real qmin = qmax ;
-      const vect3d Xgr = $gradv(X)[j] ;
+      const vect3d Xgr = $gradv(M)[j] ;
 
       const int usz = $upper.size() ;
       for(int i=0;i<usz;++i) {
-	const real Xi = $upper[i]->$cr->$X[j] ;
+	const real Xi = $upper[i]->$cr->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int lsz= $lower.size() ;
       for(int i=0;i<lsz;++i) {
-	const real Xi = $lower[i]->$cl->$X[j] ;
+	const real Xi = $lower[i]->$cl->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int bsz = $boundary_map.size() ;
       for(int i=0;i<bsz;++i) {
-	const real Xi = $boundary_map[i]->$X_f[j] ;
+	const real Xi = $boundary_map[i]->$M_f[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }      
@@ -260,7 +257,7 @@ namespace Loci {
 	limi = min(limi,vlimit(Xcc,qmin,qmax,qdif,epsilon2,ref)) ;
       }
       
-      $limiterv(X)[j] = realToDouble(limi) ;
+      $limiterv(M)[j] = realToDouble(limi) ;
     }
   }
 }

--- a/src/FVMMod/limiters/venkatakrishnan2.loci
+++ b/src/FVMMod/limiters/venkatakrishnan2.loci
@@ -58,15 +58,15 @@ namespace Loci {
     return (num+e)/(den+e) ;
   }
 
-  $type X store<real> ;
-  $type X_f store<real> ;
-  $rule pointwise(limiters(X)<-cellcenter,X,grads(X),firstOrderCells,
+  $type S store<real> ;
+  $type S_f store<real> ;
+  $rule pointwise(limiters(S)<-cellcenter,S,grads(S),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  upper->cr->(cellcenter,X),
-		  lower->cl->(cellcenter,X),
-		  boundary_map->X_f,boundary_map->facecenter),
+		  upper->cr->(cellcenter,S),
+		  lower->cl->(cellcenter,S),
+		  boundary_map->S_f,boundary_map->facecenter),
       constraint(geom_cells,V2_limiter) {
-    const real Xcc = $X ;
+    const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
     real refsq = Xcc*Xcc ;
@@ -74,12 +74,12 @@ namespace Loci {
     
     real qmax = Xcc ;
     real qmin = qmax ;
-    const vect3d Xgr = $grads(X) ;
+    const vect3d Xgr = $grads(S) ;
 
     const int usz = $upper.size() ;
     numrefs += usz ;
     for(int i=0;i<usz;++i) {
-      const real Xi = $upper[i]->$cr->$X ;
+      const real Xi = $upper[i]->$cr->$S ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -87,7 +87,7 @@ namespace Loci {
     const int lsz= $lower.size() ;
     numrefs += lsz ;
     for(int i=0;i<lsz;++i) {
-      const real Xi = $lower[i]->$cl->$X ;
+      const real Xi = $lower[i]->$cl->$S ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -95,7 +95,7 @@ namespace Loci {
     const int bsz = $boundary_map.size() ;
     numrefs += bsz ;
     for(int i=0;i<bsz;++i) {
-      const real Xi = $boundary_map[i]->$X_f ;
+      const real Xi = $boundary_map[i]->$S_f ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -119,31 +119,29 @@ namespace Loci {
       limi = min(limi,vlimit(Xcc,qmin,qmax,qdif,epsilon2,ref)) ;
     }
     
-    $limiters(X) = realToDouble(limi) ;
+    $limiters(S) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X store<vect3d> ;
-  $type X_f store<vect3d> ;
+  $type V store<vect3d> ;
+  $type V_f store<vect3d> ;
   
-  $rule pointwise(limiterv3d(X)<-cellcenter,X,gradv3d(X),firstOrderCells,
+  $rule pointwise(limiterv3d(V)<-cellcenter,V,gradv3d(V),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  upper->cr->(X,cellcenter),
-		  lower->cl->(X,cellcenter),
-		  boundary_map->X_f,boundary_map->facecenter),
+		  upper->cr->(V,cellcenter),
+		  lower->cl->(V,cellcenter),
+		  boundary_map->V_f,boundary_map->facecenter),
       constraint(geom_cells,V2_limiter) {
-    const vect3d Xcc = $X ;
+    const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
     int numrefs = 1 ;
     vect3d qmax = Xcc ;
     vect3d qmin = qmax ;
-    const tens3d Xgr = $gradv3d(X) ;
+    const tens3d Xgr = $gradv3d(V) ;
 
     const int usz = $upper.size() ;
     numrefs += usz ;
     for(int i=0;i<usz;++i) {
-      const vect3d Xi = $upper[i]->$cr->$X ;
+      const vect3d Xi = $upper[i]->$cr->$V ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -155,7 +153,7 @@ namespace Loci {
     const int lsz= $lower.size() ;
     numrefs += lsz ;
     for(int i=0;i<lsz;++i) {
-      const vect3d Xi = $lower[i]->$cl->$X ;
+      const vect3d Xi = $lower[i]->$cl->$V ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -167,7 +165,7 @@ namespace Loci {
     const int bsz = $boundary_map.size() ;
     numrefs += bsz ;
     for(int i=0;i<bsz;++i) {
-      const vect3d Xi = $boundary_map[i]->$X_f ;
+      const vect3d Xi = $boundary_map[i]->$V_f ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -203,50 +201,48 @@ namespace Loci {
       limi.z = min(limi.z,vlimit(Xcc.z,qmin.z,qmax.z,qdifz,epsilon2,ref)) ;
     }
     
-    $limiterv3d(X) = realToDouble(limi) ;
+    $limiterv3d(V) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X storeVec<real> ;
-  $type X_f storeVec<real> ;
-  $rule pointwise(limiterv(X)<-cellcenter,X,gradv(X),firstOrderCells,
+  $type M storeVec<real> ;
+  $type M_f storeVec<real> ;
+  $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  upper->cr->(X,cellcenter),
-		  lower->cl->(X,cellcenter),
-		  boundary_map->X_f,boundary_map->facecenter),
+		  upper->cr->(M,cellcenter),
+		  lower->cl->(M,cellcenter),
+		  boundary_map->M_f,boundary_map->facecenter),
     constraint(geom_cells,V2_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    const int vs = $*X.vecSize() ;
+    const int vs = $*M.vecSize() ;
     real ref = 0.0 ;
     for(int j=0;j<vs;++j)
-      ref += fabs($X[j]) ;
+      ref += fabs($M[j]) ;
     ref = max(ref,real_t(1e-5)) ;
     const real Kl3 = $Kl*$Kl*$Kl*6./(M_PI*$grid_vol) ;
     const real epsilon2 = Kl3*$vol*ref*ref ;
     
     for(int j=0;j<vs;++j) {
-      const real Xcc = $X[j] ;
+      const real Xcc = $M[j] ;
       real qmax = Xcc ;
       real qmin = qmax ;
-      const vect3d Xgr = $gradv(X)[j] ;
+      const vect3d Xgr = $gradv(M)[j] ;
 
       const int usz = $upper.size() ;
       for(int i=0;i<usz;++i) {
-	const real Xi = $upper[i]->$cr->$X[j] ;
+	const real Xi = $upper[i]->$cr->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int lsz= $lower.size() ;
       for(int i=0;i<lsz;++i) {
-	const real Xi = $lower[i]->$cl->$X[j] ;
+	const real Xi = $lower[i]->$cl->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int bsz = $boundary_map.size() ;
       for(int i=0;i<bsz;++i) {
-	const real Xi = $boundary_map[i]->$X_f[j] ;
+	const real Xi = $boundary_map[i]->$M_f[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }      
@@ -265,25 +261,20 @@ namespace Loci {
 	limi = min(limi,vlimit(Xcc,qmin,qmax,qdif,epsilon2,ref)) ;
       }
       
-      $limiterv(X)[j] = realToDouble(limi) ;
+      $limiterv(M)[j] = realToDouble(limi) ;
     }
   }
 
   //-------------------------------------------------------------------
   // alternate stencil version
-
-  $untype X ;
-  $untype X_f ;
-  $type X store<real> ;
-  $type X_f store<real> ;
   $type cellStencil multiMap ;
 
-  $rule pointwise(stencil::limiters(X)<-cellcenter,X,grads(X),firstOrderCells,
+  $rule pointwise(stencil::limiters(S)<-cellcenter,S,grads(S),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  cellStencil->(cellcenter,X),
-		  boundary_map->X_f,boundary_map->facecenter),
+		  cellStencil->(cellcenter,S),
+		  boundary_map->S_f,boundary_map->facecenter),
       constraint(geom_cells,V2_limiter) {
-    const real Xcc = $X ;
+    const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
     real refsq = Xcc*Xcc ;
@@ -291,12 +282,12 @@ namespace Loci {
     
     real qmax = Xcc ;
     real qmin = qmax ;
-    const vect3d Xgr = $grads(X) ;
+    const vect3d Xgr = $grads(S) ;
 
     const int ssz = $cellStencil.size() ;
     numrefs += ssz ;
     for(int i=0;i<ssz;++i) {
-      const real Xi = $cellStencil[i]->$X ;
+      const real Xi = $cellStencil[i]->$S ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -304,7 +295,7 @@ namespace Loci {
     const int bsz = $boundary_map.size() ;
     numrefs += bsz ;
     for(int i=0;i<bsz;++i) {
-      const real Xi = $boundary_map[i]->$X_f ;
+      const real Xi = $boundary_map[i]->$S_f ;
       refsq += Xi*Xi ;
       qmin = min(qmin,Xi) ;
       qmax = max(qmax,Xi) ;
@@ -322,30 +313,25 @@ namespace Loci {
       limi = min(limi,vlimit(Xcc,qmin,qmax,qdif,epsilon2,ref)) ;
     }
 
-    $limiters(X) = realToDouble(limi) ;
+    $limiters(S) = realToDouble(limi) ;
   }
-
-  $untype X ;
-  $untype X_f ;
-  $type X store<vect3d> ;
-  $type X_f store<vect3d> ;
   
-  $rule pointwise(stencil::limiterv3d(X)<-cellcenter,X,gradv3d(X),firstOrderCells,
+  $rule pointwise(stencil::limiterv3d(V)<-cellcenter,V,gradv3d(V),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  cellStencil->(X,cellcenter),
-		  boundary_map->X_f,boundary_map->facecenter),
+		  cellStencil->(V,cellcenter),
+		  boundary_map->V_f,boundary_map->facecenter),
       constraint(geom_cells,V2_limiter) {
-    const vect3d Xcc = $X ;
+    const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
     int numrefs = 1 ;
     vect3d qmax = Xcc ;
     vect3d qmin = qmax ;
-    const tens3d Xgr = $gradv3d(X) ;
+    const tens3d Xgr = $gradv3d(V) ;
 
     const int ssz = $cellStencil.size() ;
     numrefs += ssz ;
     for(int i=0;i<ssz;++i) {
-      const vect3d Xi = $cellStencil[i]->$X ;
+      const vect3d Xi = $cellStencil[i]->$V ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -357,7 +343,7 @@ namespace Loci {
     const int bsz = $boundary_map.size() ;
     numrefs += bsz ;
     for(int i=0;i<bsz;++i) {
-      const vect3d Xi = $boundary_map[i]->$X_f ;
+      const vect3d Xi = $boundary_map[i]->$V_f ;
       refsq += dot(Xi,Xi) ;
       qmin.x = min(qmin.x,Xi.x) ;
       qmax.x = max(qmax.x,Xi.x) ;
@@ -383,43 +369,39 @@ namespace Loci {
       limi.z = min(limi.z,vlimit(Xcc.z,qmin.z,qmax.z,qdifz,epsilon2,ref)) ;
     }
 
-    $limiterv3d(X) = realToDouble(limi) ;
+    $limiterv3d(V) = realToDouble(limi) ;
   }
 
-  $untype X ;
-  $untype X_f ;
-  $type X storeVec<real> ;
-  $type X_f storeVec<real> ;
-  $rule pointwise(stencil::limiterv(X)<-cellcenter,X,gradv(X),firstOrderCells,
+  $rule pointwise(stencil::limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
 		  Kl,vol,grid_vol,
-		  cellStencil->(X,cellcenter),
-		  boundary_map->X_f,boundary_map->facecenter),
+		  cellStencil->(M,cellcenter),
+		  boundary_map->M_f,boundary_map->facecenter),
     constraint(geom_cells,V2_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    const int vs = $*X.vecSize() ;
+    const int vs = $*M.vecSize() ;
     real ref = 0.0 ;
     for(int j=0;j<vs;++j)
-      ref += fabs($X[j]) ;
+      ref += fabs($M[j]) ;
     ref = max(ref,real_t(1e-5)) ;
     const real Kl3 = $Kl*$Kl*$Kl*6./(M_PI*$grid_vol) ;
     const real epsilon2 = Kl3*$vol*ref*ref ;
     
     for(int j=0;j<vs;++j) {
-      const real Xcc = $X[j] ;
+      const real Xcc = $M[j] ;
       real qmax = Xcc ;
       real qmin = qmax ;
-      const vect3d Xgr = $gradv(X)[j] ;
+      const vect3d Xgr = $gradv(M)[j] ;
 
       const int ssz = $cellStencil.size() ;
       for(int i=0;i<ssz;++i) {
-	const real Xi = $cellStencil[i]->$X[j] ;
+	const real Xi = $cellStencil[i]->$M[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }
       const int bsz = $boundary_map.size() ;
       for(int i=0;i<bsz;++i) {
-	const real Xi = $boundary_map[i]->$X_f[j] ;
+	const real Xi = $boundary_map[i]->$M_f[j] ;
 	qmin = min(qmin,Xi) ;
 	qmax = max(qmax,Xi) ;
       }      
@@ -432,7 +414,7 @@ namespace Loci {
 	limi = min(limi,vlimit(Xcc,qmin,qmax,qdif,epsilon2,ref)) ;
       }
       
-      $limiterv(X)[j] = realToDouble(limi) ;
+      $limiterv(M)[j] = realToDouble(limi) ;
     }
   }
 }

--- a/src/FVMMod/limiters/zero.loci
+++ b/src/FVMMod/limiters/zero.loci
@@ -30,24 +30,22 @@ namespace Loci {
   typedef real_t real ;
 
   $type Z_limiter Constraint ;
-  $type X store<real> ;
+  $type S store<real> ;
 
-  $rule pointwise(limiters(X)<-X),constraint(geom_cells,Z_limiter) {
-    $limiters(X) = 0.0 ;
+  $rule pointwise(limiters(S)<-S),constraint(geom_cells,Z_limiter) {
+    $limiters(S) = 0.0 ;
   }
 
-  $untype X ;
-  $type X store<vect3d> ;
+  $type V store<vect3d> ;
   
-  $rule pointwise(limiterv3d(X)<-X),constraint(geom_cells,Z_limiter) {
-    $limiterv3d(X) = vect3d(0.0,0.0,0.0) ;
+  $rule pointwise(limiterv3d(V)<-V),constraint(geom_cells,Z_limiter) {
+    $limiterv3d(V) = vect3d(0.0,0.0,0.0) ;
   }
     
-  $untype X ;
-  $type X storeVec<real> ;
-  $rule pointwise(limiterv(X)<-X),constraint(geom_cells,Z_limiter),prelude {
-    $limiterv(X).setVecSize($X.vecSize()) ;
+  $type M storeVec<real> ;
+  $rule pointwise(limiterv(M)<-M),constraint(geom_cells,Z_limiter),prelude {
+    $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
-    $limiterv(X) = mk_Scalar(0.) ;
+    $limiterv(M) = mk_Scalar(0.) ;
   }
 }


### PR DESCRIPTION
Incremental step (2) from issue https://github.com/EdwardALuke/loci/issues/17, where we rename parametric types X, X_f to S, V, and M for scalars, vect3d, and storeVec, respectively. In future work, these base parametric types will be more broadly used within Loci and other solvers (Chem, Stream, GGFS, etc). This is step 2 of the https://github.com/EdwardALuke/loci/issues/17 limiter work, which will go:

1) https://github.com/EdwardALuke/loci/issues/94 Limiter Subdirectory Refactor
2) Type renames (S for Scalar, V for vect3d, M for storeVec (mixture, vector)
3) limiter header (.lh) file to remove repeatability of variables in files
4) Niskikawa higher-order limiter (factored similar to V/V2 and not with the new cell2nodemax/min work in
https://github.com/EdwardALuke/loci/issues/17)
5) Vect3d uniform limiter
6) storeVec (vector) uniform limiter
7) inline limiter refactors, specifically for Barth (similar to inline for Venkata limiters)
8) max/min remaps (this may be a larger issue with adding cell-to-node maps) for limiters, but first for Nodal Barth