### PR TITLE
Graceful warning for old AMR API usage

### DIFF
--- a/src/FVMAdapt/library/write_vog.cc
+++ b/src/FVMAdapt/library/write_vog.cc
@@ -1494,6 +1494,29 @@ namespace Loci{
 
 
 namespace Loci {
+  void createVOGNode(store<vect3d> &new_pos,
+                     const store<Loci::FineNodes> &inner_nodes,
+                     int& num_nodes,
+                     fact_db & facts,
+                     vector<entitySet>& local_nodes) {
+    cerr << "AMR API has changed, this call is deprecated.  Update your AMR API calls!" << endl ;
+    Loci::Abort() ;
+  }
+  void createVOGFace(int numNodes,
+                     const store<Loci::FineFaces> &fine_faces,
+                     fact_db & facts,
+                     int& numFaces,
+                     int& ncells,
+                     Map& cl,
+                     Map& cr,
+                     multiMap& face2node,
+                     vector<entitySet>& local_faces,
+                     vector<entitySet>& local_cells
+                     ) {
+    cerr << "AMR API has changed, this call is deprecated.  Update your AMR API calls!" << endl ;
+    Loci::Abort() ;
+  }
+
   //create a new store new_pos from pos and inner_nodes
   //re_number the nodes in pos and inner_nodes,
   //and then redistribute them across the processes

--- a/src/FVMAdapt/write_vog_module.loci
+++ b/src/FVMAdapt/write_vog_module.loci
@@ -29,6 +29,7 @@
 #include "sciTypes.h"
 #include "defines.h"
 #include <Tools/tools.h>
+
 using std::cerr;
 using std::cout;
 using std::endl;
@@ -358,3 +359,16 @@ public:
   }
 };
 register_rule<get_volTag> register_get_volTag;
+
+
+// Code to write out diagnostics if application using older AMR API.
+$type inner_nodes store<Loci::FineNodes> ;
+
+$rule pointwise(inner_nodes),constraint(UNIVERSE), prelude {
+   $[Once] {
+     cerr << "AMR API has changed, program needs to be updated to support AMR!"
+          << endl ;
+   }
+   Loci::Abort() ;
+} ;
+


### PR DESCRIPTION
These simple changes resolve linking errors when compiling 4.0 versions of CHEM with the dev branch and add diagnostics when executing schedule queries for the older API.  The changes have no effect on the update AMR API, but allow for users to evaluate dev features using the current stable CHEM release.  This will be helpful for evaluating new PETSc GPGPU support.