### PR TITLE
Fixing tests for MPI stubb option

### DIFF
--- a/configure
+++ b/configure
@@ -558,7 +558,7 @@ if [ $NO_MPI == 1 ] ; then
     echo MPI_BASE = >> sys.conf
     echo MPI_LIBS = >> sys.conf
     echo MPI_INCLUDE = -DMPI_STUBB -I\$\(LOCI_BASE\)/include/MPI_stubb >> sys.conf
-    echo MPI_RUN = none >> sys.conf
+    echo MPI_RUN = \$\(LOCI_BASE\)/bin/mpinorun >> sys.conf
     echo MPI_C_COMPILER = none >> sys.conf
     echo MPI_CXX_COMPILER = none >> sys.conf
     echo MPI_F90_COMPILER = none >> sys.conf

--- a/quickTest/FVM/Makefile
+++ b/quickTest/FVM/Makefile
@@ -17,7 +17,7 @@ include $(LOCI_BASE)/Loci.conf
 .PHONY: FORCE
 
 tests: fluidTest ndiff FORCE
-	$(MAKE) -C tests TestResults LOCI_BASE=$(LOCI_BASE)
+	$(MAKE) -C tests TestResults LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)
 
 
 fluidTest: $(OBJS)

--- a/quickTest/FVM/tests/Makefile
+++ b/quickTest/FVM/tests/Makefile
@@ -1,9 +1,9 @@
 TEST_FILES=cylinder.test fixedMass.test  wedge.test shock_tube.test 
 
 
-#include $(LOCI_BASE)/test.conf
+include $(LOCI_BASE)/Loci.conf
+include $(LOCI_BASE)/version.conf
 include ../../test.conf
-#include test.conf
 
 default: TestResults
 

--- a/quickTest/FVM/tests/Makefile
+++ b/quickTest/FVM/tests/Makefile
@@ -3,7 +3,7 @@ TEST_FILES=cylinder.test fixedMass.test  wedge.test shock_tube.test
 
 include $(LOCI_BASE)/Loci.conf
 include $(LOCI_BASE)/version.conf
-include ../../test.conf
+include $(TEST_BASE)/test.conf
 
 default: TestResults
 

--- a/quickTest/FVMAdaptTest/Makefile
+++ b/quickTest/FVMAdaptTest/Makefile
@@ -1,3 +1,5 @@
+include Loci.conf
+include version.conf
 include $(TEST_BASE)/test.conf
 LIB_PATH=$(LOCI_BASE)/lib:$(LD_LIBRARY_PATH)
 DY_PATH=$(LOCI_BASE)/lib:$(DYLD_LIBRARY_PATH)

--- a/quickTest/FVMAdaptTest/Makefile
+++ b/quickTest/FVMAdaptTest/Makefile
@@ -1,5 +1,5 @@
-include Loci.conf
-include version.conf
+include $(LOCI_BASE)/Loci.conf
+include $(LOCI_BASE)/version.conf
 include $(TEST_BASE)/test.conf
 LIB_PATH=$(LOCI_BASE)/lib:$(LD_LIBRARY_PATH)
 DY_PATH=$(LOCI_BASE)/lib:$(DYLD_LIBRARY_PATH)

--- a/quickTest/FVMModUnitTests/Makefile
+++ b/quickTest/FVMModUnitTests/Makefile
@@ -24,7 +24,7 @@ $(TARGET): $(OBJS)
 .PHONY: FORCE
 
 tests: $(TARGET) FORCE
-	$(MAKE) -C tests TestResults LOCI_BASE=$(LOCI_BASE)
+	$(MAKE) -C tests TestResults LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)
 
 clean:
 	rm -fr $(OBJS) $(TARGET)

--- a/quickTest/FVMModUnitTests/tests/Makefile
+++ b/quickTest/FVMModUnitTests/tests/Makefile
@@ -1,11 +1,9 @@
 VARS_FILES= $(wildcard *.vars)
 TEST_FILES= $(subst .vars,.test, $(VARS_FILES))
 
-
-
-#include $(LOCI_BASE)/test.conf
-#include ../../test.conf
-#include test.conf
+include $(LOCI_BASE)/Loci.conf
+include $(LOCI_BASE)/version.conf
+include $(TEST_BASE)/test.conf
 
 default: TestResults
 
@@ -17,7 +15,7 @@ TestResults: $(TEST_FILES) FRC
 
 %.test : %.vars
 	@echo Test $*
-	@./test.sh $*.vars $*.test
+	@ MPIRUN=$(MPIRUN) ./test.sh $*.vars $*.test
 	@grep TEST $*.test
 
 

--- a/quickTest/FVMModUnitTests/tests/test.sh
+++ b/quickTest/FVMModUnitTests/tests/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export LD_LIBRARY_PATH=$LOCI_BASE/lib:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$LOCI_BASE/lib:$DYLD_LIBRARY_PATH
-../FVMModUnitTest $1 >& $2
+$MPIRUN -np 1 ../FVMModUnitTest $1 >& $2

--- a/quickTest/Makefile
+++ b/quickTest/Makefile
@@ -1,25 +1,28 @@
+TEST_BASE = $(shell pwd)
 default: FVM FVMModUnitTests FVMAdaptTest Containers
 
 .PHONY: FRC
 
 FVMModUnitTests: FRC
-	$(MAKE) -C FVMModUnitTests tests LOCI_BASE=$(LOCI_BASE)
+	$(MAKE) -C FVMModUnitTests tests LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)
 
 FVM: FRC
-	$(MAKE) -C FVM LOCI_BASE=$(LOCI_BASE)
+	$(MAKE) -C FVM LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)
 
 FVMAdaptTest: FRC
-	$(MAKE) -C FVMAdaptTest LOCI_BASE=$(LOCI_BASE) TEST_BASE=../
+	$(MAKE) -C FVMAdaptTest LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)
 Containers: FRC
-	$(MAKE) -C Containers LOCI_BASE=$(LOCI_BASE)
+	$(MAKE) -C Containers LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)
 
 clean: FRC
-	$(MAKE) -C FVM LOCI_BASE=$(LOCI_BASE) clean
-	$(MAKE) -C FVMModUnitTests LOCI_BASE=$(LOCI_BASE) clean
-	$(MAKE) -C Containers LOCI_BASE=$(LOCI_BASE) clean
+	$(MAKE) -C FVM LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) clean
+	$(MAKE) -C FVMModUnitTests LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) clean
+	$(MAKE) -C Containers LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) clean
+	$(MAKE) -C FVMAdaptTest LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) clean
 
 distclean:
-	$(MAKE) -C FVM LOCI_BASE=$(LOCI_BASE) distclean
-	$(MAKE) -C FVMModUnitTests LOCI_BASE=$(LOCI_BASE) distclean
-	$(MAKE) -C Containers LOCI_BASE=$(LOCI_BASE) distclean
+	$(MAKE) -C FVM LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) distclean
+	$(MAKE) -C FVMModUnitTests LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE)  distclean
+	$(MAKE) -C Containers LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) distclean
+	$(MAKE) -C FVMAdaptTest LOCI_BASE=$(LOCI_BASE) TEST_BASE=$(TEST_BASE) distclean
 

--- a/quickTest/test.conf
+++ b/quickTest/test.conf
@@ -1,4 +1,4 @@
-MPIRUN= mpirun 
+MPIRUN= $(MPI_RUN)
 MPINUMPROC=3
 
 #LOCI_BASE=

--- a/src/FVMtools/mpinorun
+++ b/src/FVMtools/mpinorun
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Skip any "-np" arguments and their values
+cmd=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -np)
+            # Ignore -np and its value
+            shift
+            shift
+            ;;
+        *)
+            cmd+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Execute the command without the "-np" argument
+"${cmd[@]}"

--- a/src/FVMtools/mpinorun
+++ b/src/FVMtools/mpinorun
@@ -1,6 +1,8 @@
 #!/bin/bash
-
-# Skip any "-np" arguments and their values
+## Helper script for running tests with stubbed out MPI calls.  This
+## works like mpirun only it just ignores the -np argument.
+set -e
+set -u
 cmd=()
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/tmpcopy
+++ b/tmpcopy
@@ -209,6 +209,13 @@ fi
 if [ ! -h libsprng.${LIB_POSTFIX} ] ; then
     ln -s ../sprng/libsprng.${LIB_POSTFIX} libsprng.${LIB_POSTFIX}
 fi
+if [ ! -h $fulltarget/bin/extract_movie ]; then
+    ln -s $source/src/FVMtools/extract_movie $fulltarget/bin/extract_movie
+fi
+if [ ! -h $fulltarget/bin/mpinorun ]; then
+    ln -s $source/src/FVMtools/mpinorun $fulltarget/bin/mpinorun
+fi
+
 cd ../bin
 if [ ! -h lpp ] ; then
   ln -s ../lpp/lpp lpp


### PR DESCRIPTION
The configure --nompi feature did not work nicely with the test scripts under quickTest because they assumed mpirun was used to run the tests.  This provides a script mpinorun that can be used in the script when testing under the --nompi configuration options.

This is part of the testing that is needed as part of stabilizing the beta release.
