### PR TITLE
Fix for DEBUG diagnostics of parSampleSort

### DIFF
--- a/src/include/parSampleSort.h
+++ b/src/include/parSampleSort.h
@@ -102,7 +102,7 @@ namespace Loci {
         long long li = std::max(i1,sdist[i]) ;
         long long ri = std::min(i2,sdist[i+1]) ;
         int len = ri-li ;
-        //        FATAL(len <= 0) ;
+        FATAL(len < 0) ;
         int s2 = li-rdist[r] ;
         FATAL(s2 < 0) ;
         if(i == r) { // local copy
@@ -114,8 +114,9 @@ namespace Loci {
             recv[s2+j] = list[s1+j] ;
         } else {
           WARN(s2+len>bsizes[r]) ;
-          MPI_Irecv(&recv[s2],len,bytearray,i,55,comm,
-                    &requests[req++]) ;
+          if(len > 0)
+            MPI_Irecv(&recv[s2],len,bytearray,i,55,comm,
+                      &requests[req++]) ;
 #ifdef DEBUG
           debugout << "balanceDistribution: recving " << len << " items from " << i << endl ;
 #endif
@@ -133,9 +134,10 @@ namespace Loci {
         int len = ri-li ;
         int s1 = li-sdist[r] ;
         FATAL(s1 < 0) ;
-        FATAL(len <= 0) ;
+        FATAL(len < 0) ;
         FATAL(size_t(s1+len) > list.size()) ;
-        MPI_Send(&list[s1],len,bytearray,i,55,comm) ;
+        if(len > 0) 
+          MPI_Send(&list[s1],len,bytearray,i,55,comm) ;
 #ifdef DEBUG
         debugout << "balanceDistribution: sending " << len << " items to " << i << endl ;
 #endif


### PR DESCRIPTION
This fixes issue where there were 0 sized messages in the balance distribution step used as part of the parSampleSort infrastructure.  The diagnostic was FATAL(len<=0) ; but this diagnostic was causing aborts on zero data transfer computations that were not actually an error.  In addition to modifying the FATAL checks, I also added a check to not perform zero sized MPI communication (although technically this is OK, just a  waste of resources).  The code has been tested on a number of applications that use the parSampleSort infrastructure including overset meshes and the space filling curve partitioner.