### PR TITLE
bug fix for vect3d nodal barth limiter

### DIFF
--- a/quickTest/FVMModUnitTests/functions.loci
+++ b/quickTest/FVMModUnitTests/functions.loci
@@ -106,12 +106,25 @@ namespace flowPsi {
   $rule pointwise(scalarVal<-cellcenter,baseGradS) {
     $scalarVal = dot($cellcenter,$baseGradS) ;
   }
+  /// Scalar field that will have grad()= 0
+  $type scalarConst store<real> ;
+  /// Compute function by inner product with target gradient
+  $rule pointwise(scalarConst<-cellcenter,baseGradS) {
+    $scalarConst = norm($baseGradS) ;
+  }
 
   /// Scalar field for boundary faces that have grad() = baseGradS
   $type scalarVal_f store<real> ;
   /// Compute function by inner product with target gradient
   $rule pointwise(scalarVal_f<-facecenter,baseGradS) {
     $scalarVal_f = dot($facecenter,$baseGradS) ;
+  }
+
+  /// Scalar field for boundary faces that have grad() = 0
+  $type scalarConst_f store<real> ;
+  /// Compute function by inner product with target gradient
+  $rule pointwise(scalarConst_f<-facecenter,baseGradS) {
+    $scalarConst_f = norm($baseGradS) ;
   }
 
   /// Vector field that has grad()=baseGradV3d
@@ -123,6 +136,12 @@ namespace flowPsi {
     $v3dVal.z = dot($cellcenter,$baseGradV3d.z) ;
   }
 
+    /// Vector field that has grad()=0
+  $type v3dConst store<vect3d> ;
+  $rule pointwise(v3dConst<-cellcenter,baseGradV3d) {
+    $v3dConst = $baseGradV3d.x ;
+  }
+
   /// Vector field at boundary that has grad()=baseGradV3d
   $type v3dVal_f store<vect3d> ;
   /// Compute vector field using linear dot product
@@ -130,6 +149,12 @@ namespace flowPsi {
     $v3dVal_f.x = dot($facecenter,$baseGradV3d.x) ;
     $v3dVal_f.y = dot($facecenter,$baseGradV3d.y) ;
     $v3dVal_f.z = dot($facecenter,$baseGradV3d.z) ;
+  }
+
+  /// Vector field at boundary that has grad()=0
+  $type v3dConst_f store<vect3d> ;
+  $rule pointwise(v3dConst_f<-facecenter,baseGradV3d) {
+    $v3dConst_f = $baseGradV3d.x ;
   }
 
   /// general vector field that has grad()=baseGradv

--- a/quickTest/FVMModUnitTests/tests/limitersNodalBarthStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limitersNodalBarthStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testScalarUnity,limiters,scalarConst)"
+grid:"test.vog"
+message:"Scalar Nodal Barth Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: NB
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limiterv3dNodalBarthStandard.vars
+++ b/quickTest/FVMModUnitTests/tests/limiterv3dNodalBarthStandard.vars
@@ -1,0 +1,9 @@
+query:"checkFunction(testv3dUnity,limiterv3d,v3dConst)"
+grid:"test.vog"
+message:"vect3d Nodal Barth Limiter with 'gradStencil: standard'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: NB
+gradStencil: standard
+centroid: wireframe
+}

--- a/quickTest/FVMModUnitTests/tests/limiterv3dNodalBarthStandard_minv3dLimit.vars
+++ b/quickTest/FVMModUnitTests/tests/limiterv3dNodalBarthStandard_minv3dLimit.vars
@@ -1,0 +1,10 @@
+query:"checkFunction(testv3dUnity,limiterv3d,v3dConst)"
+grid:"test.vog"
+message:"vect3d Nodal Barth Limiter with 'gradStencil: standard, minv3dLimiter'"
+{
+boundary_conditions: <BC_1=bc,BC_2=bc,BC_3=bc,BC_4=bc,BC_5=bc,BC_6=bc,BC=bc>
+limiter: NB
+gradStencil: standard
+centroid: wireframe
+v3dminLimiter: 1
+}

--- a/src/FVMMod/limiters/nodal_barth.loci
+++ b/src/FVMMod/limiters/nodal_barth.loci
@@ -238,7 +238,7 @@ namespace Loci {
                                 upper->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 lower->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 boundary_map->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V))),
-        constraint(geom_cells,NB_limiter) {
+  constraint(geom_cells,NB_limiter,standardv3dLimit) {
     const vect3d Xcc = $V ;
     const tens3d Xgr = $gradv3d(V) ;
     const vect3d cent = $cellcenter ;
@@ -307,7 +307,7 @@ namespace Loci {
                                 upper->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 lower->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 boundary_map->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V))),
-        constraint(geom_cells,NB_limiter) 
+  constraint(geom_cells,NB_limiter,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     const tens3d Xgr = $gradv3d(V) ;


### PR DESCRIPTION
Recent changes to limiter for vect3d where the smallest limiter value is used for all components of the velocity vector caused scheduling errors caused by improper implementation of constraints.   This fix adds the constraints to avoid scheduling conflict errors and also adds unit tests for the nodal barth limiter using a constant function instead of a linearly varying function.    Regression tests also need to be developed, but this gives at least some minimal testing for limiters that are not identically unity on linear functions.  Probably these should be extended to V2 limiters as well, but this fix is focused on the  nodal barth limiter.