### PR TITLE
Fixed lpp warning message

### DIFF
--- a/src/FVMMod/limiters/nodal_barth.loci
+++ b/src/FVMMod/limiters/nodal_barth.loci
@@ -143,8 +143,6 @@ namespace Loci {
 
   $type M storeVec<real_t> ;
   $type M_f storeVec<real_t> ;
-  $type vecSize(M) param<int> ;
-
 
   $rule unit(NGTNodalvMax(M)<-vecSize(M)), constraint(pos), prelude {
     $NGTNodalvMax(M).setVecSize(*$vecSize(M)) ;
@@ -191,7 +189,6 @@ namespace Loci {
   }
 
 
-  $type S store<real> ;
   $rule pointwise(limiters(S)<-cellcenter,S,grads(S),firstOrderCells,
 		  upper->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S)),
 		  lower->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S)),
@@ -233,7 +230,6 @@ namespace Loci {
     $limiters(S) = realToDouble(limi) ;
   }
 
-  $type V store<vect3d> ;
   $rule pointwise(limiterv3d(V)<-cellcenter,V,gradv3d(V),firstOrderCells,
                                 upper->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 lower->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
@@ -371,8 +367,6 @@ namespace Loci {
     $limiterv3d(V) = vect3d(limm,limm,limm) ;
   }
 
-  $type M storeVec<real> ;
-  $type M_f storeVec<real> ;
   $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                               upper->cr->M,upper->facecenter,
                               lower->cl->M,lower->facecenter,

--- a/src/FVMMod/node_values.loci
+++ b/src/FVMMod/node_values.loci
@@ -38,16 +38,14 @@ namespace Loci {
     $sim_nodes = true ;
   }
 
-  $type vecSize(X) param<int> ;
-  $type X storeVec<real_t> ;
+  $type M storeVec<real_t> ;
 
-  $rule unit(vecSize(X)), constraint(UNIVERSE) {
-    $vecSize(X) = 0 ;
+  $rule unit(vecSize(M)), constraint(UNIVERSE) {
+    $vecSize(M) = 0 ;
   }
 
-
-  $rule apply(vecSize(X)<-X)[Loci::Maximum], prelude {
-    join(*$vecSize(X),$X.vecSize()) ;
+  $rule apply(vecSize(M)<-M)[Loci::Maximum], prelude {
+    join(*$vecSize(M),$M.vecSize()) ;
   } ;
 
   $type nodalw_sum store<float> ;
@@ -89,15 +87,15 @@ namespace Loci {
   }
 
 
-  $type nodal_sum(X) storeVec<float> ;
-  $rule unit(nodal_sum(X)<-vecSize(X)),constraint(pos),prelude {
-    $nodal_sum(X).setVecSize(*$vecSize(X)) ;
+  $type nodal_sum(M) storeVec<float> ;
+  $rule unit(nodal_sum(M)<-vecSize(M)),constraint(pos),prelude {
+    $nodal_sum(M).setVecSize(*$vecSize(M)) ;
   } compute {
-    $nodal_sum(X) = mk_Scalar(0.0) ;
+    $nodal_sum(M) = mk_Scalar(0.0) ;
   }
 
-  $rule apply((upper,lower,boundary_map)->face2node->nodal_sum(X)<-
-	      (upper,lower,boundary_map)->face2node->pos,cellcenter,X)
+  $rule apply((upper,lower,boundary_map)->face2node->nodal_sum(M)<-
+	      (upper,lower,boundary_map)->face2node->pos,cellcenter,M)
   [Loci::Summation],constraint(geom_cells) {
     int sztot = 0 ;
     
@@ -123,25 +121,25 @@ namespace Loci {
     sort(node_list.begin(),node_list.end()) ;
     vector<Entity>::iterator ne = unique(node_list.begin(),node_list.end()) ;
     vector<Entity>::iterator ns = node_list.begin() ;
-    const int vs = $*X.vecSize() ;
+    const int vs = $*M.vecSize() ;
     for(vector<int>::iterator vi = ns;vi!=ne;++vi) {
       int nd = *vi ;
       const real weight = 1./norm($*pos[nd]-$cellcenter) ;
       for(int i=0;i<vs;++i)
-        $*nodal_sum(X)[nd][i] += realToFloat(weight*$X[i]) ;
+        $*nodal_sum(M)[nd][i] += realToFloat(weight*$M[i]) ;
     }
   }
     
 
-  $type cell2node_v(X) storeVec<float> ;
+  $type cell2node_v(M) storeVec<float> ;
 
-  $rule pointwise(cell2node_v(X)<-nodal_sum(X),nodalw_sum),constraint(pos),
+  $rule pointwise(cell2node_v(M)<-nodal_sum(M),nodalw_sum),constraint(pos),
     prelude {
-    $cell2node_v(X).setVecSize($nodal_sum(X).vecSize()) ;
+    $cell2node_v(M).setVecSize($nodal_sum(M).vecSize()) ;
   } compute {
     double rsum = 1./(double($nodalw_sum)+1e-20) ;
-    for(int i=0;i<$*nodal_sum(X).vecSize();++i) {
-      $cell2node_v(X)[i] = $nodal_sum(X)[i]*rsum ;
+    for(int i=0;i<$*nodal_sum(M).vecSize();++i) {
+      $cell2node_v(M)[i] = $nodal_sum(M)[i]*rsum ;
     }
   }
 
@@ -164,31 +162,31 @@ namespace Loci {
     }
   }
 
-  $type boundary_nodal_sum(X) storeVec<float> ;
+  $type boundary_nodal_sum(M) storeVec<float> ;
   
-  $rule unit(boundary_nodal_sum(X)<-vecSize(X)), prelude {
-    $boundary_nodal_sum(X).setVecSize(*$vecSize(X)) ;
+  $rule unit(boundary_nodal_sum(M)<-vecSize(M)), prelude {
+    $boundary_nodal_sum(M).setVecSize(*$vecSize(M)) ;
   } compute {
-    $boundary_nodal_sum(X) = mk_Scalar(0.0) ;
+    $boundary_nodal_sum(M) = mk_Scalar(0.0) ;
   }
 
-  $type X_f storeVec<real> ;
+  $type M_f storeVec<real> ;
   
-  $rule apply(face2node->boundary_nodal_sum(X)<-face2node->(pos,boundary_nodal_sum(X)),X_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
+  $rule apply(face2node->boundary_nodal_sum(M)<-face2node->(pos,boundary_nodal_sum(M)),M_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
     int fsz = $face2node.size() ;
     for(int i=0;i<fsz;++i) {
       const real weight = 1./norm($face2node[i]->$pos-$facecenter) ;
-      for(int j=0;j<$*boundary_nodal_sum(X).vecSize();++j)
-	$face2node[i]->$boundary_nodal_sum(X)[j] += realToFloat($X_f[j]*weight) ;
+      for(int j=0;j<$*boundary_nodal_sum(M).vecSize();++j)
+	$face2node[i]->$boundary_nodal_sum(M)[j] += realToFloat($M_f[j]*weight) ;
     }
   }
 
-  $rule pointwise(boundary::cell2node_v(X)<-boundary_nodalw_sum,boundary_nodal_sum(X)),constraint(boundary_node), prelude {
-    $cell2node_v(X).setVecSize($boundary_nodal_sum(X).vecSize()) ;
+  $rule pointwise(boundary::cell2node_v(M)<-boundary_nodalw_sum,boundary_nodal_sum(M)),constraint(boundary_node), prelude {
+    $cell2node_v(M).setVecSize($boundary_nodal_sum(M).vecSize()) ;
   } compute {
       double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
-      for(int i=0;i<$*boundary_nodal_sum(X).vecSize();++i) {
-        $cell2node_v(X)[i] = $boundary_nodal_sum(X)[i]*rsum ;
+      for(int i=0;i<$*boundary_nodal_sum(M).vecSize();++i) {
+        $cell2node_v(M)[i] = $boundary_nodal_sum(M)[i]*rsum ;
       }
   }
 
@@ -196,7 +194,6 @@ namespace Loci {
 
   $rule unit(c2n_scalar_sum(X) ), constraint(pos)  { $c2n_scalar_sum(X) = 0 ; }
 
-  $untype X ;
   $type X store<real> ;
 
   $rule apply((upper,lower,boundary_map)->face2node->c2n_scalar_sum(X) <-
@@ -245,7 +242,6 @@ namespace Loci {
     $boundary_scalar_sum(X) = 0 ;
   }
 
-  $untype X_f ;
   $type X_f store<real_t> ;
   $rule apply(face2node->boundary_scalar_sum(X)<-
 	      face2node->pos,X_f,facecenter)[Loci::Summation],
@@ -268,11 +264,10 @@ namespace Loci {
     $c2n_v3d_sum(X) = vector3d<float>(0.,0.,0.) ;
   }
 
-  $untype X ;
-  $type X store<vect3d> ;
+  $type V store<vect3d> ;
   
-  $rule apply((upper,lower,boundary_map)->face2node->c2n_v3d_sum(X)<-
-	      X,cellcenter,(upper,lower,boundary_map)->face2node->pos)[Loci::Summation],
+  $rule apply((upper,lower,boundary_map)->face2node->c2n_v3d_sum(V)<-
+	      V,cellcenter,(upper,lower,boundary_map)->face2node->pos)[Loci::Summation],
     constraint(geom_cells) {
     int sztot = 0 ;
     
@@ -302,49 +297,48 @@ namespace Loci {
     for(vector<int>::iterator vi = ns;vi!=ne;++vi) {
       int nd = *vi ;
       const real weight = 1./norm($*pos[nd]-$cellcenter) ;
-      vector3d<float> v(realToFloat($X.x*weight),
-			realToFloat($X.y*weight),
-			realToFloat($X.z*weight)) ;
-      join($*c2n_v3d_sum(X)[nd],v) ;
+      vector3d<float> v(realToFloat($V.x*weight),
+			realToFloat($V.y*weight),
+			realToFloat($V.z*weight)) ;
+      join($*c2n_v3d_sum(V)[nd],v) ;
     }
   }
 
-  $type cell2node_v3d(X) store<vector3d<float> > ;
-  $rule pointwise(cell2node_v3d(X)<-c2n_v3d_sum(X),nodalw_sum) {
+  $type cell2node_v3d(V) store<vector3d<float> > ;
+  $rule pointwise(cell2node_v3d(V)<-c2n_v3d_sum(V),nodalw_sum) {
     double rsum = 1./(double($nodalw_sum)+1e-20) ;
-    $cell2node_v3d(X) = $c2n_v3d_sum(X)*rsum ;
+    $cell2node_v3d(V) = $c2n_v3d_sum(V)*rsum ;
   }
-  $type boundary_v3d_sum(X) store<vector3d<float> > ;
+  $type boundary_v3d_sum(V) store<vector3d<float> > ;
   
-  $rule unit(boundary_v3d_sum(X)),constraint(pos) {
-    $boundary_v3d_sum(X) = vector3d<float>(0.0,0.0,0.0) ;
+  $rule unit(boundary_v3d_sum(V)),constraint(pos) {
+    $boundary_v3d_sum(V) = vector3d<float>(0.0,0.0,0.0) ;
   }
 
-  $untype X_f ;
-  $type X_f store<vect3d> ;
+  $type V_f store<vect3d> ;
   
-  $rule apply(face2node->boundary_v3d_sum(X)<-face2node->pos,X_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
+  $rule apply(face2node->boundary_v3d_sum(V)<-face2node->pos,V_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
     int fsz = $face2node.size();
     for(int i=0;i<fsz;++i) {
       const real weight = 1./norm($face2node[i]->$pos-$facecenter) ;
-      vector3d<float> v(realToFloat($X_f.x*weight),
-			realToFloat($X_f.y*weight),
-			realToFloat($X_f.z*weight)) ;
-      $face2node[i]->$boundary_v3d_sum(X) += v ;
+      vector3d<float> v(realToFloat($V_f.x*weight),
+			realToFloat($V_f.y*weight),
+			realToFloat($V_f.z*weight)) ;
+      $face2node[i]->$boundary_v3d_sum(V) += v ;
     }
   }
 
-  $rule pointwise(boundary::cell2node_v3d(X)<-
-		  boundary_v3d_sum(X),boundary_nodalw_sum),
+  $rule pointwise(boundary::cell2node_v3d(V)<-
+		  boundary_v3d_sum(V),boundary_nodalw_sum),
     constraint(boundary_node) {
       double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
-      $cell2node_v3d(X) = $boundary_v3d_sum(X)*rsum ;
+      $cell2node_v3d(V) = $boundary_v3d_sum(V)*rsum ;
   }
 
   //-------------------------------------------------
-  $type c2n_scalar_sump(X) store<float> ;
+  $type c2n_scalar_sump(V) store<float> ;
 
-  $rule unit(c2n_scalar_sump(X) ), constraint(pos)  { $c2n_scalar_sump(X) = 0 ; }
+  $rule unit(c2n_scalar_sump(V) ), constraint(pos)  { $c2n_scalar_sump(V) = 0 ; }
 
 #ifdef AUTODIFF2ND
   typedef Loci::FAD2d FADTYPE ;
@@ -356,11 +350,10 @@ namespace Loci {
 #endif
 #endif
 
-  $untype X ;
-  $type X store<FADTYPE> ;
+  $type XF store<FADTYPE> ;
 
-  $rule apply((upper,lower,boundary_map)->face2node->c2n_scalar_sump(X) <-
-	      (upper,lower,boundary_map)->face2node->pos,cellcenter,X)[Loci::Summation],
+  $rule apply((upper,lower,boundary_map)->face2node->c2n_scalar_sump(XF) <-
+	      (upper,lower,boundary_map)->face2node->pos,cellcenter,XF)[Loci::Summation],
     constraint(geom_cells) {
     int sztot = 0 ;
     
@@ -391,61 +384,59 @@ namespace Loci {
       int nd = *vi ;
       const double weight = realToDouble(1./norm($*pos[nd]-$cellcenter)) ;
 #ifdef MULTIFAD
-      int nv = $X.maxN ;
+      int nv = $XF.maxN ;
       for (int i=0;i<nv;i++) 
-        join($*c2n_scalar_sump(X)[nd],($X*weight).grad[i]) ;
+        join($*c2n_scalar_sump(XF)[nd],($XF*weight).grad[i]) ;
 #else
-      join($*c2n_scalar_sump(X)[nd],($X*weight).grad) ;
+      join($*c2n_scalar_sump(XF)[nd],($XF*weight).grad) ;
 #endif    
     }
   } 
 
-  $type cell2nodep(X) store<float> ;
+  $type cell2nodep(XF) store<float> ;
   
-  $rule pointwise(cell2nodep(X)<-c2n_scalar_sump(X),nodalw_sum),constraint(pos) {
+  $rule pointwise(cell2nodep(XF)<-c2n_scalar_sump(XF),nodalw_sum),constraint(pos) {
     double rsum = 1./(double($nodalw_sum)+1e-20) ;
-    $cell2nodep(X) = $c2n_scalar_sump(X)*rsum ;
+    $cell2nodep(XF) = $c2n_scalar_sump(XF)*rsum ;
   }   
 
-  $type boundary_scalar_sump(X) store<float> ;
-  $rule unit(boundary_scalar_sump(X)), constraint(pos) {
-    $boundary_scalar_sump(X) = 0 ;
+  $type boundary_scalar_sump(XF) store<float> ;
+  $rule unit(boundary_scalar_sump(XF)), constraint(pos) {
+    $boundary_scalar_sump(XF) = 0 ;
   }
 
-  $untype X_f ;
-  $type X_f store<FADTYPE> ;
-  $rule apply(face2node->boundary_scalar_sump(X)<-
-	      face2node->pos,X_f,facecenter)[Loci::Summation],
-    constraint(ci->X,no_symmetry_BC) {
+  $type XF_f store<FADTYPE> ;
+  $rule apply(face2node->boundary_scalar_sump(XF)<-
+	      face2node->pos,XF_f,facecenter)[Loci::Summation],
+    constraint(ci->XF,no_symmetry_BC) {
     int fsz = $face2node.size() ;
     for(int i=0;i<fsz;++i) {
       const double weight = realToDouble(1./norm($face2node[i]->$pos-$facecenter)) ;
 #ifdef MULTIFAD
-      int nv = $X_f.maxN ;
+      int nv = $XF_f.maxN ;
       for (int j=0;j<nv;j++) 
-        $face2node[i]->$boundary_scalar_sump(X) += ($X_f*weight).grad[j] ;
+        $face2node[i]->$boundary_scalar_sump(XF) += ($XF_f*weight).grad[j] ;
 #else
-      $face2node[i]->$boundary_scalar_sump(X) += ($X_f*weight).grad ;
+      $face2node[i]->$boundary_scalar_sump(XF) += ($XF_f*weight).grad ;
 #endif    
     }
   }
 
-  $rule pointwise(boundary::cell2nodep(X)<-boundary_scalar_sump(X),boundary_nodalw_sum),constraint(boundary_node) {
+  $rule pointwise(boundary::cell2nodep(XF)<-boundary_scalar_sump(XF),boundary_nodalw_sum),constraint(boundary_node) {
       double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
-      $cell2nodep(X) = $boundary_scalar_sump(X)*rsum ;
+      $cell2nodep(XF) = $boundary_scalar_sump(XF)*rsum ;
   }
 
-  $type c2n_v3d_sump(X) store<vector3d<float> > ;
+  $type c2n_v3d_sump(XF) store<vector3d<float> > ;
   
-  $rule unit(c2n_v3d_sump(X)),constraint(pos) {
-    $c2n_v3d_sump(X) = vector3d<float>(0.,0.,0.) ;
+  $rule unit(c2n_v3d_sump(XF)),constraint(pos) {
+    $c2n_v3d_sump(XF) = vector3d<float>(0.,0.,0.) ;
   }
 
-  $untype X ;
-  $type X store<vector3d<FADTYPE> > ;
+  $type VF store<vector3d<FADTYPE> > ;
   
-  $rule apply((upper,lower,boundary_map)->face2node->c2n_v3d_sump(X)<-
-	      X,cellcenter,(upper,lower,boundary_map)->face2node->pos)[Loci::Summation],
+  $rule apply((upper,lower,boundary_map)->face2node->c2n_v3d_sump(VF)<-
+	      VF,cellcenter,(upper,lower,boundary_map)->face2node->pos)[Loci::Summation],
     constraint(geom_cells) {
     int sztot = 0 ;
     
@@ -476,62 +467,61 @@ namespace Loci {
       int nd = *vi ;
       const double weight = realToDouble(1./norm($*pos[nd]-$cellcenter)) ;
 #ifdef MULTIFAD
-      int nv = $X.x.maxN ;
+      int nv = $VF.x.maxN ;
       for (int j=0;j<nv;j++) {
-        vector3d<float> v(($X.x*weight).grad[j],
-			  ($X.y*weight).grad[j],
-			  ($X.z*weight).grad[j]) ;
-        join($*c2n_v3d_sump(X)[nd],v) ;
+        vector3d<float> v(($VF.x*weight).grad[j],
+			  ($VF.y*weight).grad[j],
+			  ($VF.z*weight).grad[j]) ;
+        join($*c2n_v3d_sump(VF)[nd],v) ;
       }
 #else
-      vector3d<float> v(($X.x*weight).grad,
-			($X.y*weight).grad,
-			($X.z*weight).grad) ;
-      join($*c2n_v3d_sump(X)[nd],v) ;
+      vector3d<float> v(($VF.x*weight).grad,
+			($VF.y*weight).grad,
+			($VF.z*weight).grad) ;
+      join($*c2n_v3d_sump(VF)[nd],v) ;
 #endif
     }
   }
 
-  $type cell2nodep_v3d(X) store<vector3d<float> > ;
-  $rule pointwise(cell2nodep_v3d(X)<-c2n_v3d_sump(X),nodalw_sum) {
+  $type cell2nodep_v3d(VF) store<vector3d<float> > ;
+  $rule pointwise(cell2nodep_v3d(VF)<-c2n_v3d_sump(VF),nodalw_sum) {
     double rsum = 1./(double($nodalw_sum)+1e-20) ;
-    $cell2nodep_v3d(X) = $c2n_v3d_sump(X)*rsum ;
+    $cell2nodep_v3d(VF) = $c2n_v3d_sump(VF)*rsum ;
   }
-  $type boundary_v3d_sump(X) store<vector3d<float> > ;
+  $type boundary_v3d_sump(VF) store<vector3d<float> > ;
   
-  $rule unit(boundary_v3d_sump(X)),constraint(pos) {
-    $boundary_v3d_sump(X) = vector3d<float>(0.0,0.0,0.0) ;
+  $rule unit(boundary_v3d_sump(VF)),constraint(pos) {
+    $boundary_v3d_sump(VF) = vector3d<float>(0.0,0.0,0.0) ;
   }
 
-  $untype X_f ;
-  $type X_f store<vector3d<FADTYPE> > ;
+  $type VF_f store<vector3d<FADTYPE> > ;
   
-  $rule apply(face2node->boundary_v3d_sump(X)<-face2node->pos,X_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
+  $rule apply(face2node->boundary_v3d_sump(VF)<-face2node->pos,VF_f,facecenter)[Loci::Summation],constraint(ci,no_symmetry_BC) {
     int fsz = $face2node.size();
     for(int i=0;i<fsz;++i) {
       const double weight = realToDouble(1./norm($face2node[i]->$pos-$facecenter)) ;
 #ifdef MULTIFAD
-      int nv = $X_f.x.maxN ;
+      int nv = $VF_f.x.maxN ;
       for (int j=0;j<nv;j++) {
-        vector3d<float> v(($X_f.x*weight).grad[j],
-			  ($X_f.y*weight).grad[j],
-			  ($X_f.z*weight).grad[j]) ;
-        $face2node[i]->$boundary_v3d_sump(X) += v ;
+        vector3d<float> v(($VF_f.x*weight).grad[j],
+			  ($VF_f.y*weight).grad[j],
+			  ($VF_f.z*weight).grad[j]) ;
+        $face2node[i]->$boundary_v3d_sump(VF) += v ;
       }
 #else
-      vector3d<float> v(($X_f.x*weight).grad,
-			($X_f.y*weight).grad,
-			($X_f.z*weight).grad) ;
-      $face2node[i]->$boundary_v3d_sump(X) += v ;
+      vector3d<float> v(($VF_f.x*weight).grad,
+			($VF_f.y*weight).grad,
+			($VF_f.z*weight).grad) ;
+      $face2node[i]->$boundary_v3d_sump(VF) += v ;
 #endif    
     }
   }
 
-  $rule pointwise(boundary::cell2nodep_v3d(X)<-
-		  boundary_v3d_sump(X),boundary_nodalw_sum),
+  $rule pointwise(boundary::cell2nodep_v3d(VF)<-
+		  boundary_v3d_sump(VF),boundary_nodalw_sum),
     constraint(boundary_node) {
       double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
-      $cell2nodep_v3d(X) = $boundary_v3d_sump(X)*rsum ;
+      $cell2nodep_v3d(VF) = $boundary_v3d_sump(VF)*rsum ;
   }
 
 
@@ -564,13 +554,10 @@ namespace Loci {
     join($cr->$scalar_cell_error(L,R),err) ;
   }
 
-  $type face2nodeMax(X) store<float> ;
-  $rule unit(face2nodeMax(X)),constraint(pos) {
-    $face2nodeMax(X) = 0. ;
+  $type face2nodeMax(VF) store<float> ;
+  $rule unit(face2nodeMax(VF)),constraint(pos) {
+    $face2nodeMax(VF) = 0. ;
   }
-
-  $untype X ;`
-  $type X store<real_t> ;
 
   $rule apply(face2node->face2nodeMax(X)<-X)[Loci::Maximum] {
     double val = realToDouble($X) ;
@@ -717,10 +704,8 @@ namespace Loci {
       }
   } ;
 
-  $untype X ;
-  $type X store<vect3d> ;
-  $rule apply((upper,lower,boundary_map)->face2node->cell2nodeMaxv3d(X)<-
-	      X)[maxVect3d],constraint(geom_cells) {
+  $rule apply((upper,lower,boundary_map)->face2node->cell2nodeMaxv3d(V)<-
+	      V)[maxVect3d],constraint(geom_cells) {
     int sztot = 0 ;
     
     for(const Entity *fi=$upper.begin();fi!=$upper.end();++fi)
@@ -747,7 +732,7 @@ namespace Loci {
     vector<Entity>::iterator ns = node_list.begin() ;
 
     for(vector<int>::iterator vi = ns;vi!=ne;++vi) {
-      join(vi->$cell2nodeMaxv3d(X),realToFloat($X)) ;
+      join(vi->$cell2nodeMaxv3d(V),realToFloat($V)) ;
     }    
   }
 

--- a/src/include/FVM.lh
+++ b/src/include/FVM.lh
@@ -129,6 +129,7 @@ $type leftv3d(X) store<Loci::vector3d<Loci::real_t> > ;
 /** MUSCL 3-D vector extrapolation for right side of face */
 $type rightv3d(X) store<Loci::vector3d<Loci::real_t> > ;
 
+
 /** Simple scalar interpolation from geom_cells and boundary faces to nodes */
 $type cell2node(X) store<float > ;
 /**
@@ -188,6 +189,9 @@ $type LinfNorm(X) param<Loci::real_t> ;
 
 /** Get file number of entity */
 $type fileNumber(X) store<int> ;
+
+/// get vector size of storeVec<real_t>
+$type vecSize(M) param<int> ;
 
 /** Used to store the volume tag name for tagged vog file regions */
 $type volumeTag(X) param<string> ;


### PR DESCRIPTION
The lpp warning message from retyped variable in nodal_barth.loci was caused because a variable was retyped from store<real_t> to store<real>.  In fixing the problem, changed the typing convention to use the V and M conventions for vect3d and mixture array types.  I also moved the vecSize(M) type to the FVM.lh header as that is a generally useful utility that should be part of the finite volume module type definitions.  I checked that nodal barth still functioned correctly using CHEM on stand alone cases in addition to running Loci and CHEM quickTests.