### PR TITLE
Memory Scalability Fix for FVMAdapt

### DIFF
--- a/quickTest/FVMAdaptTest/Makefile
+++ b/quickTest/FVMAdaptTest/Makefile
@@ -1,56 +1,77 @@
 include $(TEST_BASE)/test.conf
-#LD_LIBRARY_PATH=$(LOCI_BASE)/lib:$LD_LIBRARY_PATH
-#DYLD_LIBRARY_PATH=$(LOCI_BASE)/lib:$DYLD_LIBRARY_PATH
+LIB_PATH=$(LOCI_BASE)/lib:$(LD_LIBRARY_PATH)
+DY_PATH=$(LOCI_BASE)/lib:$(DYLD_LIBRARY_PATH)
 
 default: testGridRef.dat testGridRef2.dat testGridRef3.dat
-	diff testGridRef.dat dats/testGridRef.dat
-	diff testGridRef2.dat dats/testGridRef2.dat
-	diff testGridRef3.dat dats/testGridRef3.dat
+	cat dats/testGridRef.dat |sort -g > testGridRef.ref
+	diff testGridRef.dat testGridRef.ref
+	rm testGridRef.ref
+	cat dats/testGridRef2.dat |sort -g > testGridRef2.ref
+	diff testGridRef2.dat testGridRef2.ref
+	rm testGridRef2.ref
+	cat dats/testGridRef3.dat |sort -g > testGridRef3.ref
+	diff testGridRef3.dat testGridRef3.ref
+	rm testGridRef3.ref
 	rm -fr output debug
 	rm *.plan *.tag testGridRef*.vog *.quality
 	rm testGridRef.dat testGridRef2.dat testGridRef3.dat 
 
 testGrid.tag: testGrid.vog
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/vogcheck testGrid
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np 1 $(LOCI_BASE)/bin/extract -ascii testGrid 0 x | sed "s/0[.][01234].*/0/" | sed "s/0[.][56789].*/1/"| sed "s/.*e-.*/0/"> testGrid.tag
 
 testGrid.plan: testGrid.vog testGrid.tag
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/marker -g testGrid.vog -tag testGrid.tag -o testGrid.plan
 
 testGridRef.vog: testGrid.vog testGrid.plan
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/refmesh -g testGrid.vog -r testGrid.plan -o testGridRef.vog
 
 output/testGridRef.topo: testGridRef.vog
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/vogcheck testGridRef
 
 testGridRef.dat: output/testGridRef.topo
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np 1 $(LOCI_BASE)/bin/extract -ascii testGridRef 0 x y z | sort -g > testGridRef.dat
 
 testGridRef.tag: output/testGridRef.topo
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np 1 $(LOCI_BASE)/bin/extract -ascii testGridRef 0 y | sed "s/0[.][01234].*/0/" | sed "s/0[.][56789].*/1/" |sed "s/.*e-.*/0/" > testGridRef.tag
 
 testGridRef2.plan: testGrid.vog testGrid.plan testGridRef.tag
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/marker -g testGrid.vog -r testGrid.plan -tag testGridRef.tag -o testGridRef2.plan
 
 testGridRef2.vog: testGrid.vog testGridRef2.plan
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/refmesh -g testGrid.vog -r testGridRef2.plan -o testGridRef2.vog
 
 output/testGridRef2.topo: testGridRef2.vog
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/vogcheck testGridRef2
 
 testGridRef2.dat: output/testGridRef2.topo
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np 1 $(LOCI_BASE)/bin/extract -ascii testGridRef2 0 x y z | sort -g > testGridRef2.dat
 
 testGridRef3.plan: testGridRef.vog testGridRef.tag
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/marker -g testGridRef.vog -tag testGridRef.tag -o testGridRef3.plan
 
 testGridRef3.vog: testGridRef.vog testGridRef3.plan
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/refmesh -g testGridRef.vog -r testGridRef3.plan -o testGridRef3.vog
 
 output/testGridRef3.topo: testGridRef3.vog
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np $(MPINUMPROC) $(LOCI_BASE)/bin/vogcheck testGridRef3
 
 testGridRef3.dat: output/testGridRef3.topo
+	LD_LIBRARY_PATH=$(LIB_PATH) DYLD_LIBRARY_PATH=$(DY_PATH) \
 	$(MPIRUN) -np 1 $(LOCI_BASE)/bin/extract -ascii testGridRef3 0 x y z | sort -g > testGridRef3.dat
 
 clean:

--- a/src/FVMAdapt/get_fine_face.loci
+++ b/src/FVMAdapt/get_fine_face.loci
@@ -69,7 +69,7 @@ public:
     name_store("pos", pos);
     name_store("balanced_node_offset", node_offset);
     name_store("balanced_cell_offset", cell_offset);
-    name_store("fine_faces", fine_faces);
+    name_store("fine_faces_cell", fine_faces);
     name_store("fileNumber(pos)", node_l2f);
     name_store("is_quadface", is_quadface);
     
@@ -79,7 +79,7 @@ public:
     input("(lower, upper, boundary_map)->face2node->(pos, fileNumber(pos))");
     input("(lower, upper, boundary_map)->face2edge->edge2node->pos");
   
-    output("fine_faces");
+    output("fine_faces_cell");
     constraint("gnrlcells");
   }
   virtual void compute(const sequence &seq){

--- a/src/FVMAdapt/get_fine_grid.loci
+++ b/src/FVMAdapt/get_fine_grid.loci
@@ -71,7 +71,7 @@ public:
     name_store("pos", pos);
 
 
-    name_store("inner_nodes", inner_nodes);
+    name_store("inner_nodes_cell", inner_nodes);
     name_store("fileNumber(pos)", node_l2f);
     name_store("is_quadface", is_quadface);
     
@@ -81,7 +81,7 @@ public:
     input("(lower, upper, boundary_map)->face2node->(pos, fileNumber(pos))");
     input("(lower, upper, boundary_map)->face2edge->edge2node->pos");
    
-    output("inner_nodes");
+    output("inner_nodes_cell");
     constraint("gnrlcells");
   }
   virtual void compute(const sequence &seq){
@@ -164,10 +164,10 @@ public:
     name_store("balancedEdgePlan", edgePlan);
     name_store("pos", pos); 
     name_store("edge2node", edge2node);
-    name_store("inner_nodes", inner_nodes);
+    name_store("inner_nodes_edge", inner_nodes);
     input("balancedEdgePlan");
     input("edge2node->pos");
-    output("inner_nodes");
+    output("inner_nodes_edge");
    
   }
   virtual void compute(const sequence &seq){

--- a/src/FVMAdapt/get_hex_fine_face.loci
+++ b/src/FVMAdapt/get_hex_fine_face.loci
@@ -80,7 +80,7 @@ public:
     name_store("balanced_node_offset", node_offset);
     name_store("balanced_cell_offset", cell_offset);
     
-    name_store("fine_faces", fine_faces);
+    name_store("fine_faces_cell", fine_faces);
     name_store("fileNumber(face2node)", face_l2f);
     name_store("fileNumber(pos)", node_l2f);
     
@@ -91,7 +91,7 @@ public:
     input("(lower, upper, boundary_map)->face2node->(pos, fileNumber(pos))");
     input("(lower, upper, boundary_map)->face2edge->edge2node->(pos, fileNumber(pos))");
     
-    output("fine_faces");
+    output("fine_faces_cell");
     constraint("hexcells");
   }
   virtual void compute(const sequence &seq){

--- a/src/FVMAdapt/get_hex_fine_grid.loci
+++ b/src/FVMAdapt/get_hex_fine_grid.loci
@@ -80,7 +80,7 @@ public:
     name_store("pos", pos);
   
 
-    name_store("inner_nodes", inner_nodes);
+    name_store("inner_nodes_cell", inner_nodes);
     name_store("fileNumber(face2node)", node_l2f);
 
     
@@ -91,7 +91,7 @@ public:
     input("(lower, upper, boundary_map)->face2node->pos");
     input("(lower, upper, boundary_map)->face2edge->edge2node->pos");
     
-    output("inner_nodes");
+    output("inner_nodes_cell");
     constraint("hexcells");
   }
   virtual void compute(const sequence &seq){

--- a/src/FVMAdapt/get_prism_fine_face.loci
+++ b/src/FVMAdapt/get_prism_fine_face.loci
@@ -81,7 +81,7 @@ public:
     name_store("balanced_node_offset", node_offset);
     name_store("balanced_cell_offset", cell_offset);
   
-    name_store("fine_faces", fine_faces);
+    name_store("fine_faces_cell", fine_faces);
     name_store("fileNumber(face2node)", face_l2f);
     name_store("fileNumber(pos)", node_l2f);
     
@@ -92,7 +92,7 @@ public:
     input("(lower, upper, boundary_map)->face2node->(pos, fileNumber(pos))");
     input("(lower, upper, boundary_map)->face2edge->edge2node->(pos, fileNumber(pos))");
     input("(lower, upper, boundary_map)->fileNumber(face2node)");
-    output("fine_faces");
+    output("fine_faces_cell");
     constraint("prisms");
   }
   virtual void compute(const sequence &seq){

--- a/src/FVMAdapt/get_prism_fine_grid.loci
+++ b/src/FVMAdapt/get_prism_fine_grid.loci
@@ -77,7 +77,7 @@ public:
     name_store("pos", pos);
 
     
-    name_store("inner_nodes", inner_nodes);
+    name_store("inner_nodes_cell", inner_nodes);
      name_store("fileNumber(face2node)", node_l2f);
   
     
@@ -88,7 +88,7 @@ public:
     input("(lower, upper, boundary_map)->face2node->pos");
     input("(lower, upper, boundary_map)->face2edge->edge2node->pos");
     input("(lower, upper, boundary_map)->fileNumber(face2node)");
-    output("inner_nodes");
+    output("inner_nodes_cell");
     constraint("prisms");
   }
   virtual void compute(const sequence &seq){
@@ -194,13 +194,13 @@ public:
     name_store("edge2node", edge2node);
     name_store("pos", pos);
     name_store("is_quadface", is_quadface);
-    name_store("inner_nodes", inner_nodes);
+    name_store("inner_nodes_face", inner_nodes);
     
     
     input("(balancedFacePlan,is_quadface)");
     input("face2edge->(balancedEdgePlan, edge2node)");
     input("face2node->pos");
-    output("inner_nodes");
+    output("inner_nodes_face");
     constraint("faces");
   }
   virtual void compute(const sequence &seq){

--- a/src/FVMAdapt/library/color_matrix.cc
+++ b/src/FVMAdapt/library/color_matrix.cc
@@ -60,7 +60,10 @@ namespace Loci{
   namespace pio{ 
     void writeVOGNodeS(hid_t file_id,
                        Loci::storeRepP &pos,
-                       const_store<Loci::FineNodes> &inner_nodes){ //serial io
+                       const_store<Loci::FineNodes> &inner_nodes_cell,
+                       const_store<Loci::FineNodes> &inner_nodes_face,
+                       const_store<Loci::FineNodes> &inner_nodes_edge
+                       ){ //serial io
 
       hid_t group_id = 0 ;
   
@@ -68,8 +71,14 @@ namespace Loci{
         //firsr write out numNodes
         long long num_original_nodes  = pos->domain().size();
         long long num_inner_nodes  = 0;
-        FORALL(inner_nodes.domain(), cc){
-          num_inner_nodes += inner_nodes[cc].size();
+        FORALL(inner_nodes_cell.domain(), cc){
+          num_inner_nodes += inner_nodes_cell[cc].size();
+        }ENDFORALL;
+        FORALL(inner_nodes_face.domain(), cc){
+          num_inner_nodes += inner_nodes_face[cc].size();
+        }ENDFORALL;
+        FORALL(inner_nodes_edge.domain(), cc){
+          num_inner_nodes += inner_nodes_edge[cc].size();
         }ENDFORALL;
       
         long long array_size = num_original_nodes + num_inner_nodes;
@@ -147,18 +156,18 @@ namespace Loci{
 
           long index = 0;
           FORALL(local_edges, cc){
-            for(unsigned int i = 0; i < inner_nodes[cc].size(); i++){
-              v_nodes[index++] = inner_nodes[cc][i];
+            for(unsigned int i = 0; i < inner_nodes_edge[cc].size(); i++){
+              v_nodes[index++] = inner_nodes_edge[cc][i];
             }
           }ENDFORALL;
           FORALL(*geom_cells, cc){
-            for(unsigned int i = 0; i < inner_nodes[cc].size(); i++){
-              v_nodes[index++] = inner_nodes[cc][i];
+            for(unsigned int i = 0; i < inner_nodes_cell[cc].size(); i++){
+              v_nodes[index++] = inner_nodes_cell[cc][i];
             }
           }ENDFORALL; 
           FORALL(*faces, cc){
-            for(unsigned int i = 0; i < inner_nodes[cc].size(); i++){
-              v_nodes[index++] = inner_nodes[cc][i];
+            for(unsigned int i = 0; i < inner_nodes_face[cc].size(); i++){
+              v_nodes[index++] = inner_nodes_face[cc][i];
             }
           }ENDFORALL;
                 
@@ -205,19 +214,19 @@ namespace Loci{
   
       offset = 0;
       store<Loci::FineNodes> edge_inner_nodes;
-      edge_inner_nodes = Loci::Local2FileOrder(inner_nodes.Rep(),local_edges,offset,dist,MPI_COMM_WORLD) ;
+      edge_inner_nodes = Loci::Local2FileOrder(inner_nodes_edge.Rep(),local_edges,offset,dist,MPI_COMM_WORLD) ;
       entitySet file_edges = edge_inner_nodes.domain();
   
       offset= 0;
       // Create container vardist that
       store<Loci::FineNodes> cell_inner_nodes;
-      cell_inner_nodes = Loci::Local2FileOrder(inner_nodes.Rep(),local_cells,offset,dist,MPI_COMM_WORLD) ;
+      cell_inner_nodes = Loci::Local2FileOrder(inner_nodes_cell.Rep(),local_cells,offset,dist,MPI_COMM_WORLD) ;
       entitySet file_cells = cell_inner_nodes.domain();
   
       offset= 0;
       // Create container vardist that
       store<Loci::FineNodes> face_inner_nodes;
-      face_inner_nodes = Loci::Local2FileOrder(inner_nodes.Rep(),local_faces,offset,dist,MPI_COMM_WORLD) ;
+      face_inner_nodes = Loci::Local2FileOrder(inner_nodes_face.Rep(),local_faces,offset,dist,MPI_COMM_WORLD) ;
       entitySet file_faces = face_inner_nodes.domain();
   
   
@@ -536,13 +545,17 @@ namespace Loci{
 
     void writeVOGNodeP(hid_t file_id,
                        Loci::storeRepP &pos,
-                       const_store<Loci::FineNodes> &inner_nodes){ //parallel io
+                       const_store<Loci::FineNodes> &inner_nodes_cell,
+                       const_store<Loci::FineNodes> &inner_nodes_face,
+                       const_store<Loci::FineNodes> &inner_nodes_edge
+                       ){ //parallel io
   
 #ifndef H5_HAVE_PARALLEL
   
       writeVOGNodeS( file_id,
                      pos,
-                     inner_nodes);
+                     inner_nodes_cell,inner_nodes_face,inner_nodes_edge
+                     );
 #else
    
       hid_t group_id = 0 ;  
@@ -574,19 +587,19 @@ namespace Loci{
   
       offset = 0;
       store<Loci::FineNodes> edge_inner_nodes;
-      edge_inner_nodes = Loci::Local2FileOrder(inner_nodes.Rep(),local_edges,offset,dist,MPI_COMM_WORLD) ;
+      edge_inner_nodes = Loci::Local2FileOrder(inner_nodes_edge.Rep(),local_edges,offset,dist,MPI_COMM_WORLD) ;
       entitySet file_edges = edge_inner_nodes.domain();
   
       offset= 0;
       // Create container vardist that
       store<Loci::FineNodes> cell_inner_nodes;
-      cell_inner_nodes = Loci::Local2FileOrder(inner_nodes.Rep(),local_cells,offset,dist,MPI_COMM_WORLD) ;
+      cell_inner_nodes = Loci::Local2FileOrder(inner_nodes_cell.Rep(),local_cells,offset,dist,MPI_COMM_WORLD) ;
       entitySet file_cells = cell_inner_nodes.domain();
   
       offset= 0;
       // Create container vardist that
       store<Loci::FineNodes> face_inner_nodes;
-      face_inner_nodes = Loci::Local2FileOrder(inner_nodes.Rep(),local_faces,offset,dist,MPI_COMM_WORLD) ;
+      face_inner_nodes = Loci::Local2FileOrder(inner_nodes_face.Rep(),local_faces,offset,dist,MPI_COMM_WORLD) ;
       entitySet file_faces = face_inner_nodes.domain();
   
   
@@ -811,9 +824,18 @@ namespace Loci{
   
   void writeVOGNode(hid_t file_id,
                     Loci::storeRepP &pos,
-                    const_store<Loci::FineNodes> &inner_nodes){
-    if(use_parallel_io)pio::writeVOGNodeP( file_id,pos,inner_nodes);
-    else pio::writeVOGNodeS( file_id,pos,inner_nodes);
+                    const_store<Loci::FineNodes> &inner_nodes_cell,
+                    const_store<Loci::FineNodes> &inner_nodes_face,
+                    const_store<Loci::FineNodes> &inner_nodes_edge
+                    ){
+    if(use_parallel_io)pio::writeVOGNodeP( file_id,pos,
+                                           inner_nodes_cell,
+                                           inner_nodes_face,
+                                           inner_nodes_edge);
+    else pio::writeVOGNodeS( file_id,pos,
+                             inner_nodes_cell,
+                             inner_nodes_face,
+                             inner_nodes_edge);
   }
 
   

--- a/src/FVMAdapt/library/hexcell.cc
+++ b/src/FVMAdapt/library/hexcell.cc
@@ -1547,9 +1547,9 @@ bool HexCell::balance_cell(int split_mode,
           bitset<2> faceyz = bitset<2>(face[0]->code) | bitset<2>(face[1]->code);
           bitset<2> facexz = bitset<2>(face[2]->code) | bitset<2>(face[3]->code);
           the_code.reset();
-          the_code[0] = faceyz[0] || facexz[0];//x bit
-          the_code[1] = facexy[0] || faceyz[1];//y bit
-          the_code[2] = facexy[1] || facexz[1];//z bit
+          the_code[0] = faceyz[0] | facexz[0];//x bit
+          the_code[1] = facexy[0] | faceyz[1];//y bit
+          the_code[2] = facexy[1] | facexz[1];//z bit
           
           mySplitCode = char(the_code.to_ulong());
           
@@ -1564,17 +1564,17 @@ bool HexCell::balance_cell(int split_mode,
         bitset<2> facexz = bitset<2>(face[2]->code) | bitset<2>(face[3]->code);
         the_code.reset();
         if(face[0]->child != 0 && face[1]->child != 0){//faceyz
-          the_code[1] = the_code[1] || faceyz[1];
-          the_code[0] = the_code[0] || faceyz[0];
+          the_code[1] = the_code[1] | faceyz[1];
+          the_code[0] = the_code[0] | faceyz[0];
         }
         if (face[2]->child != 0 && face[3]->child != 0){//facexz
-          the_code[2] = the_code[2] || facexz[1];
-          the_code[0] = the_code[0] || facexz[0];
+          the_code[2] = the_code[2] | facexz[1];
+          the_code[0] = the_code[0] | facexz[0];
         }
         if(face[4]->child != 0 && face[5]->child != 0){//facexy
 
-          the_code[2] = the_code[2] || facexy[1];
-          the_code[1] = the_code[1] || facexy[0];
+          the_code[2] = the_code[2] | facexy[1];
+          the_code[1] = the_code[1] | facexy[0];
         }
           
         mySplitCode = char(the_code.to_ulong());  

--- a/src/FVMAdapt/library/write_vog.cc
+++ b/src/FVMAdapt/library/write_vog.cc
@@ -307,7 +307,7 @@ namespace Loci {
       refine_facts.create_fact("cellweight_outDB_par",cellweight_outDB_par);
         
       if(!Loci::makeQuery(refine_rules,refine_facts,
-			  "cellplan_output,cellweight_output,cell2parent_DB,inner_nodes,fine_faces,volTag_blackbox")) {
+			  "cellplan_output,cellweight_output,cell2parent_DB,inner_nodes_cell,inner_nodes_face,inner_nodes_edge,fine_faces_cell,fine_faces,volTag_blackbox")) {
 	std::cerr << "adapt query failed!" << std::endl;
 	Loci::Abort();
       }
@@ -318,13 +318,17 @@ namespace Loci {
     Loci::DataXFER_DB.insertItem("currentPlan",newPlan) ;
     Loci::DataXFER_DB.deleteItem("nextPlan") ;
 	
-    store<Loci::FineNodes> inner_nodes;
-    inner_nodes = refine_facts.get_variable("inner_nodes");
+    store<Loci::FineNodes> inner_nodes_cell;
+    inner_nodes_cell = refine_facts.get_variable("inner_nodes_cell");
+    store<Loci::FineNodes> inner_nodes_face;
+    inner_nodes_face = refine_facts.get_variable("inner_nodes_face");
+    store<Loci::FineNodes> inner_nodes_edge;
+    inner_nodes_edge = refine_facts.get_variable("inner_nodes_edge");
         
        
     int num_nodes;
     createVOGNode(gridDataP->new_pos,
-		  inner_nodes,
+		  inner_nodes_cell,inner_nodes_face,inner_nodes_edge,
 		  num_nodes,
 		  refine_facts,
 		  gridDataP->local_nodes
@@ -332,6 +336,8 @@ namespace Loci {
     if(Loci::MPI_rank ==0)
       cerr<< "num_nodes: " << num_nodes << " in adaptcycle" << endl;
         
+    store<Loci::FineFaces> fine_faces_cell;
+    fine_faces_cell = refine_facts.get_variable("fine_faces_cell");
     store<Loci::FineFaces> fine_faces;
     fine_faces = refine_facts.get_variable("fine_faces");
         
@@ -339,6 +345,7 @@ namespace Loci {
     int num_cells = 0;
       
     createVOGFace( num_nodes,
+		   fine_faces_cell,
 		   fine_faces,
 		   refine_facts,
 		   num_faces,
@@ -438,13 +445,17 @@ namespace Loci {
     refine_facts.create_fact("balanced_planDB_par",balanced_planDB_par) ;
 	      
     if(!Loci::makeQuery(refine_rules,refine_facts,
-			"inner_nodes,fine_faces,volTag_blackbox")) {
+			"inner_nodes_cell,inner_nodes_face,inner_nodes_edge,fine_faces,fine_faces_cell,volTag_blackbox")) {
       std::cerr << "adapt query failed!" << std::endl;
       Loci::Abort();
     }
        
-    store<Loci::FineNodes> inner_nodes;
-    inner_nodes = refine_facts.get_variable("inner_nodes");
+    store<Loci::FineNodes> inner_nodes_cell;
+    inner_nodes_cell = refine_facts.get_variable("inner_nodes_cell");
+    store<Loci::FineNodes> inner_nodes_face;
+    inner_nodes_face = refine_facts.get_variable("inner_nodes_face");
+    store<Loci::FineNodes> inner_nodes_edge;
+    inner_nodes_edge = refine_facts.get_variable("inner_nodes_edge");
 
 	  
     gridDataP = new(refinedGridData) ;
@@ -453,13 +464,15 @@ namespace Loci {
        
     int num_nodes;
     createVOGNode(gridDataP->new_pos,
-		  inner_nodes,
+		  inner_nodes_cell,inner_nodes_face,inner_nodes_edge,
 		  num_nodes,
 		  refine_facts,
 		  gridDataP->local_nodes
 		  );
     if(Loci::MPI_rank ==0)cerr<< "num_nodes: " << num_nodes << " before chem run" <<  endl;
         
+    store<Loci::FineFaces> fine_faces_cell;
+    fine_faces_cell = refine_facts.get_variable("fine_faces_cell");
     store<Loci::FineFaces> fine_faces;
     fine_faces = refine_facts.get_variable("fine_faces");
 	      
@@ -467,6 +480,7 @@ namespace Loci {
     int num_cells = 0;
 	      
     createVOGFace( num_nodes,
+		   fine_faces_cell,
 		   fine_faces,
 		   refine_facts,
 		   num_faces,
@@ -1484,7 +1498,10 @@ namespace Loci {
   //re_number the nodes in pos and inner_nodes,
   //and then redistribute them across the processes
   void createVOGNode(store<vector3d<double> > &new_pos,
-                     const store<Loci::FineNodes> &inner_nodes,
+                     const store<Loci::FineNodes> &inner_nodes_cell,
+                     const store<Loci::FineNodes> &inner_nodes_face,
+                     const store<Loci::FineNodes> &inner_nodes_edge,
+                     
                      int& num_nodes,
                      fact_db & facts,//in global numbering
                      vector<entitySet>& nodes_ptn
@@ -1497,8 +1514,14 @@ namespace Loci {
       //firsr write out numNodes
       long  num_original_nodes  = pos.domain().size();
       long  num_inner_nodes  = 0;
-      FORALL(inner_nodes.domain(), cc){
-        num_inner_nodes += inner_nodes[cc].size();
+      FORALL(inner_nodes_cell.domain(), cc){
+        num_inner_nodes += inner_nodes_cell[cc].size();
+      }ENDFORALL;
+      FORALL(inner_nodes_face.domain(), cc){
+        num_inner_nodes += inner_nodes_face[cc].size();
+      }ENDFORALL;
+      FORALL(inner_nodes_edge.domain(), cc){
+        num_inner_nodes += inner_nodes_edge[cc].size();
       }ENDFORALL;
     
       int node_base = 0;
@@ -1519,18 +1542,18 @@ namespace Loci {
       entitySet local_edges = facts.get_variable("edge2node")->domain();
 
       FORALL(local_edges, cc){
-        for(unsigned int i = 0; i < inner_nodes[cc].size(); i++, nei++){
-          new_pos[*nei] = inner_nodes[cc][i];
+        for(unsigned int i = 0; i < inner_nodes_edge[cc].size(); i++, nei++){
+          new_pos[*nei] = inner_nodes_edge[cc][i];
         }
       }ENDFORALL;
       FORALL(*geom_cells, cc){
-        for(unsigned int i = 0; i < inner_nodes[cc].size(); i++, nei++){
-          new_pos[*nei] = inner_nodes[cc][i];
+        for(unsigned int i = 0; i < inner_nodes_cell[cc].size(); i++, nei++){
+          new_pos[*nei] = inner_nodes_cell[cc][i];
         }
       }ENDFORALL; 
       FORALL(*faces, cc){
-        for(unsigned int i = 0; i < inner_nodes[cc].size(); i++, nei++){
-          new_pos[*nei] = inner_nodes[cc][i];
+        for(unsigned int i = 0; i < inner_nodes_face[cc].size(); i++, nei++){
+          new_pos[*nei] = inner_nodes_face[cc][i];
         }
       }ENDFORALL;
       num_nodes = new_domain.size();
@@ -1572,19 +1595,19 @@ namespace Loci {
     
       eoffset = 0;
       store<Loci::FineNodes> edge_inner_nodes;
-      edge_inner_nodes = Loci::Global2FileOrder(inner_nodes.Rep(),local_edges,eoffset,dist,MPI_COMM_WORLD) ;
+      edge_inner_nodes = Loci::Global2FileOrder(inner_nodes_edge.Rep(),local_edges,eoffset,dist,MPI_COMM_WORLD) ;
       entitySet file_edges = edge_inner_nodes.domain();
       
       coffset= 0;
       // Create container 
       store<Loci::FineNodes> cell_inner_nodes;
-      cell_inner_nodes = Loci::Global2FileOrder(inner_nodes.Rep(),local_cells,coffset,dist,MPI_COMM_WORLD) ;
+      cell_inner_nodes = Loci::Global2FileOrder(inner_nodes_cell.Rep(),local_cells,coffset,dist,MPI_COMM_WORLD) ;
       entitySet file_cells = cell_inner_nodes.domain();
   
       foffset= 0;
       // Create container
       store<Loci::FineNodes> face_inner_nodes;
-      face_inner_nodes = Loci::Global2FileOrder(inner_nodes.Rep(),local_faces,foffset,dist,MPI_COMM_WORLD) ;
+      face_inner_nodes = Loci::Global2FileOrder(inner_nodes_face.Rep(),local_faces,foffset,dist,MPI_COMM_WORLD) ;
       entitySet file_faces = face_inner_nodes.domain();
       
       //Now allocate temp entitySet in file numbering
@@ -1793,6 +1816,7 @@ namespace Loci {
   //re_number the nodes in pos and inner_nodes,
   //and then redistribute them across the processes
   void createVOGFace(int numNodes,
+                     const store<Loci::FineFaces> &fine_faces_cell,
                      const store<Loci::FineFaces> &fine_faces,
                      fact_db & facts,
                      int& numFaces,
@@ -1809,8 +1833,11 @@ namespace Loci {
     my_faces = facts.get_variable("faces");
     my_geom_cells = facts.get_variable("geom_cells");
     entitySet dom = fine_faces.domain() & (*my_faces+*my_geom_cells);
-  
+    entitySet domc = fine_faces_cell.domain() ;
     int local_num_face = 0;
+    for(entitySet::const_iterator ei = domc.begin(); ei != domc.end(); ei++){
+      local_num_face += fine_faces_cell[*ei].size();
+    }
     for(entitySet::const_iterator ei = dom.begin(); ei != dom.end(); ei++){
       local_num_face += fine_faces[*ei].size();
     }
@@ -1834,6 +1861,19 @@ namespace Loci {
     int cell_max = std::numeric_limits<int>::min();
     int cell_min = std::numeric_limits<int>::max();
     entitySet::const_iterator fid = faces.begin();
+    for(entitySet::const_iterator ei = domc.begin(); ei != domc.end(); ei++){
+      for(unsigned int i = 0; i < fine_faces_cell[*ei].size(); i++){
+        cl[*fid] = fine_faces_cell[*ei][i][0] + cell_base -1;// -1 finefaces cell index start at 1
+        if(fine_faces_cell[*ei][i][1]>=0) cr[*fid] = fine_faces_cell[*ei][i][1] + cell_base -1;
+        else  cr[*fid] = fine_faces_cell[*ei][i][1];
+        cell_max = max(cell_max,cl[*fid]);
+        cell_max = max(cell_max,cr[*fid]);
+        cell_min = min(cell_min,cl[*fid]);
+        if (cr[*fid]>=0) cell_min = min(cell_min,cr[*fid]);
+        count[*fid] = fine_faces_cell[*ei][i].size()-2;
+        fid++;
+      }
+    }
     for(entitySet::const_iterator ei = dom.begin(); ei != dom.end(); ei++){
       for(unsigned int i = 0; i < fine_faces[*ei].size(); i++){
         cl[*fid] = fine_faces[*ei][i][0] + cell_base -1;// -1 finefaces cell index start at 1
@@ -1881,6 +1921,17 @@ namespace Loci {
     //fill up face2node  
     face2node.allocate(count);
     fid = faces.begin();
+    for(entitySet::const_iterator ei = domc.begin(); ei != domc.end(); ei++){
+      for(unsigned int i = 0; i < fine_faces_cell[*ei].size(); i++){
+        for(int j = 0; j < count[*fid]; j++){
+          //vog file node index start with 0
+          // face2node[*fid][j] = fine_faces_cell[*ei][i][j+2]-1;
+          // if(fine_faces_cell[*ei][i][j+2] < 0) cerr <<"WARNING: negative node index" << endl;
+          face2node[*fid][j] = fine_faces_cell[*ei][i][j+2];
+        }
+        fid++;
+      }
+    }
     for(entitySet::const_iterator ei = dom.begin(); ei != dom.end(); ei++){
       for(unsigned int i = 0; i < fine_faces[*ei].size(); i++){
         for(int j = 0; j < count[*fid]; j++){
@@ -1920,10 +1971,6 @@ namespace Loci{
   void writeVOGSurf(hid_t file_id, std::vector<pair<int,string> > surface_ids);
   void writeVOGTag(hid_t output_fid,  vector<pair<string,entitySet> >& volTags);
   void writeVOGClose(hid_t file_id) ;
-  void writeVOGNode(hid_t file_id,
-                    Loci::storeRepP &pos,
-                    const_store<Loci::FineNodes> &inner_nodes);
-
 
 }
 

--- a/src/FVMAdapt/write_vog_module.loci
+++ b/src/FVMAdapt/write_vog_module.loci
@@ -52,12 +52,14 @@ vector<pair<string,entitySet> >  getVOGTagFromLocal(const vector<pair<string,ent
                                                     int num_original_faces);
 
 
-class node_output_file : public pointwise_rule {
+class node_output_file : public blackbox_rule {
 
-  store<bool> node_output ;
+  param<bool> node_output ;
   const_param<string> outfile_par ;
   const_param<string> meshfile_par ;
-  const_store<Loci::FineNodes> inner_nodes;
+  const_store<Loci::FineNodes> inner_nodes_cell;
+  const_store<Loci::FineNodes> inner_nodes_face;
+  const_store<Loci::FineNodes> inner_nodes_edge;
   
   
   
@@ -67,13 +69,15 @@ public:
     name_store("outfile_par", outfile_par);
     name_store("meshfile_par", meshfile_par);
      
-    name_store("inner_nodes", inner_nodes);
-    
- 
+    name_store("inner_nodes_cell", inner_nodes_cell);
+    name_store("inner_nodes_face", inner_nodes_face);
+    name_store("inner_nodes_edge", inner_nodes_edge);
     
     input("outfile_par");
     input("meshfile_par");
-    input("inner_nodes");
+    input("inner_nodes_cell");
+    input("inner_nodes_face");
+    input("inner_nodes_edge");
  
     
     output("node_output");
@@ -86,7 +90,10 @@ public:
     Loci::readBCfromVOG(*meshfile_par, boundary_ids);
     Loci::writeVOGSurf(file_id,boundary_ids);
     Loci::storeRepP pos = Loci::exec_current_fact_db->get_variable("pos");
-    writeVOGNode(file_id, pos, inner_nodes);
+    writeVOGNode(file_id, pos,
+                 inner_nodes_cell,
+                 inner_nodes_face,
+                 inner_nodes_edge);
     Loci::writeVOGClose(file_id) ;
   }
 };
@@ -98,10 +105,11 @@ register_rule<node_output_file> register_node_output_file;
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
-class face_output_file : public pointwise_rule {
+class face_output_file : public blackbox_rule {
  
-  store<bool> face_output ;
+  param<bool> face_output ;
   const_param<string> outfile_par ;
+  const_store<Loci::FineFaces> fine_faces_cell;
   const_store<Loci::FineFaces> fine_faces;
 
   
@@ -109,10 +117,12 @@ public:
   face_output_file(){
     name_store("face_output", face_output);
     name_store("outfile_par", outfile_par);
+    name_store("fine_faces_cell", fine_faces_cell);
     name_store("fine_faces", fine_faces);
     
     
     input("outfile_par");
+    input("fine_faces_cell");
     input("fine_faces");
     
     output("face_output");
@@ -151,11 +161,25 @@ public:
     //problem here; MPI has no long long 
     if(MPI_processes > 1 && !Loci::use_parallel_io) MPI_Bcast(&numNodes, 1, MPI_LONG_LONG_INT, 0, MPI_COMM_WORLD);
      
+    // get 
     //compute numFaces
     int local_num_face = 0;
-    for(sequence::const_iterator ei = seq.begin(); ei != seq.end(); ei++){
+
+    fact_db::distribute_infoP dist =
+      Loci::exec_current_fact_db->get_distribute_info() ;
+    entitySet my_entities = (dist->my_entities) ;
+    entitySet domc = my_entities & fine_faces_cell.domain() ;
+    entitySet dom = my_entities & fine_faces.domain() ;
+
+    for(auto ei = domc.begin(); ei != domc.end(); ei++){
+      local_num_face += fine_faces_cell[*ei].size();
+    }
+    for(auto ei = dom.begin(); ei != dom.end(); ei++){
       local_num_face += fine_faces[*ei].size();
     }
+    //    for(sequence::const_iterator ei = seq.begin(); ei != seq.end(); ei++){
+    //      local_num_face += fine_faces[*ei].size();
+    //    }
 
     std::vector<int> face_sizes= Loci::all_collect_sizes(local_num_face);
 
@@ -177,7 +201,16 @@ public:
     count.allocate(faces);
      
     entitySet::const_iterator fid = faces.begin();
-    for(sequence::const_iterator ei = seq.begin(); ei != seq.end(); ei++){
+    for(auto ei = domc.begin(); ei != domc.end(); ei++){
+      for(unsigned int i = 0; i < fine_faces_cell[*ei].size(); i++){
+        cl[*fid] = fine_faces_cell[*ei][i][0] + cell_min;
+        if(fine_faces_cell[*ei][i][1]>=0) cr[*fid] = fine_faces_cell[*ei][i][1] + cell_min;
+        else  cr[*fid] = fine_faces_cell[*ei][i][1];
+        count[*fid] = fine_faces_cell[*ei][i].size()-2;
+        fid++;
+      }
+    }
+    for(auto ei = dom.begin(); ei != dom.end(); ei++){
       for(unsigned int i = 0; i < fine_faces[*ei].size(); i++){
         cl[*fid] = fine_faces[*ei][i][0] + cell_min;
         if(fine_faces[*ei][i][1]>=0) cr[*fid] = fine_faces[*ei][i][1] + cell_min;
@@ -190,7 +223,18 @@ public:
     face2node.allocate(count);
 
     fid = faces.begin();
-    for(sequence::const_iterator ei = seq.begin(); ei != seq.end(); ei++){
+    for(auto ei = domc.begin(); ei != domc.end(); ei++){
+      for(unsigned int i = 0; i < fine_faces_cell[*ei].size(); i++){
+        for(int j = 0; j < count[*fid]; j++){
+          //vog file node index start with 0
+          // face2node[*fid][j] = fine_faces_cell[*ei][i][j+2]-1;
+          // if(fine_faces_cell[*ei][i][j+2] < 0) cerr <<"WARNING: negative node index" << endl;
+          face2node[*fid][j] = fine_faces_cell[*ei][i][j+2]; 
+        }
+        fid++;
+      }
+    }
+    for(auto ei = dom.begin(); ei != dom.end(); ei++){
       for(unsigned int i = 0; i < fine_faces[*ei].size(); i++){
         for(int j = 0; j < count[*fid]; j++){
           //vog file node index start with 0

--- a/src/include/FVMAdapt/defines.h
+++ b/src/include/FVMAdapt/defines.h
@@ -422,7 +422,10 @@ namespace Loci {
 
   extern void writeVOGNode(hid_t file_id,
                            Loci::storeRepP &pos,
-                           const_store<Loci::FineNodes> &inner_nodes);
+                           const_store<Loci::FineNodes> &inner_nodes_cell,
+                           const_store<Loci::FineNodes> &inner_nodes_face,
+                           const_store<Loci::FineNodes> &inner_nodes_edge
+                           );
   extern void writeVOGFace(hid_t file_id, Map &cl, Map &cr, multiMap &face2node) ;
   extern  unsigned long readAttributeLong(hid_t group, const char *name);
   

--- a/src/include/FVMAdapt/gridInterface.h
+++ b/src/include/FVMAdapt/gridInterface.h
@@ -6,12 +6,15 @@ namespace Loci {
   void parallelClassifyCell(fact_db &facts) ;
 
   void createVOGNode(store<vector3d<double> > &new_pos,
-                     const store<Loci::FineNodes> &inner_nodes,
+                     const store<Loci::FineNodes> &inner_nodes_cell,
+                     const store<Loci::FineNodes> &inner_nodes_face,
+                     const store<Loci::FineNodes> &inner_nodes_edge,
                      int& num_nodes,
                      fact_db & facts,//in global numbering
                      vector<entitySet>& nodes_ptn) ;
 
   void createVOGFace(int numNodes,
+                     const store<Loci::FineFaces> &fine_faces_cell,
                      const store<Loci::FineFaces> &fine_faces,
                      fact_db & facts,
                      int& numFaces,


### PR DESCRIPTION
This fixes an issue with FVMAdapt memory scalability caused by requested variables being in cell, faces, and edge global numbering creating grid sized gaps in store allocations. Since these datastructures used std::vector with constructor calls, the transformation of the data to global ordering caused large memory allocations.  The fix is to segregate these data structures into cell, face, and edge parts, each with compact allocations in global numbering.