### PR TITLE
Changed depreciated warning to only print when running in debug mode

### DIFF
--- a/src/System/distribute.cc
+++ b/src/System/distribute.cc
@@ -826,9 +826,12 @@ namespace Loci {
   // Collect entitities to a unified entitySet that is distributed across
   // processors according to the partition ptn.
   entitySet dist_collect_entitySet(entitySet inSet, const vector<entitySet> &ptn) {
-    cerr << "dist_collect_entitySet is depreciated" << endl ;
     const int p = MPI_processes ;
     const int r = MPI_rank ;
+#ifdef DEBUG
+    if(r == 0) 
+      cerr << "dist_collect_entitySet is depreciated" << endl ;
+#endif
     entitySet retval = inSet & ptn[r] ;
     // Check for empty and universal set
     int sbits = ((inSet != EMPTY)?1:0)| ((retval != ptn[r])?2:0) ;


### PR DESCRIPTION
This is a simple modification of the depreciated message that limits its output to only the DEBUG mode.  Also only prints out from rank 0 so we don't see a message from every processor.