### PR TITLE
Update to segregate versioning dependencies

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -60,21 +60,28 @@ LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]
 include/Config/version_info.h: FORCE
 	@echo \#ifndef CONFIG_LOCI_INFO_H > version_info.h
 	@echo \#define CONFIG_LOCI_INFO_H >> version_info.h
-	@echo \#define LOCI_VERSION \"$(GIT_INFO)\" >> version_info.h
-	@echo \#define LOCI_BRANCH \"$(GIT_BRANCH)\" >> version_info.h
 	@echo \#define LOCI_VERSION_MAJOR $(LOCI_MAJOR_VERSION) >> version_info.h
 	@echo \#define LOCI_VERSION_MINOR $(LOCI_MINOR_VERSION) >> version_info.h
 	@echo \#endif >> version_info.h
 	@# Only update version_info.h if it has changed.
 	@if [ -e $@ ]; then if ! cmp version_info.h $@; then mv version_info.h $@ ; else rm version_info.h ; fi ; else mv version_info.h $@ ; fi
 
+include/Config/version_details.h: FORCE
+	@echo \#ifndef CONFIG_LOCI_DETAILS_H > version_details.h
+	@echo \#define CONFIG_LOCI_DETAILS_H >> version_details.h
+	@echo \#define LOCI_VERSION \"$(GIT_INFO)\" >> version_details.h
+	@echo \#define LOCI_BRANCH \"$(GIT_BRANCH)\" >> version_details.h
+	@echo \#endif >> version_details.h
+	@# Only update version_details.h if it has changed.
+	@if [ -e $@ ]; then if ! cmp version_details.h $@; then mv version_details.h $@ ; else rm version_details.h ; fi ; else mv version_details.h $@ ; fi
+
 Tools/libTools.$(LIB_SUFFIX): include/Config/version_info.h FORCE
 	$(MAKE) -C Tools LOCI_BASE="$(LOCI_BASE)" libTools.$(LIB_SUFFIX)
 
-System/libLoci.$(LIB_SUFFIX): include/Config/version_info.h FORCE
+System/libLoci.$(LIB_SUFFIX): include/Config/version_info.h include/Config/version_details.h FORCE
 	$(MAKE) -C System LOCI_BASE="$(LOCI_BASE)" libLoci.$(LIB_SUFFIX)
 
-lpp: Tools/libTools.$(LIB_SUFFIX) include/Config/version_info.h FORCE
+lpp: Tools/libTools.$(LIB_SUFFIX) include/Config/version_info.h include/Config/version_details.h FORCE
 	$(MAKE) -C lpp LOCI_BASE="$(LOCI_BASE)" lpp
 
 FVMtools: library lpp FVMAdapt SPRNG FORCE

--- a/src/System/Loci_version.cc
+++ b/src/System/Loci_version.cc
@@ -19,7 +19,7 @@
 //#
 //#############################################################################
 #include <Loci_version.h>
-
+#include <Config/version_details.h>
 namespace Loci {
 
 

--- a/src/System/Makefile
+++ b/src/System/Makefile
@@ -52,7 +52,7 @@ compile: $(TARGET)
 #	$(RANLIB) libLoci.a
 
 LIB_OBJS=$(OBJS:.o=_lo.o)
-libLoci.$(LIB_SUFFIX): $(LIB_OBJS) Loci_version.cc
+libLoci.$(LIB_SUFFIX): $(LIB_OBJS) Loci_version.cc $(LOCI_BASE)/include/Config/version_details.h
 	$(CXX) $(PIC_FLAGS) $(COPT) $(DEFINES) $(LOCI_INCLUDES) $(INCLUDES) -o Loci_version_lo.o -c Loci_version.cc
 	$(DYNAMIC_LD) $(DYNAMIC_LD_FLAGS) libLoci.$(LIB_SUFFIX) $(LIB_FLAGS) $(LIB_OBJS) Loci_version_lo.o $(PETSC_LIBS)
 

--- a/src/lpp/main.cc
+++ b/src/lpp/main.cc
@@ -19,6 +19,7 @@
 //#
 //#############################################################################
 #include "lpp.h"
+#include <Config/version_details.h>
 #include <unistd.h>
 
 using namespace std ;


### PR DESCRIPTION
The automatic versioning information was causing the entire of Loci to recompile whenever the first change to a clean git repository was made.  This was because the LOCI_VERSION string changed to include the dirty.  However, this is only being accessed in a few places where detailed versioning information was printed.  This divides the information into two parts, one that includes version numbers that change less frequently and the other that includes detailed version information that frequently changes.  This makes compilation when making minor git changes more efficient.