### PR TITLE
Fix error in data accessor in block_hash copy code

### DIFF
--- a/src/include/Tools/block_hash.h
+++ b/src/include/Tools/block_hash.h
@@ -133,11 +133,11 @@ namespace Loci {
     cached_erase_set = cp.cached_erase_set ;
     erase_threshold = cp.erase_threshold ;
     for(int i=0;i<4096;++i) {
-      if(cp->data[i] != 0) {
+      if(cp.data[i] != 0) {
         data[i] = new block_info *[2048] ;
         for(int j=0;j<2048;++j) {
-          if(cp->data[i][j] != 0)
-            data[i][j] = new block_info(cp->data[i][j]) ;
+          if(cp.data[i][j] != 0)
+            data[i][j] = new block_info(cp.data[i][j]) ;
         }
       }
     }


### PR DESCRIPTION
This error has been in the code for a while, but became evident after compiling on my Mac after a recent OS upgrade.  The fix should not have any effect on existing code as the copy constructor is not typically used in the implementation of DStore and DMap and it is unlikely that any external application would have directly used the block_hash type.

