### PR TITLE
RLF[#99]: limiters.lh added to include/FVMMod, with variables removed…

### DIFF
--- a/src/FVMMod/limiter.loci
+++ b/src/FVMMod/limiter.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -28,8 +29,6 @@ namespace Loci {
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
-
-  $type firstOrderCells store<char> ;
 
   $rule unit(firstOrderCells),constraint(geom_cells) {
     $firstOrderCells = 0 ;
@@ -66,24 +65,13 @@ namespace Loci {
     }
   }
     
-  $type Kl param<real> ;
   $rule default(Kl),comments("This parameter is a smoothness parameter for the venkatakrishnan limiter.  A value of zero will not allow overshoots, while a larger value may allow some overshoots to ensure accuracy in locally smooth regions.  The typical values for this parameter range from .1 to 100") {
     $Kl = 1.0 ;
   }
-
-  $type limiter param<std::string> ;
   
   $rule default(limiter),comments("Limiter used in face extrapolations.  This function can take the values of 'venkatakrishnan', 'barth', 'none' for second order solutions, and 'zero' for first order solutions") {
     $limiter = "venkatakrishnan" ;
   }
-
-  $type V_limiter Constraint ;
-  $type B_limiter Constraint ;
-  $type N_limiter Constraint ;
-  $type Z_limiter Constraint ;
-  $type NB_limiter Constraint ;
-  $type V2_limiter Constraint ;
-  $type limiter param<std::string> ;
   
   $rule constraint(V_limiter,B_limiter,N_limiter,Z_limiter,NB_limiter,V2_limiter<-limiter) {
     $V_limiter = EMPTY ;

--- a/src/FVMMod/limiters/barth.loci
+++ b/src/FVMMod/limiters/barth.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -29,8 +30,6 @@ namespace Loci {
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
 
-  $type B_limiter Constraint ;  
-  $type firstOrderCells store<char> ;
   $type S store<real> ;
   $type S_f store<real> ;
   $rule pointwise(limiters(S)<-cellcenter,S,grads(S),firstOrderCells,

--- a/src/FVMMod/limiters/nodal_barth.loci
+++ b/src/FVMMod/limiters/nodal_barth.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -36,12 +37,8 @@ namespace Loci {
   // Like Barth except limiting to nodal max/min rather than at face centers
   //
   //==========================================================================
-  $type NB_limiter Constraint ;
-  $type firstOrderCells store<char> ;
   $type S store<real_t> ;
   $type S_f store<real_t> ;
-  $type NGTNodalMax(S) store<real_t> ;
-  $type NGTNodalMin(S) store<real_t> ;
 
   using std::max ;
   using std::min ;
@@ -87,9 +84,6 @@ namespace Loci {
 
   $type V store<vector3d<real_t> > ;
   $type V_f store<vector3d<real_t> > ;
-  $type NGTNodalv3dMax(V) store<vector3d<real_t> > ;
-  $type NGTNodalv3dMin(V) store<vector3d<real_t> > ;
-
 
   inline vector3d<real_t> max(const vector3d<real_t> &v1,
                               const vector3d<real_t> &v2) {
@@ -149,8 +143,6 @@ namespace Loci {
 
   $type M storeVec<real_t> ;
   $type M_f storeVec<real_t> ;
-  $type NGTNodalvMax(M) storeVec<real_t> ;
-  $type NGTNodalvMin(M) storeVec<real_t> ;
   $type vecSize(M) param<int> ;
 
 

--- a/src/FVMMod/limiters/none.loci
+++ b/src/FVMMod/limiters/none.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -29,7 +30,6 @@ namespace Loci {
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
 
-  $type N_limiter Constraint;
   $type S store<real> ;
 
   $rule pointwise(limiters(S)<-S),constraint(geom_cells,N_limiter) {

--- a/src/FVMMod/limiters/venkatakrishnan.loci
+++ b/src/FVMMod/limiters/venkatakrishnan.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -28,11 +29,6 @@ namespace Loci {
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
-
- 
-  $type V_limiter Constraint ;
-  $type firstOrderCells store<char> ;
-  $type Kl param<real> ;
 
   inline real vlimit(real Xcc, real qmin, real qmax, real qdif, real eps2,
 		     real ref) {

--- a/src/FVMMod/limiters/venkatakrishnan2.loci
+++ b/src/FVMMod/limiters/venkatakrishnan2.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -35,10 +36,6 @@ namespace Loci {
   // Venkatakrishnan Limiter2 (Limit to cell centers)
   //
   //==========================================================================
-  $type V2_limiter Constraint ;
-  $type firstOrderCells store<char> ;
-  $type Kl param<real> ;
- 
   inline real vlimit(real Xcc, real qmin, real qmax, real qdif, real eps2,
 		     real ref) {
 #ifdef REFLIM

--- a/src/FVMMod/limiters/zero.loci
+++ b/src/FVMMod/limiters/zero.loci
@@ -20,6 +20,7 @@
 //#############################################################################
 #include <Loci.h>
 $include "FVM.lh"
+$include "FVMMod/limiters.lh"
 
 using std::cerr ;
 using std::endl ;
@@ -29,7 +30,6 @@ namespace Loci {
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
 
-  $type Z_limiter Constraint ;
   $type S store<real> ;
 
   $rule pointwise(limiters(S)<-S),constraint(geom_cells,Z_limiter) {

--- a/src/Install.bash
+++ b/src/Install.bash
@@ -109,6 +109,7 @@ for i in  Tools Config MPI_stubb FVMAdapt FVMOverset; do
     cp include/$i/*.h $INSTALL_PATH/include/$i
 done
 cp include/FVMOverset/*.lh $INSTALL_PATH/include/FVMOverset
+cp include/FVMMod/*.lh $INSTALL_PATH/include/FVMMod
 
 mkdir -p $INSTALL_PATH/docs
 mkdir -p $INSTALL_PATH/docs/1D-Diffusion

--- a/src/include/FVMMod/limiters.lh
+++ b/src/include/FVMMod/limiters.lh
@@ -1,0 +1,56 @@
+//#############################################################################
+//#
+//# Copyright 2008-2019, Mississippi State University
+//#
+//# This file is part of the Loci Framework.
+//#
+//# The Loci Framework is free software: you can redistribute it and/or modify
+//# it under the terms of the Lesser GNU General Public License as published by
+//# the Free Software Foundation, either version 3 of the License, or
+//# (at your option) any later version.
+//#
+//# The Loci Framework is distributed in the hope that it will be useful,
+//# but WITHOUT ANY WARRANTY; without even the implied warranty of
+//# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//# Lesser GNU General Public License for more details.
+//#
+//# You should have received a copy of the Lesser GNU General Public License
+//# along with the Loci Framework.  If not, see <http://www.gnu.org/licenses>
+//#
+//#############################################################################
+
+/** Marker for locally first-order cells to disable limiters */
+$type firstOrderCells store<char> ;
+/** This parameter is a smoothness parameter for the venkatakrishnan limiter.  
+ * A value of zero will not allow overshoots, while a larger value may allow 
+ * some overshoots to ensure accuracy in locally smooth regions.  
+ * The typical values for this parameter range from .1 to 100 */
+$type Kl param<real> ;
+/** Limiter used in face extrapolations.  This function can take the values of 
+ * 'venkatakrishnan', 'barth', 'none' for second order solutions, and 'zero' 
+ * for first order solutions" */
+$type limiter param<std::string> ;
+/** Venkatakrishnan limiter */
+$type V_limiter Constraint ;
+/** Barth limiter */
+$type B_limiter Constraint ;
+/** No limiter (limiter = 1) */
+$type N_limiter Constraint ;
+/** Zero limiter (limiter = 0) */
+$type Z_limiter Constraint ;
+/** Nodal Barth limiter  */
+$type NB_limiter Constraint ;
+/** Venkatakrishnan 2 (cell center) limiter */
+$type V2_limiter Constraint ;
+/** Scalar cell to node max */
+$type NGTNodalMax(S) store<real_t> ;
+/** Scalar cell to node min */
+$type NGTNodalMin(S) store<real_t> ;
+/** Vect3d cell to node max */
+$type NGTNodalv3dMax(V) store<vector3d<real_t> > ;
+/** Vect3d cell to node min */
+$type NGTNodalv3dMin(V) store<vector3d<real_t> > ;
+/** Vector cell to node max */
+$type NGTNodalvMax(M) storeVec<real_t> ;
+/** Vector cell to node min */
+$type NGTNodalvMin(M) storeVec<real_t> ;

--- a/tmpcopy
+++ b/tmpcopy
@@ -79,7 +79,7 @@ if [ ${target:0:1} != "/" ]; then
    echo setting target to \'$target\'
 fi
 
-TARGET_DIRS="System Tools lpp FVMtools FVMtools/libadf FVMMod FVMMod/limiters sprng sprng/include sprng/include/sprng FVMAdapt FVMOverset include include/Tools include/Config include/MPI_stubb include/FVMAdapt include/FVMOverset"
+TARGET_DIRS="System Tools lpp FVMtools FVMtools/libadf FVMMod FVMMod/limiters sprng sprng/include sprng/include/sprng FVMAdapt FVMOverset include include/Tools include/Config include/MPI_stubb include/FVMAdapt include/FVMMod include/FVMOverset"
 #TOOLS_DIRS="lpp FVMtools FVMtools/libadf FVMMod sprng sprng/include sprng/include/sprng"
 TOOLS_DIRS=""
 


### PR DESCRIPTION
Incremental step (3) from issue https://github.com/EdwardALuke/loci/issues/17, where we put limiter variables into a limiter.lh header to reduce repeatability/retyping of variables across files. This excludes S,V,M--those should probably go into FVM.lh if they go into a header. This is step 3 of the https://github.com/EdwardALuke/loci/issues/17 limiter work, which will go:

1) https://github.com/EdwardALuke/loci/issues/94 Limiter Subdirectory Refactor
2) #97
3) limiter header (.lh) file to remove repeatability of variables in files
4) Niskikawa higher-order limiter (factored similar to V/V2 and not with the new cell2nodemax/min work in
https://github.com/EdwardALuke/loci/issues/17)
5) Vect3d uniform limiter
6) storeVec (vector) uniform limiter
7) inline limiter refactors, specifically for Barth (similar to inline for Venkata limiters)
8) max/min remaps (this may be a larger issue with adding cell-to-node maps) for limiters, but first for Nodal Barth