### PR TITLE
Fixed bug in 2dgv extraction for online adaptation

### DIFF
--- a/src/FVMtools/extract_2dgv.cc
+++ b/src/FVMtools/extract_2dgv.cc
@@ -104,8 +104,7 @@ void get_2dgv(string casename, string iteration,
 
   vector<Array<int,3> > edges ;
 
-  string gridtopo = "output/" + casename +".topo" ;
-
+  string gridtopo = getTopoFileName(output_dir, casename, iteration) ;
 
   file_id = H5Fopen(gridtopo.c_str(),H5F_ACC_RDONLY,H5P_DEFAULT) ;
 #ifdef H5_USE_16_API  


### PR DESCRIPTION
The extract -2d option used a hard coded path for finding the topo file rather than using the API that finds the appropriate version used when online adaptation features are used.  This fixes that bug.