### PR TITLE
Update to prevent crash when rule compiler is not found

### DIFF
--- a/src/System/visit_assemble.cc
+++ b/src/System/visit_assemble.cc
@@ -636,7 +636,7 @@ namespace Loci {
           rmi = rcm.find(*ri) ;
           // Warning means rule compiler could not be found
           WARN(rmi == rcm.end()) ;
-          if(rmi != rcm.end()) // If rule compiler found, and it to compilers
+          if(rmi != rcm.end()) // If rule compiler found, add it to compilers
             dag_comp.push_back(rmi->second) ;
         }
 

--- a/src/System/visit_assemble.cc
+++ b/src/System/visit_assemble.cc
@@ -634,11 +634,10 @@ namespace Loci {
         for(ri=rules.begin();ri!=rules.end();++ri) {
           rulecomp_map::const_iterator rmi ;
           rmi = rcm.find(*ri) ;
-          if(rmi == rcm.end()) {
-            cerr << "could not find rule compiler for " <<*ri << endl ;
-          }
-          FATAL(rmi == rcm.end()) ;
-          dag_comp.push_back(rmi->second) ;
+          // Warning means rule compiler could not be found
+          WARN(rmi == rcm.end()) ;
+          if(rmi != rcm.end()) // If rule compiler found, and it to compilers
+            dag_comp.push_back(rmi->second) ;
         }
 
 #ifdef DYNAMICSCHEDULING


### PR DESCRIPTION
When the rule compiler was not found, the code accessed the uninitialized data anyway.  It turns out that when memory release is delayed into the advance phase of the loop, it could trigger this, but in this case, ignoring the rule compiler was a satisfactory solution.  The code is modified so that it will still generate a warning when this occurs when compiled with debug mode enabled.
