### PR TITLE
Update to remove use of all_collect_entitySet() calls causing scalability problems

### DIFF
--- a/src/System/categories.cc
+++ b/src/System/categories.cc
@@ -36,7 +36,7 @@ using std::string ;
 
 #include <iostream>
 using std::cout ;
-using std::cerr ; 
+using std::cerr ;
 using std::endl ;
 using std::ios ;
 using std::ostream ;
@@ -52,7 +52,6 @@ using std::ostringstream ;
 
 namespace Loci {
 
-
   inline bool compare_var_sizes(const pair<variable,int> &p1, const pair<variable,int> &p2) {
     return p1.second > p2.second ;
   }
@@ -64,269 +63,271 @@ namespace Loci {
 
 
   namespace {
-  // Compute associations between variables and their domains
-  // Note, we also create image variables to represent the images of maps
-  //   over their domains.
-  void getVariableAssociations(map<variable,entitySet> &vm, fact_db &facts, int kd) {
-    vector<entitySet> ptn = facts.get_init_ptn(kd) ;
-    entitySet total_entities ;
-    vm.clear() ;
-    variableSet vars = facts.get_typed_variables() ;
-    for(variableSet::const_iterator vi=vars.begin();vi!=vars.end();++vi) {
-      storeRepP p = facts.get_variable(*vi) ;
+    // Compute associations between variables and their domains
+    // Note, we also create image variables to represent the images of maps
+    //   over their domains.
+    void getVariableAssociations(map<variable,entitySet> &vm, fact_db &facts, int kd) {
+      vector<entitySet> ptn = facts.get_init_ptn(kd) ;
+      entitySet total_entities ;
+      entitySet my_entities = ptn[MPI_rank] ;
+      vm.clear() ;
+      variableSet vars = facts.get_typed_variables() ;
+      for(variableSet::const_iterator vi=vars.begin();vi!=vars.end();++vi) {
+        storeRepP p = facts.get_variable(*vi) ;
 
-      if(p->getDomainKeySpace() == kd) {
-	if(isMAP(p)) {
-	  entitySet tmp = dist_collect_entitySet(p->domain(), ptn) ;
-	  vm[*vi] = tmp ;
-	  total_entities += tmp ;
-	} else if(isSTORE(p)) {
-	  entitySet tmp = dist_collect_entitySet(p->domain(), ptn) ;
-	  vm[*vi] = tmp ;
-	  total_entities += tmp ;
-	} else {
-	  if(p->domain() != ~EMPTY) {
-	    entitySet all_collect = dist_collect_entitySet(p->domain(),ptn) ;
-	    vm[*vi] = all_collect ; 
-	    total_entities += all_collect ;
-	  }
-	}
-      }
-    }
-    for(variableSet::const_iterator vi=vars.begin();vi!=vars.end();++vi) {
-      storeRepP p = facts.get_variable(*vi) ;
-      if(isMAP(p)) {
-        // Add any map image that refers to entities not already identified.
-        MapRepP mp = MapRepP(p->getRep()) ;
-
-	if(mp->getRangeKeySpace() == kd) {
-	  entitySet image_dom = mp->image(p->domain()) ;
-	  image_dom = dist_collect_entitySet(image_dom, ptn) ;
-	  entitySet testSet = image_dom - total_entities ;
-	  int size = testSet.size() ;
-	  int tsize = 0 ;
-	  MPI_Allreduce(&size,&tsize,1,MPI_INT,MPI_SUM,MPI_COMM_WORLD) ;
-	  if(tsize != 0) {
-	    std::string name = "image_" ;
-	    name.append(vi->get_info().name) ;
-	    variable v = variable(name) ;
-	    vm[v] = image_dom ;
-	    total_entities += image_dom ;
-	  }
-	}
-      }
-    }
-    variable v_leftout("SENTINEL_LEFTOUT") ;
-    vm[v_leftout] = ptn[MPI_rank]-total_entities ;
-  }
-
-  // Compute the distict intervals that are required to describe all of
-  // the variable domain sets.
-  void getLocalIntervals(vector<interval> &pvec,
-                         const map<variable,entitySet> &vm) {
-    pvec.clear() ;
-    vector<int> vals ;
-    set<entitySet>::iterator si ;
-    map<variable,entitySet>::const_iterator mi ;
-    entitySet totSet ;
-    for(mi=vm.begin();mi!=vm.end();++mi) {
-      entitySet s = mi->second ; 
-      totSet += s ;
-      for(size_t i = 0;i < s.num_intervals(); ++i) {
-	vals.push_back(s[i].first-1) ;
-	vals.push_back(s[i].first) ;
-	vals.push_back(s[i].second) ;
-	vals.push_back(s[i].second+1) ;
-      }
-    }
-    
-    std::sort(vals.begin(),vals.end()) ;
-
-    vector<int>::iterator uend = std::unique(vals.begin(),vals.end()) ;
-
-    vector<int>::iterator ii = vals.begin() ;
-
-    ++ii ;
-    while(ii+1 != uend) {
-      int i1 = *ii ;
-      int i2 = *(ii+1)  ;
-      if(i1+1 == i2)
-        i2 = i1 ;
-      else
-        ++ii ;
-      ++ii ;
-      interval iv(i1,i2) ;
-      if((entitySet(iv)&totSet) != EMPTY)
-        pvec.push_back(iv) ;
-    }
-
-  }
-
-  // Identify categories by the association of attributes (variables)
-  // with entities.  These categories are only for entities owned by
-  // the current processors (i.e. local)
-  void getLocalCategories(map<variableSet, entitySet> &cmap,
-                          const map<variable, entitySet> &vm) {
-    cmap.clear() ;
-    vector<interval> pvec ;
-    getLocalIntervals(pvec,vm) ;
-    
-    vector<variableSet> cat_names(pvec.size()) ;
-#ifdef VERBOSE
-    debugout << "pvec.size() = " << pvec.size()
-
-             << "vm.size() = " << vm.size() << endl ;
-#endif
-
-    map<entitySet, variableSet> vt ;
-    map<variable,entitySet>::const_iterator mi ;
-    for(mi=vm.begin();mi!=vm.end();++mi) {
-      vt[mi->second] += mi->first ;
-    } ;
-#ifdef VERBOSE
-    debugout << "pvec.size() = " << pvec.size()
-             << " vm.size() = " << vm.size() 
-             << " vt.size() = " << vt.size() << endl ;
-#endif
-    map<entitySet,variableSet>::const_iterator mt ;
-    
-    for(mt=vt.begin();mt!=vt.end();++mt) {
-      variableSet vs = mt->second ;
-      entitySet e = mt->first ;
-      for(size_t i=0;i<pvec.size();++i) {
-        if(e.inSet(pvec[i].first)) {
-#ifdef DEBUG
-          entitySet isect = entitySet(pvec[i]) & e ;
-          WARN(isect != entitySet(pvec[i]) ) ;
-#endif
-          cat_names[i] += vs ;
+        if(p->getDomainKeySpace() == kd) {
+          if(isMAP(p)) {
+            entitySet tmp = my_entities & p->domain() ;
+            vm[*vi] = tmp ;
+            total_entities += tmp ;
+          } else if(isSTORE(p)) {
+            entitySet tmp = my_entities & p->domain() ;
+            vm[*vi] = tmp ;
+            total_entities += tmp ;
+          } else {
+            if(p->domain() != ~EMPTY) {
+              entitySet tmp = my_entities & p->domain() ;
+              vm[*vi] = tmp ;
+              total_entities += tmp ;
+            }
+          }
         }
       }
+      for(variableSet::const_iterator vi=vars.begin();vi!=vars.end();++vi) {
+        storeRepP p = facts.get_variable(*vi) ;
+        if(isMAP(p)) {
+          // Add any map image that refers to entities not already identified.
+          MapRepP mp = MapRepP(p->getRep()) ;
+
+          if(mp->getRangeKeySpace() == kd) {
+            entitySet dom = my_entities & p->domain() ;
+            entitySet image_dom = mp->image(dom) ;
+            image_dom += distribute_entitySet(image_dom, ptn) ;
+            entitySet testSet = image_dom - total_entities ;
+            int size = testSet.size() ;
+            int tsize = 0 ;
+            MPI_Allreduce(&size,&tsize,1,MPI_INT,MPI_SUM,MPI_COMM_WORLD) ;
+            if(tsize != 0) {
+              std::string name = "image_" ;
+              name.append(vi->get_info().name) ;
+              variable v = variable(name) ;
+              vm[v] = image_dom ;
+              total_entities += image_dom ;
+            }
+          }
+        }
+      }
+      variable v_leftout("SENTINEL_LEFTOUT") ;
+      vm[v_leftout] = ptn[MPI_rank]-total_entities ;
     }
-    
-    for(size_t i=0;i<pvec.size();++i) 
-      cmap[cat_names[i]] += pvec[i] ;
 
-  }
-
-  
-
-  // Unify local categories across all processors, return in a universal order
-  // variables and categories.
-  void getGlobalCategories(vector<variableSet> &clist,
-                           vector<variable> &vlist,
-                           const map<variableSet,entitySet> &cmap,
+    // Compute the distict intervals that are required to describe all of
+    // the variable domain sets.
+    void getLocalIntervals(vector<interval> &pvec,
                            const map<variable,entitySet> &vm) {
-    vector<string> vnlist ;
-    map<variable,entitySet>::const_iterator ii ;
-    for(ii=vm.begin();ii!=vm.end();++ii) {
-      ostringstream oss ;
-      oss << ii->first ;
-      vnlist.push_back(oss.str()) ;
-    }
-    sort(vnlist.begin(),vnlist.end()) ;
-    vlist.clear() ;
-    map<variable,int> vident ;
-    for(size_t i=0;i<vnlist.size();++i) {
-      variable v(vnlist[i]) ;
-      vlist.push_back(v) ;
-      vident[v] = i ;
-    }
-    
-    set<entitySet> cat_set ;
-    map<variableSet,entitySet>::const_iterator ci ;
-    for(ci=cmap.begin();ci!=cmap.end();++ci) {
-      entitySet tmp ;
-      variableSet s = ci->first ;
-      for(variableSet::const_iterator vi=s.begin();vi!=s.end();++vi) 
-        tmp += vident[*vi] ;
-      cat_set.insert(tmp) ;
-    }
-
-    set<entitySet> cat_set_unified ;
-    int comm_root = 0 ;
-    while(comm_root != -1) {
-      vector<int> buffer ;
-      if(comm_root == MPI_rank) {
-        set<entitySet>::const_iterator si ;
-        for(si=cat_set.begin();si!=cat_set.end();++si) {
-          entitySet s = *si ;
-          buffer.push_back(s.size()) ;
-          for(entitySet::const_iterator ei=s.begin();ei!=s.end();++ei)
-            buffer.push_back(*ei) ;
+      pvec.clear() ;
+      vector<int> vals ;
+      set<entitySet>::iterator si ;
+      map<variable,entitySet>::const_iterator mi ;
+      entitySet totSet ;
+      for(mi=vm.begin();mi!=vm.end();++mi) {
+        entitySet s = mi->second ;
+        totSet += s ;
+        for(size_t i = 0;i < s.num_intervals(); ++i) {
+          vals.push_back(s[i].first-1) ;
+          vals.push_back(s[i].first) ;
+          vals.push_back(s[i].second) ;
+          vals.push_back(s[i].second+1) ;
         }
       }
-      int buf_size = buffer.size() ;
-      MPI_Bcast(&buf_size,1,MPI_INT,comm_root,MPI_COMM_WORLD) ;
-      if(comm_root != MPI_rank)
-        buffer = vector<int>(buf_size) ;
-      MPI_Bcast(&buffer[0],buf_size,MPI_INT,comm_root,MPI_COMM_WORLD) ;
 
-      for(size_t ex=0;ex<buffer.size();) {
-        int num_ents = buffer[ex] ;
-        ex++ ;
-        entitySet s ;
-        for(int i=0;i<num_ents;++i) {
-          s += buffer[ex] ;
+      std::sort(vals.begin(),vals.end()) ;
+
+      vector<int>::iterator uend = std::unique(vals.begin(),vals.end()) ;
+
+      vector<int>::iterator ii = vals.begin() ;
+
+      ++ii ;
+      while(ii+1 != uend) {
+        int i1 = *ii ;
+        int i2 = *(ii+1)  ;
+        if(i1+1 == i2)
+          i2 = i1 ;
+        else
+          ++ii ;
+        ++ii ;
+        interval iv(i1,i2) ;
+        if((entitySet(iv)&totSet) != EMPTY)
+          pvec.push_back(iv) ;
+      }
+
+    }
+
+    // Identify categories by the association of attributes (variables)
+    // with entities.  These categories are only for entities owned by
+    // the current processors (i.e. local)
+    void getLocalCategories(map<variableSet, entitySet> &cmap,
+                            const map<variable, entitySet> &vm) {
+      cmap.clear() ;
+      vector<interval> pvec ;
+      getLocalIntervals(pvec,vm) ;
+
+      vector<variableSet> cat_names(pvec.size()) ;
+#ifdef VERBOSE
+      debugout << "pvec.size() = " << pvec.size()
+
+               << "vm.size() = " << vm.size() << endl ;
+#endif
+
+      map<entitySet, variableSet> vt ;
+      map<variable,entitySet>::const_iterator mi ;
+      for(mi=vm.begin();mi!=vm.end();++mi) {
+        vt[mi->second] += mi->first ;
+      } ;
+#ifdef VERBOSE
+      debugout << "pvec.size() = " << pvec.size()
+               << " vm.size() = " << vm.size()
+               << " vt.size() = " << vt.size() << endl ;
+#endif
+      map<entitySet,variableSet>::const_iterator mt ;
+
+      for(mt=vt.begin();mt!=vt.end();++mt) {
+        variableSet vs = mt->second ;
+        entitySet e = mt->first ;
+        for(size_t i=0;i<pvec.size();++i) {
+          if(e.inSet(pvec[i].first)) {
+#ifdef DEBUG
+            entitySet isect = entitySet(pvec[i]) & e ;
+            WARN(isect != entitySet(pvec[i]) ) ;
+#endif
+            cat_names[i] += vs ;
+          }
+        }
+      }
+
+      for(size_t i=0;i<pvec.size();++i)
+        cmap[cat_names[i]] += pvec[i] ;
+
+    }
+
+
+
+    // Unify local categories across all processors, return in a universal order
+    // variables and categories.
+    void getGlobalCategories(vector<variableSet> &clist,
+                             vector<variable> &vlist,
+                             const map<variableSet,entitySet> &cmap,
+                             const map<variable,entitySet> &vm) {
+      vector<string> vnlist ;
+      map<variable,entitySet>::const_iterator ii ;
+      for(ii=vm.begin();ii!=vm.end();++ii) {
+        ostringstream oss ;
+        oss << ii->first ;
+        vnlist.push_back(oss.str()) ;
+      }
+      sort(vnlist.begin(),vnlist.end()) ;
+      vlist.clear() ;
+      map<variable,int> vident ;
+      for(size_t i=0;i<vnlist.size();++i) {
+        variable v(vnlist[i]) ;
+        vlist.push_back(v) ;
+        vident[v] = i ;
+      }
+
+      set<entitySet> cat_set ;
+      map<variableSet,entitySet>::const_iterator ci ;
+      for(ci=cmap.begin();ci!=cmap.end();++ci) {
+        entitySet tmp ;
+        variableSet s = ci->first ;
+        for(variableSet::const_iterator vi=s.begin();vi!=s.end();++vi)
+          tmp += vident[*vi] ;
+        cat_set.insert(tmp) ;
+      }
+
+      set<entitySet> cat_set_unified ;
+      int comm_root = 0 ;
+      while(comm_root != -1) {
+        vector<int> buffer ;
+        if(comm_root == MPI_rank) {
+          set<entitySet>::const_iterator si ;
+          for(si=cat_set.begin();si!=cat_set.end();++si) {
+            entitySet s = *si ;
+            buffer.push_back(s.size()) ;
+            for(entitySet::const_iterator ei=s.begin();ei!=s.end();++ei)
+              buffer.push_back(*ei) ;
+          }
+        }
+        int buf_size = buffer.size() ;
+        MPI_Bcast(&buf_size,1,MPI_INT,comm_root,MPI_COMM_WORLD) ;
+        if(comm_root != MPI_rank)
+          buffer = vector<int>(buf_size) ;
+        MPI_Bcast(&buffer[0],buf_size,MPI_INT,comm_root,MPI_COMM_WORLD) ;
+
+        for(size_t ex=0;ex<buffer.size();) {
+          int num_ents = buffer[ex] ;
           ex++ ;
+          entitySet s ;
+          for(int i=0;i<num_ents;++i) {
+            s += buffer[ex] ;
+            ex++ ;
+          }
+          cat_set_unified.insert(s) ;
+          cat_set.erase(s) ;
         }
-        cat_set_unified.insert(s) ;
-        cat_set.erase(s) ;
+        int r = -1 ;
+        if(cat_set.size() != 0)
+          r = MPI_rank ;
+        MPI_Allreduce(&r,&comm_root,1,MPI_INT,MPI_MAX,MPI_COMM_WORLD) ;
       }
-      int r = -1 ;
-      if(cat_set.size() != 0)
-        r = MPI_rank ;
-      MPI_Allreduce(&r,&comm_root,1,MPI_INT,MPI_MAX,MPI_COMM_WORLD) ;
-    }
-    clist.clear() ;
-    set<entitySet>::const_iterator si ;
-    for(si=cat_set_unified.begin();si!=cat_set_unified.end();++si) {
-      entitySet s = *si ;
-      variableSet vs ;
-      for(entitySet::const_iterator ei=s.begin();ei!=s.end();++ei)
-        vs += vlist[*ei] ;
-      clist.push_back(vs) ;
-    }
-  }
-
-  // Collect the sizes of the distributed variable sets
-  void getVarSizes(vector<pair<variable,int> > &var_sizes,
-                   const vector<variable> &var_list,
-                   const map<variable,entitySet> &vm) {
-    var_sizes.clear() ;
-    for(size_t i=0;i<var_list.size();++i) {
-      variable v = var_list[i] ;
-      map<variable,entitySet>::const_iterator vinfo = vm.find(v) ;
-      int local_size = vinfo->second.size() ;
-      int vsize = 0 ;
-      MPI_Allreduce(&local_size,&vsize,1,MPI_INT,MPI_SUM,MPI_COMM_WORLD) ;
-      var_sizes.push_back(pair<variable,int>(v,vsize)) ;
-    }
-    std::stable_sort(var_sizes.begin(),var_sizes.end(),compare_var_sizes) ;
-  }
-
-  void getCategoryKeys(vector<pair<variableSet,string> > &cat_keys,
-                  const vector<pair<variable,int> > &var_sizes,
-                  const vector<variableSet> &cat_list) {
-    cat_keys.clear() ;
-    for(size_t i=0;i<cat_list.size();++i) {
-      variableSet vset = cat_list[i] ;
-      string key ;
-      for(size_t j=0;j<var_sizes.size();++j) {
-        key += vset.inSet(var_sizes[j].first)?'1':'0' ;
+      clist.clear() ;
+      set<entitySet>::const_iterator si ;
+      for(si=cat_set_unified.begin();si!=cat_set_unified.end();++si) {
+        entitySet s = *si ;
+        variableSet vs ;
+        for(entitySet::const_iterator ei=s.begin();ei!=s.end();++ei)
+          vs += vlist[*ei] ;
+        clist.push_back(vs) ;
       }
-      cat_keys.push_back(pair<variableSet,string>(vset,key)) ;
     }
-    std::stable_sort(cat_keys.begin(),cat_keys.end(),compare_groups) ;
+
+    // Collect the sizes of the distributed variable sets
+    void getVarSizes(vector<pair<variable,int> > &var_sizes,
+                     const vector<variable> &var_list,
+                     const map<variable,entitySet> &vm) {
+      var_sizes.clear() ;
+      for(size_t i=0;i<var_list.size();++i) {
+        variable v = var_list[i] ;
+        map<variable,entitySet>::const_iterator vinfo = vm.find(v) ;
+        int local_size = vinfo->second.size() ;
+        int vsize = 0 ;
+        MPI_Allreduce(&local_size,&vsize,1,MPI_INT,MPI_SUM,MPI_COMM_WORLD) ;
+        var_sizes.push_back(pair<variable,int>(v,vsize)) ;
+      }
+      std::stable_sort(var_sizes.begin(),var_sizes.end(),compare_var_sizes) ;
+    }
+
+    void getCategoryKeys(vector<pair<variableSet,string> > &cat_keys,
+                         const vector<pair<variable,int> > &var_sizes,
+                         const vector<variableSet> &cat_list) {
+      cat_keys.clear() ;
+      for(size_t i=0;i<cat_list.size();++i) {
+        variableSet vset = cat_list[i] ;
+        string key ;
+        for(size_t j=0;j<var_sizes.size();++j) {
+          key += vset.inSet(var_sizes[j].first)?'1':'0' ;
+        }
+        cat_keys.push_back(pair<variableSet,string>(vset,key)) ;
+      }
+      std::stable_sort(cat_keys.begin(),cat_keys.end(),compare_groups) ;
+    }
   }
-  }                  
   void categories(fact_db &facts,vector<entitySet> &pvec, int kd) {
     map<variable, entitySet> vm ;
     getVariableAssociations(vm,facts,kd) ;
 
     if(vm.size() == 1) // Empty kd
       return ;
-    
+
     map<variableSet, entitySet> cmap ;
     getLocalCategories(cmap,vm) ;
 

--- a/src/System/dist_tools.cc
+++ b/src/System/dist_tools.cc
@@ -413,20 +413,29 @@ namespace Loci {
     // 	referencedEntities += tmp_mp->image(tmp_sp->domain()) ;
     //   }
     // }
-	  
+    variableSet constraintVars ;
+    variableSet mapVars ;
     for(variableSet::const_iterator vi = tmp_vars.begin(); vi != tmp_vars.end(); ++vi) {
       storeRepP tmp_sp = facts.get_variable(*vi) ;
       if(tmp_sp->RepType() == CONSTRAINT) {
         entitySet tmp_dom = tmp_sp->domain() ;
         if(GLOBAL_OR(tmp_dom != ~EMPTY,MPI_COMM_WORLD)) {
-	  entitySet global_tmp_dom = all_collect_entitySet(tmp_dom) ;
-	  //	  entitySet global_tmp_dom = collectSet(tmp_dom,referencedEntities,
-	  //						MPI_COMM_WORLD) ;
+          std::vector<entitySet> &ptn =
+            facts.get_init_ptn(tmp_sp->getDomainKeySpace()) ; 
+	  entitySet global_tmp_dom = distribute_entitySet(tmp_dom,ptn) ;
+          //global_tmp_dom = all_collect_entitySet(tmp_dom) ;
+
           constraint tmp ;
           *tmp = global_tmp_dom ;
 	  tmp.Rep()->setDomainKeySpace(tmp_sp->getDomainKeySpace()) ;
           facts.replace_fact(*vi,tmp) ;
-        }
+          constraintVars += *vi ;
+        } else {
+          constraint tmp ;
+          *tmp = ~EMPTY ;
+	  tmp.Rep()->setDomainKeySpace(tmp_sp->getDomainKeySpace()) ;
+          facts.replace_fact(*vi,tmp) ;
+        }          
       }
       if(isMAP(tmp_sp)) {
 	MapRepP tmp_mp = MapRepP(tmp_sp->getRep()) ;
@@ -437,6 +446,7 @@ namespace Loci {
 	tmp_mp = MapRepP(map_sp->getRep()) ;
 	tmp_mp->setRangeKeySpace(kd_range) ;
         facts.replace_fact(*vi, map_sp) ;
+        mapVars += *vi ;
       }
     }
 
@@ -505,6 +515,33 @@ namespace Loci {
     double clone_time_start = MPI_Wtime() ;
 
     vector<entitySet> image =dist_expand_map(tmp_set, facts, dist_maps) ;
+
+    // Figure out what entities we need to communicate for proper
+    // constraint evaluation
+    std::map<int,entitySet> keyspace_expand ;
+    for(auto vi = mapVars.begin();vi!=mapVars.end();++vi) {
+      storeRepP tmp_sp = facts.get_variable(*vi) ;
+      MapRepP tmp_mp = MapRepP(tmp_sp->getRep()) ;
+      int kd_range = tmp_mp->getRangeKeySpace() ;
+      entitySet image = tmp_mp->image(tmp_mp->domain()) ;
+      std::vector<entitySet> &ptn =
+        facts.get_init_ptn(kd_range) ; 
+      keyspace_expand[kd_range]+=image-ptn[MPI_rank] ;
+    }
+
+    for(auto vi = constraintVars.begin();vi!=constraintVars.end();++vi) {
+      storeRepP tmp_sp = facts.get_variable(*vi) ;
+      int kd = tmp_sp->getDomainKeySpace() ;
+      std::vector<entitySet> &ptn = facts.get_init_ptn(kd) ;
+      entitySet dom = tmp_sp->domain() ;
+      dom = dist_expand_entitySet(dom,keyspace_expand[kd],ptn) ;
+      constraint tmp ;
+      *tmp = dom ;
+      tmp.Rep()->setDomainKeySpace(kd) ;
+      facts.replace_fact(*vi,tmp) ;
+    }
+      
+
 
     vector<vector<entitySet> > copyv(nkd), send_clonev(nkd) ;
     for(int kd=0;kd<nkd;++kd) {
@@ -584,13 +621,16 @@ namespace Loci {
       std::vector<entitySet> iv ;
       categories(facts,iv,kd) ; // FIX THIS
       std::vector<entitySet> &ptn = facts.get_init_ptn(kd) ; 
+      for(size_t i=0;i<iv.size();++i) {
+        iv[i] &= ptn[MPI_rank] ;
+      }
       debugout << "finding categories time = " << s.stop() << endl ;
       s.start() ;
       for(size_t i=0;i < iv.size(); ++i) {
 	debugout << "iv["<< i << "] size before expand = " << iv[i].num_intervals()<< endl ;
 	entitySet tmp_copy =  image[kd] - ptn[MPI_rank] ;
-	iv[i] = dist_expand_entitySet(iv[i],tmp_copy,ptn) ;
-	debugout << "iv["<< i << "] size after expand = " << iv[i].num_intervals() <<endl;
+        iv[i] = dist_expand_entitySet(iv[i],tmp_copy,ptn) ;
+        debugout << "iv["<< i << "] size after expand = " << iv[i].num_intervals() <<endl;
       }
       debugout << "time expanding categories = " << s.stop() << endl ;
       s.start() ;
@@ -788,7 +828,6 @@ namespace Loci {
     facts.create_intensional_fact("my_entities",my_entities);
 
   }
-
 
   /** ************************************************************************
    *

--- a/src/System/distribute.cc
+++ b/src/System/distribute.cc
@@ -826,6 +826,7 @@ namespace Loci {
   // Collect entitities to a unified entitySet that is distributed across
   // processors according to the partition ptn.
   entitySet dist_collect_entitySet(entitySet inSet, const vector<entitySet> &ptn) {
+    cerr << "dist_collect_entitySet is depreciated" << endl ;
     const int p = MPI_processes ;
     const int r = MPI_rank ;
     entitySet retval = inSet & ptn[r] ;
@@ -934,75 +935,104 @@ namespace Loci {
     
     return retval ;
   }
-  
-  entitySet dist_expand_entitySet(entitySet inSet, entitySet copy,
+
+  // -----------------------------------------------------------------------
+  /// @brief dist_expand_entitySet() is given an input set and a set of
+  /// entities that are in the clone region.  The ownership of entities
+  /// are given by the partition, it will recieve the data from the clone
+  /// regions so that the expanded set is valid representation of the
+  /// distributed set in the provided clone regions
+  ///
+  /// @param [inSet] input set that represents the set distributed across
+  /// processors
+  /// @param [clone] input set of cloned entities that we wish to fill in
+  /// with set values from the remote procesors
+  /// @param [ptn]   partition function that describes which processor owns
+  /// which entities.
+  entitySet dist_expand_entitySet(entitySet inSet, entitySet clone,
                                   const vector<entitySet> &ptn) {
-    vector<int> send_req(ptn.size()) ;
-    for(size_t i=0;i < ptn.size();++i)
-      if((copy&ptn[i]) != EMPTY)
-        send_req[i] = 1 ;
-      else
-        send_req[i] = 0 ;
-    vector<int> recv_req(ptn.size()) ;
-    MPI_Alltoall(&send_req[0],1,MPI_INT, &recv_req[0],1,MPI_INT,
+    // We don't need to send data to ourselves
+    clone -= inSet ;
+
+    // Send an interval that contains the cloned region for each processor
+    // If there is no entities on the processor, mark by an invalid interval
+    vector<int> send_req(ptn.size()*2) ;
+    for(size_t i=0;i < ptn.size();++i) {
+      entitySet clone_i = clone&ptn[i] ;
+      if(clone_i != EMPTY) {
+        send_req[i*2+0] = clone_i.Min() ;
+        send_req[i*2+1] = clone_i.Max() ;
+      } else {
+        send_req[i*2+0] = 1 ;
+        send_req[i*2+1] = 0 ;
+      }
+    }
+
+    // Send clone requests to partners
+    vector<int> recv_req(ptn.size()*2) ;
+    MPI_Alltoall(&send_req[0],2,MPI_INT, &recv_req[0],2,MPI_INT,
                  MPI_COMM_WORLD) ;
+
+    // From the clone requests, find a set that we need to send to the
+    // corresponding processor
     vector<int> send_sizes(ptn.size()) ;
-    int send_intervals = inSet.num_intervals() ;
-    
+    vector<entitySet> send_data(ptn.size()) ;
     for(size_t i=0;i < ptn.size();++i)
-      if(recv_req[i]!=0)
-        send_sizes[i] = send_intervals ;
-      else
-        send_sizes[i] = 0 ;
+      if(recv_req[i*2+0]<=recv_req[i*2+1]) {
+        send_data[i] = inSet & interval(recv_req[i*2+0],recv_req[i*2+1]) ;
+        send_sizes[i] = send_data[i].num_intervals() ;
+      }
+
+    // Share the size information with partners
     vector<int> recv_sizes(ptn.size()) ;
     MPI_Alltoall(&send_sizes[0],1,MPI_INT, &recv_sizes[0],1,MPI_INT,
                  MPI_COMM_WORLD) ;
-    vector<vector<int> > recv_buffers ;
-    vector<int> buf_size ;
-    vector<int> proc ;
-    vector<MPI_Request> recv_Requests ;
+
+    // Compress all of the recieves to a single buffer, compute offsets
+    // within each buffer for the recieves
+    vector<int> recv_offsets(ptn.size()+1) ;
+    recv_offsets[0] = 0 ;
+    int numRecvs = 0 ;
+    for(size_t i=0;i<ptn.size();++i) {
+      recv_offsets[i+1] = recv_offsets[i]+recv_sizes[i] ;
+      if(recv_sizes[i] > 0)
+        numRecvs++ ;
+    }
+    vector<int> recv_buffer(recv_offsets[ptn.size()]*2,0) ;
+
+    // Allocate request buffers for Irecvs
+    vector<MPI_Request> recv_Requests(numRecvs) ;
+    int cnt = 0 ;
     for(size_t i=0;i < ptn.size();++i) {
-      if(recv_sizes[i] != 0) {
+      if(recv_sizes[i] > 0) {
         int recv_size = recv_sizes[i]*2 ;
-        recv_buffers.push_back(vector<int>(recv_size))  ;
-        buf_size.push_back(recv_sizes[i]) ;
-        recv_Requests.push_back(MPI_Request()) ;
-        proc.push_back(i) ;
+        int recv_offset = recv_offsets[i]*2 ;
+        
+        MPI_Irecv(&(recv_buffer[recv_offset]),recv_size,MPI_INT,i,3,
+                  MPI_COMM_WORLD,&recv_Requests[cnt++]) ;
       }
     }
-    for(size_t i=0;i < recv_buffers.size();++i) {
-      int recv_size = buf_size[i]*2 ;
-      
-      MPI_Irecv(&recv_buffers[i][0],recv_size,MPI_INT, proc[i],3,
-                MPI_COMM_WORLD,&recv_Requests[i]) ;
-    }
 
-    vector<int> send_buf(send_intervals*2) ;
-    for(int j=0;j < send_intervals;++j) {
-      send_buf[j*2] = inSet[j].first ;
-      send_buf[j*2+1] = inSet[j].second ;
-    }
-
+    // Send the data to partner
     for(size_t i=0;i < ptn.size();++i) {
       if(send_sizes[i] != 0) {
-        MPI_Send(&send_buf[0],send_intervals*2,MPI_INT,i,3,
-                 MPI_COMM_WORLD) ;
+        MPI_Send(&(send_data[i][0]),send_sizes[i]*2,MPI_INT,i,3,MPI_COMM_WORLD) ;
       }
     }
-    for(size_t i=0;i<recv_Requests.size();++i) {
-      MPI_Status stat ;
-      MPI_Wait(&recv_Requests[i], &stat ) ;
-    }
-    entitySet recvSet ;
-    for(size_t i=0;i<recv_buffers.size();++i)
-      for(int j=0;j<buf_size[i];++j) {
-        recvSet += interval(recv_buffers[i][j*2],recv_buffers[i][j*2+1]) ;
-      }
 
-    inSet += recvSet ;
+    // Wait for communication to complete
+    vector<MPI_Status> recv_Status(recv_Requests.size()) ;
+    MPI_Waitall(numRecvs,&recv_Requests[0],&recv_Status[0]) ;
+
+    // update set to add results from clone regions of other processors
+    for(size_t i=0;i<recv_buffer.size();i=i+2)
+      inSet += interval(recv_buffer[i+0],recv_buffer[i+1]) ;
+
+    // return modified set
     return inSet ;
   }
-    
+
+  
   inline bool spec_ival_compare(const interval &i1,
                             const interval &i2) {
     if(i1.first < i2.first)

--- a/src/include/distribute.h
+++ b/src/include/distribute.h
@@ -66,6 +66,8 @@ namespace Loci {
   std::vector<entitySet> all_collect_vectors(entitySet &e,MPI_Comm comm) ;
   std::vector<entitySet> all_collect_vectors(entitySet &e) ;
 
+  entitySet distribute_entitySet(entitySet e,const std::vector<entitySet> &ptn) ;
+
   entitySet all_collect_entitySet(const entitySet &e) ;
 
   // This is equivalent to but more efficient than


### PR DESCRIPTION
This modifies part of the code that finds categories and generates local numbering so that it no longer assumes that sets will be small due to being a single contiguously numbered interval in global numbering.  This improves query performance and memory performance.