### PR TITLE
Fixes issues with PETSC_DEFAULT being deprecated in latest PETSC releases.

### DIFF
--- a/src/FVMMod/petsc.loci
+++ b/src/FVMMod/petsc.loci
@@ -77,6 +77,10 @@ $include "FVM.lh"
   #define LociPetscCall(expr) do { PetscErrorCode _ierr = (expr); CHKERRQ(_ierr); } while (0)
 #endif
 
+#ifndef PETSC_CURRENT
+ #define PETSC_CURRENT PETSC_DEFAULT
+#endif
+
 enum PetscMatrixType {
   PETSC_MATRIX_TYPE_SEQ_SCALAR,
   PETSC_MATRIX_TYPE_SEQ_BLOCKED,


### PR DESCRIPTION
This fixes portability bug that allows the petsc interface in FVMMod to compile with older versions of PETSc that don't provide the PETSC_CURRENT macro.