### PR TITLE
Fixed bug in create_cell_stencil_full and create_cell_stencil

### DIFF
--- a/quickTest/FVMModUnitTests/gridReader.loci
+++ b/quickTest/FVMModUnitTests/gridReader.loci
@@ -89,7 +89,8 @@ namespace flowPsi {
         while(ifile.peek() != '{' && ifile.peek() != EOF) {
           ifile.get() ;
         }
-        cerr << "reading " << varsfile << endl ;
+        if(Loci::MPI_rank == 0)
+          cerr << "reading " << varsfile << endl ;
         facts.read_vars(ifile,rdb) ;
       }
     } catch(const Loci::BasicException &err) {

--- a/quickTest/FVMModUnitTests/main.loci
+++ b/quickTest/FVMModUnitTests/main.loci
@@ -469,12 +469,14 @@ int main(int ac, char *av[]) {
   Loci::Finalize() ;
   if(message.size()== 0)
     message = query ;
-  
+
   if(testPassed) {
-    cout << "TEST " << message << ": PASSED!" << endl ;
+    if(Loci::MPI_rank == 0) 
+      cout << "TEST " << message << ": PASSED!" << endl ;
     return 0 ;
   }
-  cout << "TEST " << message << ": FAILED!" << endl ;
+  if(Loci::MPI_rank == 0) 
+    cout << "TEST " << message << ": FAILED!" << endl ;
   return -1 ;
 }
 

--- a/quickTest/FVMModUnitTests/tests/Makefile
+++ b/quickTest/FVMModUnitTests/tests/Makefile
@@ -15,7 +15,7 @@ TestResults: $(TEST_FILES) FRC
 
 %.test : %.vars
 	@echo Test $*
-	@ MPIRUN=$(MPIRUN) ./test.sh $*.vars $*.test
+	@ MPIRUN="$(MPIRUN)" MPINUMPROC=$(MPINUMPROC) ./test.sh $*.vars $*.test
 	@grep TEST $*.test
 
 

--- a/quickTest/FVMModUnitTests/tests/test.sh
+++ b/quickTest/FVMModUnitTests/tests/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export LD_LIBRARY_PATH=$LOCI_BASE/lib:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$LOCI_BASE/lib:$DYLD_LIBRARY_PATH
-$MPIRUN -np 1 ../FVMModUnitTest $1 >& $2
+$MPIRUN -np $MPINUMPROC ../FVMModUnitTest $1 >& $2

--- a/src/System/FVMStuff.cc
+++ b/src/System/FVMStuff.cc
@@ -2068,8 +2068,9 @@ namespace Loci{
     entitySet geom_cells = *geom_cells_c ;
     // We need to have all of the geom_cells to do the correct test in the
     // loop before, so gather with clone cells
-    geom_cells = collectSet(geom_cells,cellmask,MPI_COMM_WORLD) ;
-
+    std::vector<entitySet> ptn = facts.get_init_ptn() ;
+    geom_cells = dist_collect_entitySet(geom_cells,ptn) ;
+    dist_expand_entitySet(geom_cells,cellmask,ptn) ;
     Loci::protoMap f2cell ;
 
     // Get mapping from face to geometric cells
@@ -2103,7 +2104,6 @@ namespace Loci{
     //
     // Create cell stencil map from protoMap
     multiMap cellStencil ;
-    std::vector<entitySet> ptn = facts.get_init_ptn() ;
     distributed_inverseMap(cellStencil,c2c,geom_cells,geom_cells,ptn) ;
     // Put in fact database
     facts.create_fact("cellStencil",cellStencil) ;
@@ -2126,8 +2126,10 @@ namespace Loci{
     entitySet geom_cells = *geom_cells_c ;
     // We need to have all of the geom_cells to do the correct test in the
     // loop before, so gather clone cells
-    geom_cells = collectSet(geom_cells,cellmask,MPI_COMM_WORLD) ;
-
+    std::vector<entitySet> ptn = facts.get_init_ptn() ;
+    geom_cells = dist_collect_entitySet(geom_cells,ptn) ;
+    dist_expand_entitySet(geom_cells,cellmask,ptn) ;
+    
     Loci::protoMap f2cell ;
 
     // Get mapping from face to geometric cells
@@ -2161,7 +2163,7 @@ namespace Loci{
     //
     // Create cell stencil map from protoMap
     multiMap cellStencil ;
-    std::vector<entitySet> ptn = facts.get_init_ptn() ;
+    //    std::vector<entitySet> ptn = facts.get_init_ptn() ;
     distributed_inverseMap(cellStencil,c2c,geom_cells,geom_cells,ptn) ;
 
     // Now downselect cells


### PR DESCRIPTION
The create_cell_stencil_full and create_cell_stencil utility functions would segfault in some isolated partitioning cases.  The fault is related to the use of the collectSet utility function.  The function was replaced with the dist_collect_entitySet and dist_expand_entitySet functions.  There are other places in the code that use the collectSet utility that probably should be shifted to use the dist_colllect_entitySet and dist_expand_entitySet utilities instead.  This is left to future work.

There have been changes to the quickTest infrastructure to allow the unit tests for the full and stable stencils to be run in parallel to reproduce the error.   The fix resolves the error, the flowPsi and chem codes also pass their tests.