### PR TITLE
Bugfix for venkatakrishnan limiter

### DIFF
--- a/quickTest/FVMModUnitTests/functions.loci
+++ b/quickTest/FVMModUnitTests/functions.loci
@@ -287,6 +287,36 @@ namespace flowPsi {
     }
   }
 
+  $type VU store<vect3d> ;
+  /// Limiters for linear functions should evaluate to unity under the right
+  /// grid topologies.  This function is sued to evaluate scalar limiters
+  $type errv3dUnity(VU) param<real> ;
+  $rule unit(errv3dUnity(VU)),constraint(UNIVERSE) {
+    $errv3dUnity(VU) = -1 ;
+  }
+  $rule apply(errv3dUnity(VU)<-VU)[Loci::Maximum] {
+    vect3d diff = $VU-vect3d(1.0,1.0,1.0) ;
+    
+    join($errv3dUnity(VU),dot(diff,diff)) ;
+  }
+
+  /// Test for limiter functions recovering unity when give linear functions
+  $type testv3dUnity(FUNC) param<bool> ;
+  $rule singleton(testv3dUnity(FUNC)<-errv3dUnity(FUNC)) {
+    $testv3dUnity(FUNC) = ($errv3dUnity(FUNC)<1e-8) ;
+    $[Once] {
+      if(!$testv3dUnity(FUNC)) {
+        std::cerr << "TEST FAILED, err=" << sqrt($errv3dUnity(FUNC)) << std::endl ;
+      }
+    }
+    if($errv3dUnity(FUNC) < 0) {
+      $testv3dUnity(FUNC) = false ;
+      $[Once] {
+        std::cerr << "TEST FAILED, No Function Evaluated!" << std::endl ;
+      }
+    }
+  }
+
   /// Error for generalized vector field gradients
   $type errvGrad(M) param<real> ;
   $rule unit(errvGrad(M)),constraint(UNIVERSE) {
@@ -319,5 +349,38 @@ namespace flowPsi {
     }
   }
   
+  $type VM storeVec<real> ;
+  /// Limiters for linear functions should evaluate to unity under the right
+  /// grid topologies.  This function is sued to evaluate scalar limiters
+  $type errvectUnity(VM) param<real> ;
+  $rule unit(errvectUnity(VM)),constraint(UNIVERSE) {
+    $errvectUnity(VM) = -1 ;
+  }
+  $rule apply(errvectUnity(VM)<-VM)[Loci::Maximum] {
+    int vs = $*VM.vecSize() ;
+    for(int i=0;i<vs;++i) {
+      real diff = $VM[i]-1.0 ;
+      join($errvectUnity(VM),diff*diff) ;
+    }
+  }
+
+  /// Test for limiter functions recovering unity when give linear functions
+  $type testvectUnity(FUNC) param<bool> ;
+
+  $rule singleton(testvectUnity(FUNC)<-errvectUnity(FUNC)) {
+    $testvectUnity(FUNC) = ($errvectUnity(FUNC)<1e-8) ;
+    $[Once] {
+      if(!$testvectUnity(FUNC)) {
+        std::cerr << "TEST FAILED, err=" << sqrt($errvectUnity(FUNC)) << std::endl ;
+      }
+    }
+    if($errvectUnity(FUNC) < 0) {
+      $testvectUnity(FUNC) = false ;
+      $[Once] {
+        std::cerr << "TEST FAILED, No Function Evaluated!" << std::endl ;
+      }
+    }
+  }
+
 }
     

--- a/quickTest/FVMModUnitTests/tests/limitersNoneStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limitersNoneStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testScalarUnity,limiters,scalarVal)"
+grid:"block.vog"
+message:"Scalar None Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: none
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limiterv3dBarthStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limiterv3dBarthStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testv3dUnity,limiterv3d,v3dVal)"
+grid:"block.vog"
+message:"vect3d Barth Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: barth
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limiterv3dNoneStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limiterv3dNoneStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testv3dUnity,limiterv3d,v3dVal)"
+grid:"block.vog"
+message:"vect3d none Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: none
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limiterv3dVenkatakrishnanStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limiterv3dVenkatakrishnanStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testv3dUnity,limiterv3d,v3dVal)"
+grid:"block.vog"
+message:"vect3d Venkatakrishnan Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: V
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limitervBarthStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limitervBarthStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testvectUnity,limiterv,vectVal)"
+grid:"block.vog"
+message:"vect Barth Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: barth
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limitervNone.vars
+++ b/quickTest/FVMModUnitTests/tests/limitervNone.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testvectUnity,limiterv,vectVal)"
+grid:"block.vog"
+message:"vect vect Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: none
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limitervVenkatakrishnan.vars
+++ b/quickTest/FVMModUnitTests/tests/limitervVenkatakrishnan.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testvectUnity,limiterv,vectVal)"
+grid:"block.vog"
+message:"vect Venkatakrishnan Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: V
+gradStencil: standard
+centroid: wireframe
+}

--- a/src/FVMMod/limiter.loci
+++ b/src/FVMMod/limiter.loci
@@ -77,7 +77,7 @@ namespace Loci {
     $limiter = "venkatakrishnan" ;
   }
 
-  $type V_limiter Constraint ;
+  $type Vk_limiter Constraint ;
   $type B_limiter Constraint ;
   $type N_limiter Constraint ;
   $type Z_limiter Constraint ;
@@ -85,8 +85,8 @@ namespace Loci {
   $type V2_limiter Constraint ;
   $type limiter param<std::string> ;
   
-  $rule constraint(V_limiter,B_limiter,N_limiter,Z_limiter,NB_limiter,V2_limiter<-limiter) {
-    $V_limiter = EMPTY ;
+  $rule constraint(Vk_limiter,B_limiter,N_limiter,Z_limiter,NB_limiter,V2_limiter<-limiter) {
+    $Vk_limiter = EMPTY ;
     $V2_limiter = EMPTY ;
     $B_limiter = EMPTY ;
     $NB_limiter = EMPTY ;
@@ -94,7 +94,7 @@ namespace Loci {
     $Z_limiter = EMPTY ;
       
     if($limiter == "venkatakrishnan" || $limiter == "V") {
-      $V_limiter = ~EMPTY ;
+      $Vk_limiter = ~EMPTY ;
     } else if($limiter == "V2") {
       $V2_limiter = ~EMPTY ;
     } else if($limiter == "barth" || $limiter == "B") {
@@ -109,7 +109,7 @@ namespace Loci {
       cerr << "limiter " << $limiter
 	   << " not supported for generalized grids" << endl ;
       cerr << "defaulting to venkatakrishnan limiter" << endl ;
-      $V_limiter = ~EMPTY ;
+      $Vk_limiter = ~EMPTY ;
     }
   }
 

--- a/src/FVMMod/limiters/venkatakrishnan.loci
+++ b/src/FVMMod/limiters/venkatakrishnan.loci
@@ -30,7 +30,7 @@ namespace Loci {
   typedef real_t real ;
 
  
-  $type V_limiter Constraint ;
+  $type Vk_limiter Constraint ;
   $type firstOrderCells store<char> ;
   $type Kl param<real> ;
 
@@ -60,7 +60,7 @@ namespace Loci {
 		  upper->cr->S,upper->facecenter,
 		  lower->cl->S,lower->facecenter,
 		  boundary_map->S_f,boundary_map->facecenter),
-      constraint(geom_cells,V_limiter) {
+      constraint(geom_cells,Vk_limiter) {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
@@ -125,7 +125,7 @@ namespace Loci {
 		  upper->cr->V,upper->facecenter,
 		  lower->cl->V,lower->facecenter,
 		  boundary_map->V_f,boundary_map->facecenter),
-      constraint(geom_cells,V_limiter) {
+      constraint(geom_cells,Vk_limiter) {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
     int numrefs = 1 ;
@@ -207,7 +207,7 @@ namespace Loci {
 		  upper->cr->M,upper->facecenter,
 		  lower->cl->M,lower->facecenter,
 		  boundary_map->M_f,boundary_map->facecenter),
-    constraint(geom_cells,V_limiter),prelude {
+    constraint(geom_cells,Vk_limiter),prelude {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
     const int vs = $*M.vecSize() ;


### PR DESCRIPTION
Recent changes in substitution of X for V as parametric variable had an unintended side effect of impacting the V_limiter selector causing the V to be substituted for the variable V.  This fixes that by changing the selector to Vk_limiter and adding some additional unit tests so that oversights similar to this would show up in future tests.