### PR TITLE
Stencil scalability and segfault bug fixes

### DIFF
--- a/src/System/FVMStuff.cc
+++ b/src/System/FVMStuff.cc
@@ -47,23 +47,6 @@ using std::cout ;
 namespace Loci{
   extern int getKeyDomain(entitySet dom, fact_db::distribute_infoP dist, MPI_Comm comm) ;
   extern  bool useDomainKeySpaces  ;
-  // Convert container from local numbering to file numbering
-  // pass in store rep pointer: sp
-  // entitySet to write: dom
-  // return offset in file numbering (each processor will allocate from zero,
-  // add offset to domain to get actual file numbering)
-  // distribution info pointer (dist)
-  // MPI Communicator
-  storeRepP Local2FileOrder(storeRepP sp, entitySet dom, int &offset,
-                            fact_db::distribute_infoP dist, MPI_Comm comm);
-  // Convert container from local numbering to output file numbering
-  // pass in store rep pointer: sp
-  // entitySet to write: dom
-  // fact_db pointer  (facts)
-  // MPI Communicator
-  storeRepP Local2FileOrder_output(storeRepP sp, entitySet dom,
-                                   fact_db& facts, MPI_Comm comm);
-  
   
   //map from local numbering to input file numbering
   //assume the union of nodes on all processors will be either all the nodes,
@@ -1898,7 +1881,12 @@ namespace Loci{
   // remove self2self references
   // Convert resulting structure to multiMap
 
-  void getFaceCenter(fact_db &facts, dstore<vector3d<double> > &fcenter, dstore<double> &area, dstore<vector3d<double> > &normal) {
+
+
+  void getFaceCenter(fact_db &facts,
+                     store<vector3d<double> > &fcenter,
+                     store<double> &area,
+                     store<vector3d<double> > &normal) {
     // Compute face centers
     store<vector3d<double> > pos ;
     pos = facts.get_variable("pos") ;
@@ -1906,42 +1894,45 @@ namespace Loci{
     multiMap face2node ;
     face2node = facts.get_variable("face2node") ;
     entitySet fdom = face2node.domain() ;
-    entitySet f2n_image = Loci::MapRepP(face2node.Rep())->image(fdom) ;
+    // Find nodes that face2node accesses
+    entitySet node_access = Loci::MapRepP(face2node.Rep())->image(fdom) ;
 
-    entitySet out_of_dom = f2n_image - pos.domain() ;
-
-    dstore<vector3d<double> > tmp_pos ;
-    FORALL(pos.domain(), pi) {
-      tmp_pos[pi] = pos[pi] ;
-    } ENDFORALL ;
-    Loci::storeRepP sp = tmp_pos.Rep() ;
-    int tmp_out = out_of_dom.size() ;
-    if(facts.is_distributed_start()) {
-      int nkeyspace = pos.getDomainKeySpace() ;
-      std::vector<entitySet> init_ptn = facts.get_init_ptn(nkeyspace) ;
-      if(GLOBAL_OR(tmp_out)) 
-	fill_clone(sp, out_of_dom, init_ptn) ;
-    }
-
+    std::vector<vector3d<double> > posdata ;
+    int nkeyspace = pos.getDomainKeySpace() ;
+    std::vector<entitySet> node_ptn = facts.get_init_ptn(nkeyspace) ;
+    // gather nodal data needed for the computation.
+    std::map<int,int> g2l ;
+    getLocalContextMap(g2l,node_access) ;
+    gatherData(posdata,pos,node_access,node_ptn) ;
+    fcenter.allocate(fdom) ;
+    area.allocate(fdom) ;
+    normal.allocate(fdom) ;
     param<std::string> centroid ;
     centroid = facts.get_variable("centroid") ;
     bool exact = false ;
     if(*centroid == "exact") 
       exact = true ;
-
     FORALL(fdom,fc) {
       int fsz = face2node[fc].size() ;
-      vector3d<double>  center = vector3d<double> (0,0,0) ;
+      vector3d<double>  center = vector3d<double>(0,0,0) ;
       double wsum = 0 ;
 	
       for(int i=1;i<fsz;++i) {
-	double len = norm(tmp_pos[face2node[fc][i-1]]-tmp_pos[face2node[fc][i]]) ;
-	vector3d<double>  eloc = 0.5*(tmp_pos[face2node[fc][i-1]]+tmp_pos[face2node[fc][i]]) ;
+        FATAL(g2l[face2node[fc][i-1]] > posdata.size()) ;
+        FATAL(g2l[face2node[fc][i-1]] < 0) ;
+        FATAL(g2l[face2node[fc][i]] > posdata.size()) ;
+        FATAL(g2l[face2node[fc][i]] < 0) ;
+	double len = norm(posdata[g2l[face2node[fc][i-1]]]-
+                          posdata[g2l[face2node[fc][i  ]]]) ;
+	vector3d<double>  eloc = 0.5*(posdata[g2l[face2node[fc][i-1]]]+
+                                      posdata[g2l[face2node[fc][i  ]]]) ;
 	center += len*eloc ;
 	wsum += len ;
       }
-      double lenr = norm(tmp_pos[face2node[fc][0]]-tmp_pos[face2node[fc][fsz-1]]) ;
-      vector3d<double>  elocr = 0.5*(tmp_pos[face2node[fc][0]]+tmp_pos[face2node[fc][fsz-1]]) ;
+      double lenr = norm(posdata[g2l[face2node[fc][0    ]]]-
+                         posdata[g2l[face2node[fc][fsz-1]]]) ;
+      vector3d<double>  elocr = 0.5*(posdata[g2l[face2node[fc][0    ]]]+
+                                     posdata[g2l[face2node[fc][fsz-1]]]) ;
       center += lenr*elocr ;
       wsum += lenr ;
       center *= 1./wsum ;
@@ -1958,8 +1949,8 @@ namespace Loci{
 	  for(int i=0;i<fsz;++i) {
 	    int n1 = i ;
 	    int n2 = (i+1==fsz)?0:i+1 ;
-	    vector3d<double>  p1 = tmp_pos[face2node[fc][n1]] ;
-	    vector3d<double>  p2 = tmp_pos[face2node[fc][n2]] ;
+	    vector3d<double>  p1 = posdata[g2l[face2node[fc][n1]]] ;
+	    vector3d<double>  p2 = posdata[g2l[face2node[fc][n2]]] ;
 	    
 	    const vector3d<double>  t_centroid = (p1 + p2 + tmpcenter)/3.0 ;
 	    const double t_area = 0.5*norm(cross(p1-tmpcenter,p2-tmpcenter)) ;
@@ -1975,8 +1966,8 @@ namespace Loci{
       for(int i=0;i<fsz;++i) {
 	int n1 = i ;
 	int n2 = (i+1==fsz)?0:i+1 ;
-	vector3d<double>  p1 = tmp_pos[face2node[fc][n1]] ;
-	vector3d<double>  p2 = tmp_pos[face2node[fc][n2]] ;
+	vector3d<double>  p1 = posdata[g2l[face2node[fc][n1]]] ;
+	vector3d<double>  p2 = posdata[g2l[face2node[fc][n2]]] ;
 	
 	facearea += cross(p1-tmpcenter,p2-tmpcenter) ;
       }
@@ -1985,13 +1976,12 @@ namespace Loci{
       normal[fc] = (1./nfacearea)*facearea ;
     } ENDFORALL ;
   }
-
-  void getCellCenter(fact_db &facts, dstore<vector3d<double> > &fcenter,
-		     dstore<vector3d<double> > &fnormal,
-		     dstore<vector3d<double> > &ccenter) {
-
-    dstore<double> area ;
-    getFaceCenter(facts,fcenter,area,fnormal) ;
+  
+  void getCellCenter(fact_db &facts,
+                      store<vector3d<double> > &ccenter,
+                      store<vector3d<double> > &fcenter,
+                      store<double> &area) {
+    
     multiMap upper,lower,boundary_map ;
     upper = facts.get_variable("upper") ;
     lower = facts.get_variable("lower") ;
@@ -2001,64 +1991,56 @@ namespace Loci{
     faceimage += Loci::MapRepP(upper.Rep())->image(cells) ;
     faceimage += Loci::MapRepP(lower.Rep())->image(cells) ;
     faceimage += Loci::MapRepP(boundary_map.Rep())->image(cells) ;
-    entitySet out_of_dom = faceimage - fcenter.domain() ;
-    int tmp_out = out_of_dom.size() ;
-    if(facts.is_distributed_start()) {
-      
-      int fkeyspace = upper.getRangeKeySpace() ;
-      std::vector<entitySet> init_ptn = facts.get_init_ptn(fkeyspace) ;
-      if(GLOBAL_OR(tmp_out)) {
-	Loci::storeRepP sp = fcenter.Rep() ;
-	fill_clone(sp, out_of_dom, init_ptn) ;
-	sp = area.Rep() ;
-	fill_clone(sp, out_of_dom, init_ptn) ;
-	sp = fnormal.Rep() ;
-	fill_clone(sp, out_of_dom, init_ptn) ;
-      }
-    }
-    dstore<vector3d<double> > wccenter ;
+    ccenter.allocate(cells) ;
+
+    vector<vector3d<double> > fcenterdata ;
+    vector<double> areadata ;
+    int fkeyspace = upper.getRangeKeySpace() ;
+    std::vector<entitySet> face_ptn = facts.get_init_ptn(fkeyspace) ;
+    std::map<int,int> g2l ;
+    getLocalContextMap(g2l,faceimage) ;
+    gatherData(fcenterdata,fcenter,faceimage,face_ptn) ;
+    gatherData(areadata,area,faceimage,face_ptn) ;
     // compute wireframe centroid
     FORALL(cells,cc) {
       vector3d<double>  csum = vector3d<double> (0,0,0) ;
       double wsum = 0 ;
       int lsz = lower[cc].size() ;
       for(int i=0;i<lsz;++i) {
-	int f = lower[cc][i] ;
-	double w = area[f] ;
-	vector3d<double>  v = fcenter[f] ;
+	int f = g2l[lower[cc][i]] ;
+	double w = areadata[f] ;
+	vector3d<double>  v = fcenterdata[f] ;
 	csum += w*v ;
 	wsum += w ;
       }
       int usz = upper[cc].size() ;
       for(int i=0;i<usz;++i) {
-	int f = upper[cc][i] ;
-	double w = area[f] ;
-	vector3d<double>  v = fcenter[f] ;
+	int f = g2l[upper[cc][i]] ;
+	double w = areadata[f] ;
+	vector3d<double>  v = fcenterdata[f] ;
 	csum += w*v ;
 	wsum += w ;
       }
       int bsz = boundary_map[cc].size() ;
       for(int i=0;i<bsz;++i) {
-	int f = boundary_map[cc][i] ;
-	double w = area[f] ;
-	vector3d<double>  v = fcenter[f] ;
+	int f = g2l[boundary_map[cc][i]] ;
+	double w = areadata[f] ;
+	vector3d<double>  v = fcenterdata[f] ;
 	csum += w*v ;
 	wsum += w ;
       }
       csum *= 1./wsum ;
-      wccenter[cc] = csum ;
       ccenter[cc] = csum ;
     } ENDFORALL ;
     param<std::string> centroid ;
     centroid = facts.get_variable("centroid") ;
     if(*centroid == "exact")  {
       // Here we add code to compute exact centroid.
-      // face2node needs to be expanded to do this...
+      // face2node needs to be expanded to do this..., not trivial
     }
-    
   }
 
-  void create_cell_stencil_full(fact_db &facts) {
+  void get_full_cellStencil(multiMap &cellStencil,fact_db &facts) {
     using std::vector ;
     using std::pair ;
     Map cl,cr ;
@@ -2072,18 +2054,26 @@ namespace Loci{
     constraint geom_cells_c ;
     geom_cells_c = facts.get_variable("geom_cells") ;
     entitySet geom_cells = *geom_cells_c ;
+
     // We need to have all of the geom_cells to do the correct test in the
     // loop before, so gather with clone cells
     int gkeyspace = geom_cells_c.getDomainKeySpace() ;
     std::vector<entitySet> ptn = facts.get_init_ptn(gkeyspace) ;
     geom_cells = distribute_entitySet(geom_cells,ptn) ;
-    dist_expand_entitySet(geom_cells,cellmask,ptn) ;
+    entitySet geom_cell_expand =
+      dist_expand_entitySet(geom_cells,cellmask,ptn) ;
     Loci::protoMap f2cell ;
 
+#ifdef DEBUG
+    // Check to see if there are any ORPHAN cells in geom_cells.
+    entitySet accessedSet = distribute_entitySet(cellmask,ptn) ;
+    WARN(GLOBAL_OR((geom_cells-accessedSet) != EMPTY))
+#endif
     // Get mapping from face to geometric cells
     Loci::addToProtoMap(cl,f2cell) ;
     FORALL(faces,fc) {
-      if(geom_cells.inSet(cr[fc]))
+      WARN(cl[fc] == cr[fc]) ;
+      if(geom_cell_expand.inSet(cr[fc]))
         f2cell.push_back(pair<int,int>(fc,cr[fc])) ;
     } ENDFORALL ;
 
@@ -2110,75 +2100,69 @@ namespace Loci{
 
     //
     // Create cell stencil map from protoMap
-    multiMap cellStencil ;
     distributed_inverseMap(cellStencil,c2c,geom_cells,geom_cells,ptn) ;
+
+#ifdef DEBUG
+    entitySet degen_cells ;
+    FORALL(geom_cells,ii) {
+      if(cellStencil[ii].size() == 0) {
+        debugout << "geom cell " << ii << " has degenerate stencil"
+                 << endl ;
+        degen_cells += ii ;
+      }
+    } ENDFORALL ;
+    entitySet tot_degen = all_collect_entitySet(degen_cells) ;
+    WARN(tot_degen!=EMPTY) ;
+    if(tot_degen != EMPTY) {
+      debugout << "tot_degen=" << tot_degen << endl ;
+      if(MPI_rank==0)
+        cerr << "tot_degen = " << tot_degen << endl ;
+    }
+    FORALL(faces,fc) {
+      if(tot_degen.inSet(cl[fc]) || tot_degen.inSet(cr[fc])) {
+        debugout << "fc=" << fc << ",cl="<<cl[fc] << ",cr=" << cr[fc] << endl ;
+        cerr << "fc=" << fc << ",cl="<<cl[fc] << ",cr=" << cr[fc] << endl ;
+      }
+    } ENDFORALL ;    
+#endif
+  }
+
+  void create_cell_stencil_full(fact_db &facts) {
+    // Create cell stencil map from protoMap
+    multiMap cellStencil ;
+    get_full_cellStencil(cellStencil,facts) ;
     // Put in fact database
     facts.create_fact("cellStencil",cellStencil) ;
+  }
+
+  inline void getMaxMinDirections(int &maxid,
+                                  int &minid,
+                                  const vector3d<double> &dir,
+                                  std::vector<vector3d<double> > &cdirs) {
+    minid = 0 ;
+    maxid = 0 ;
+    double minval = dot(dir,cdirs[0]) ;
+    double maxval = minval ;
+    int sz = cdirs.size() ;
+    for(int j=1;j<sz;++j) {
+      double v = dot(dir,cdirs[j]) ;
+      if(minval < v) {
+        minid = j ;
+        minval = v ;
+      }
+      if(maxval > v) {
+        maxid = j ;
+        maxval = v ;
+      }
+    }
   }
   
   void create_cell_stencil(fact_db & facts) {
     using std::vector ;
-    using std::pair ;
-    Map cl,cr ;
-    multiMap face2node ;
-    cl = facts.get_variable("cl") ;
-    cr = facts.get_variable("cr") ;
-    face2node = facts.get_variable("face2node") ;
 
-    entitySet faces = face2node.domain() ;
-    entitySet cellmask = cl.image(faces)+cr.image(faces) ;
-    
-    constraint geom_cells_c ;
-    geom_cells_c = facts.get_variable("geom_cells") ;
-    entitySet geom_cells = *geom_cells_c ;
-    // We need to have all of the geom_cells to do the correct test in the
-    // loop before, so gather clone cells
-    int gkeyspace = geom_cells_c.getDomainKeySpace() ;
-    std::vector<entitySet> ptn = facts.get_init_ptn(gkeyspace) ;
-    geom_cells = distribute_entitySet(geom_cells,ptn) ;
-    dist_expand_entitySet(geom_cells,cellmask,ptn) ;
-    
-    Loci::protoMap f2cell ;
-
-    // Get mapping from face to geometric cells
-    Loci::addToProtoMap(cl,f2cell) ;
-    FORALL(faces,fc) {
-      if(geom_cells.inSet(cr[fc]))
-        f2cell.push_back(pair<int,int>(fc,cr[fc])) ;
-    } ENDFORALL ;
-
-    // Get mapping from face to nodes
-    Loci::protoMap f2node ;
-    Loci::addToProtoMap(face2node,f2node) ;
-
-    // Equijoin on first of pairs to get node to neighboring cell mapping
-    // This will give us a mapping from nodes to neighboring cells
-    Loci::protoMap n2c ;
-    Loci::equiJoinFF(f2node,f2cell,n2c) ;
-
-    // In case there are processors that have no n2c's allocated to them
-    // re-balance map distribution
-    Loci::balanceDistribution(n2c,MPI_COMM_WORLD) ;
-    // Equijoin node2cell with itself to get cell to cell map of
-    // all cells that share one or more nodes
-    Loci::protoMap n2cc = n2c ;
-    Loci::protoMap c2c ;
-    Loci::equiJoinFF(n2c,n2cc,c2c) ;
-
-    // Remove self references
-    Loci::removeIdentity(c2c) ;
-
-    //
-    // Create cell stencil map from protoMap
+    // get full stencil
     multiMap cellStencil ;
-    //    std::vector<entitySet> ptn = facts.get_init_ptn() ;
-    distributed_inverseMap(cellStencil,c2c,geom_cells,geom_cells,ptn) ;
-
-    // Now downselect cells
-    dstore<vector3d<double> > fcenter ;
-    dstore<vector3d<double> > fnormal ;
-    dstore<vector3d<double> > ccenter ;
-    getCellCenter(facts, fcenter, fnormal, ccenter) ;
+    get_full_cellStencil(cellStencil,facts) ;
 
     entitySet cells = cellStencil.domain() ;
     multiMap upper,lower,boundary_map ;
@@ -2186,154 +2170,92 @@ namespace Loci{
     lower = facts.get_variable("lower") ;
     boundary_map = facts.get_variable("boundary_map") ;
 
+    entitySet faceimage  ;
+    faceimage += Loci::MapRepP(upper.Rep())->image(cells) ;
+    faceimage += Loci::MapRepP(lower.Rep())->image(cells) ;
+    faceimage += Loci::MapRepP(boundary_map.Rep())->image(cells) ;
+    int fkeyspace = upper.getRangeKeySpace() ;
+    std::vector<entitySet> face_ptn = facts.get_init_ptn(fkeyspace) ;
+    store<vector3d<double> > fcenter,normal ;
+    store<double> area ;
+    getFaceCenter(facts,fcenter,area,normal) ;
+    store<vector3d<double> > ccenter ;
+    getCellCenter(facts,ccenter,fcenter,area) ;
+    
+    // gather face data needed for the computation.
+    std::map<int,int> fg2l ;
+    getLocalContextMap(fg2l,faceimage) ;
+    vector<vector3d<double> > fcenterdata ;
+    vector<vector3d<double> > fnormaldata ;
+    gatherData(fcenterdata,fcenter,faceimage,face_ptn) ;
+    gatherData(fnormaldata,normal,faceimage,face_ptn) ;
+    
+    int ckeyspace = upper.getDomainKeySpace() ;
+    std::vector<entitySet> cell_ptn = facts.get_init_ptn(ckeyspace) ;
+
     entitySet cellImage = Loci::MapRepP(cellStencil.Rep())->image(cells) ;
-    cellImage -= cells ;
-    if(facts.is_distributed_start()) {
-      int gkeyspace = geom_cells_c.getDomainKeySpace() ;
-      std::vector<entitySet> ptn = facts.get_init_ptn(gkeyspace) ;
-      std::vector<entitySet> init_ptn = facts.get_init_ptn(gkeyspace) ;
-      int tmp_out = cellImage.size() ;
-      if(GLOBAL_OR(tmp_out)) {
-	Loci::storeRepP sp = ccenter.Rep() ;
-	fill_clone(sp, cellImage, init_ptn) ;
-      }
-    }
+
+    vector<vector3d<double> > ccenterdata ;
+    std::map<int,int> cg2l ;
+    getLocalContextMap(cg2l,cellImage) ;
+    gatherData(ccenterdata,ccenter,cellImage,cell_ptn) ;
 
     store<int> sizes ;
     sizes.allocate(cells) ;
-    vector<int> cellmap ;
     FORALL(cells,cc) {
       int csz = cellStencil[cc].size() ;
       int bsz = boundary_map[cc].size() ; ;
       vector3d<double>  ccent = ccenter[cc] ;
       vector<vector3d<double> > cdirs(csz+bsz) ;
       for(int i=0;i<csz;++i) {
-	cdirs[i] = ccenter[cellStencil[cc][i]]-ccent ;
+	cdirs[i] = ccenterdata[cg2l[cellStencil[cc][i]]]-ccent ;
 	cdirs[i] *= 1./norm(cdirs[i]) ;
       }
       for(int i=0;i<bsz;++i) {
-	cdirs[csz+i] = fcenter[boundary_map[cc][i]]-ccent ;
+	cdirs[csz+i] = fcenterdata[fg2l[boundary_map[cc][i]]]-ccent ;
 	cdirs[csz+i] *= 1./norm(cdirs[csz+i]) ;
       }
 	
       vector<int> flags(csz+bsz,0) ;
       int lsz = lower[cc].size() ;
       for(int i=0;i<lsz;++i) {
-	vector3d<double>  dir = fcenter[lower[cc][i]] -ccent;
+	vector3d<double>  dir = fcenterdata[fg2l[lower[cc][i]]] -ccent;
 	dir *= 1./norm(dir) ;
-	int minid = 0 ;
-	int maxid = 0 ;
-	double minval = dot(dir,cdirs[0]) ;
-	double maxval = minval ;
-	for(int j=1;j<csz+bsz;++j) {
-	  double v = dot(dir,cdirs[j]) ;
-	  if(minval < v) {
-	    minid = j ;
-	    minval = v ;
-	  }
-	  if(maxval > v) {
-	    maxid = j ;
-	    maxval = v ;
-	  }
-	}
+	int minid = 0, maxid = 0 ;
+        getMaxMinDirections(maxid,minid,dir,cdirs) ;
 	flags[minid] = 1 ;
 	flags[maxid] = 1 ;
-	minid = 0 ;
-	maxid = 0 ;
-	dir = fnormal[lower[cc][i]] ;
-	minval = dot(dir,cdirs[0]) ;
-	maxval = minval ;
-	for(int j=1;j<csz+bsz;++j) {
-	  double v = dot(dir,cdirs[j]) ;
-	  if(minval < v) {
-	    minid = j ;
-	    minval = v ;
-	  }
-	  if(maxval > v) {
-	    maxid = j ;
-	    maxval = v ;
-	  }
-	}
+	dir = fnormaldata[fg2l[lower[cc][i]]] ;
+        getMaxMinDirections(maxid,minid,dir,cdirs) ;
 	flags[minid] = 1 ;
 	flags[maxid] = 1 ;
       }
       int usz = upper[cc].size() ;
       for(int i=0;i<usz;++i) {
-	vector3d<double>  dir = fcenter[upper[cc][i]] -ccent;
+	vector3d<double>  dir = fcenterdata[fg2l[upper[cc][i]]] -ccent;
 	dir *= 1./norm(dir) ;
-	int minid = 0 ;
-	int maxid = 0 ;
-	double minval = dot(dir,cdirs[0]) ;
-	double maxval = minval ;
-	for(int j=1;j<csz+bsz;++j) {
-	  double v = dot(dir,cdirs[j]) ;
-	  if(minval < v) {
-	    minid = j ;
-	    minval = v ;
-	  }
-	  if(maxval > v) {
-	    maxid = j ;
-	    maxval = v ;
-	  }
-	}
+	int minid = 0, maxid = 0 ;
+        getMaxMinDirections(maxid,minid,dir,cdirs) ;
 	flags[minid] = 1 ;
 	flags[maxid] = 1 ;
-	minid = 0 ;
-	maxid = 0 ;
-	dir = fnormal[upper[cc][i]] ;
-	minval = dot(dir,cdirs[0]) ;
-	maxval = minval ;
-	for(int j=1;j<csz+bsz;++j) {
-	  double v = dot(dir,cdirs[j]) ;
-	  if(minval < v) {
-	    minid = j ;
-	    minval = v ;
-	  }
-	  if(maxval > v) {
-	    maxid = j ;
-	    maxval = v ;
-	  }
-	}
+
+	dir = fnormaldata[fg2l[upper[cc][i]]] ;
+        getMaxMinDirections(maxid,minid,dir,cdirs) ;
 	flags[minid] = 1 ;
 	flags[maxid] = 1 ;
       }
 
       for(int i=0;i<bsz;++i) {
-	vector3d<double>  dir = fcenter[boundary_map[cc][i]] -ccent;
+	vector3d<double>  dir = fcenterdata[fg2l[boundary_map[cc][i]]] -ccent;
 	dir *= 1./norm(dir) ;
-	int minid = 0 ;
-	int maxid = 0 ;
-	double minval = dot(dir,cdirs[0]) ;
-	double maxval = minval ;
-	for(int j=1;j<csz+bsz;++j) {
-	  double v = dot(dir,cdirs[j]) ;
-	  if(minval < v) {
-	    minid = j ;
-	    minval = v ;
-	  }
-	  if(maxval > v) {
-	    maxid = j ;
-	    maxval = v ;
-	  }
-	}
+	int minid = 0, maxid = 0 ;
+        getMaxMinDirections(maxid,minid,dir,cdirs) ;
 	flags[minid] = 1 ;
 	flags[maxid] = 1 ;
 	minid = 0 ;
 	maxid = 0 ;
-	dir = fnormal[boundary_map[cc][i]] ;
-	minval = dot(dir,cdirs[0]) ;
-	maxval = minval ;
-	for(int j=1;j<csz+bsz;++j) {
-	  double v = dot(dir,cdirs[i]) ;
-	  if(minval < v) {
-	    minid = j ;
-	    minval = v ;
-	  }
-	  if(maxval > v) {
-	    maxid = j ;
-	    maxval = v ;
-	  }
-	}
+	dir = fnormaldata[fg2l[boundary_map[cc][i]]] ;
+        getMaxMinDirections(maxid,minid,dir,cdirs) ;
 	flags[minid] = 1 ;
 	flags[maxid] = 1 ;
       }
@@ -2341,7 +2263,7 @@ namespace Loci{
       int cnt = 0 ;
       for(int i=0;i<csz;++i)
 	if(flags[i] > 0) {
-	  cellmap.push_back(cellStencil[cc][i]) ;
+          cellStencil[cc][cnt] = cellStencil[cc][i] ;
 	  cnt++ ;
 	}
       sizes[cc] = cnt ;
@@ -2352,7 +2274,7 @@ namespace Loci{
     int cnt = 0 ;
     FORALL(cells,cc) {
       for(int i=0;i<cellStencilFiltered[cc].size();++i) {
-	cellStencilFiltered[cc][i] = cellmap[cnt] ;
+	cellStencilFiltered[cc][i] = cellStencil[cc][i] ; 
 	cnt++ ;
       }
     } ENDFORALL ;
@@ -3460,7 +3382,7 @@ namespace Loci{
       int ckeyspace = cl.getRangeKeySpace() ;
       std::vector<entitySet> cptn = facts.get_init_ptn(ckeyspace) ;
       entitySet volgather = distribute_entitySet(mi->second,cptn) ;
-      dist_expand_entitySet(volgather,domc,cptn) ;
+      volgather = dist_expand_entitySet(volgather,domc,cptn) ;
       volSets.push_back(volgather) ;
     }
 

--- a/src/System/distribute.cc
+++ b/src/System/distribute.cc
@@ -980,11 +980,11 @@ namespace Loci {
     // corresponding processor
     vector<int> send_sizes(ptn.size()) ;
     vector<entitySet> send_data(ptn.size()) ;
-    for(size_t i=0;i < ptn.size();++i)
-      if(recv_req[i*2+0]<=recv_req[i*2+1]) {
+    for(size_t i=0;i < ptn.size();++i) {
+      if(recv_req[i*2+0]<=recv_req[i*2+1]) 
         send_data[i] = inSet & interval(recv_req[i*2+0],recv_req[i*2+1]) ;
-        send_sizes[i] = send_data[i].num_intervals() ;
-      }
+      send_sizes[i] = send_data[i].num_intervals() ;
+    }
 
     // Share the size information with partners
     vector<int> recv_sizes(ptn.size()) ;

--- a/src/include/distribute_container.h
+++ b/src/include/distribute_container.h
@@ -35,6 +35,7 @@
 #include <fact_db.h>
 #include <Map.h>
 #include <multiMap.h>
+#include <store.h>
 #include <distribute_io.h>
 
 namespace Loci {
@@ -240,6 +241,111 @@ namespace Loci {
     FORALL(dom,e) {
       mp.push_back(std::pair<int,int>(e,m[e])) ;
     } ENDFORALL ;
+  }
+
+    // -----------------------------------------------------------------------
+  /// @brief getLocalContextMap returns a global to local mapping that
+  /// can be used to translate global numbers to the local numbering
+  /// provided by a data access gathering set.  The local numbering is just
+  /// the ordering of the data in the get set.
+  ///
+  /// @param [g2l] The resulting global to local map
+  /// @param [get] The sets that each processor will be accessing
+  template<class T> void getLocalContextMap(T &g2l, entitySet get) {
+    int cnt = 0 ;
+    for(size_t i=0;i<get.num_intervals();++i)
+      for(Entity ii=get[i].first;ii<=get[i].second;++ii)
+        g2l[ii] = cnt++ ;
+  }
+
+  // -----------------------------------------------------------------------
+  /// @brief gatherData gathers the distributed data that will be accessed
+  /// by each processor from a store that is partitioned according to ptn,
+  ///
+  /// @param[result] std::vector that will contain the gathered data for
+  /// each processor, this will be ordered as the entitySet provided
+  /// @param[data] The input store container that is distributed across
+  /// processors
+  /// @param[get] The requested set of entities that will be accessed by each
+  /// processor
+  /// @param[ptn] The partition of the data stored in container [data]
+  template <class T>  void gatherData(std::vector<T> &result,
+                                      store<T> &data,
+                                      entitySet get,
+                                      std::vector<entitySet> &ptn) {
+    using std::vector ;
+    { vector<T> tmp(get.size()) ; result.swap(tmp) ;}
+
+    const int r = Loci::MPI_rank ;
+    const int p = Loci::MPI_processes ;
+    FATAL(p!=int(ptn.size())) ;
+
+    vector<entitySet> recv_sets(p) ;
+    for(int i=0;i<p;++i)
+      recv_sets[i] = get&ptn[i] ;
+
+    vector<entitySet> send_sets =
+      transpose_entitySet(recv_sets, MPI_COMM_WORLD) ;
+    int send_sz = 0 ;
+    int reqs = 0 ;
+    for(int i=0;i<p;++i) {
+      send_sz += send_sets[i].size() ;
+      if(i!=r) {
+        if(send_sets[i] != EMPTY)
+          reqs++ ;
+        if(recv_sets[i] != EMPTY)
+          reqs++ ;
+      }
+    }
+    std::vector<T> send_data(send_sz) ;
+    int j = 0 ;
+    for(int i=0;i<p;++i) {
+      FORALL(send_sets[i],ii) {
+        send_data[j] = data[ii] ;
+        j++ ;
+      } ENDFORALL ;
+    }
+    vector<int> send_offsets(p,0) ;
+    vector<int> recv_offsets(p,0) ;
+    for(int i=1;i<p;++i) {
+      send_offsets[i] = send_offsets[i-1]+send_sets[i-1].size() ;
+      recv_offsets[i] = recv_offsets[i-1]+recv_sets[i-1].size() ;
+    }
+
+    // copy self data first
+    for(size_t i=0;i<send_sets[r].size();++i)
+      result[recv_offsets[r]+i] = send_data[send_offsets[r]+i] ;
+
+    // Single processor we are done
+    if(p == 1)
+      return ;
+    
+    std::vector<MPI_Request> requests(reqs) ;
+    int cnt = 0 ;
+    for(int i=0;i<p;++i)
+      // If I am not recving from myself and I have something to recv
+      if(i!=r && recv_sets[i] != EMPTY) {
+        MPI_Irecv(&result[recv_offsets[i]],
+                  recv_sets[i].size()*sizeof(T),
+                  MPI_BYTE,i,99,MPI_COMM_WORLD,&requests[cnt]) ;
+        cnt++ ;
+      }
+    for(int i=0;i<p;++i)
+      if(i!=r && send_sets[i] != EMPTY) {
+        // If I am not sending to myself and I have something to send
+        MPI_Isend(&send_data[send_offsets[i]],
+                  send_sets[i].size()*sizeof(T),
+                  MPI_BYTE,i,99,MPI_COMM_WORLD,&requests[cnt]) ;
+        cnt++ ;
+      }
+
+    // If this processor does not commuicate we are done
+    if(cnt == 0)
+      return ;
+
+    // otherwise wait for communication to finish
+    vector<MPI_Status> status_list(cnt) ;
+    MPI_Waitall(cnt,&requests[0],&status_list[0]) ;
   }
 
 }


### PR DESCRIPTION
This fixes some issues that were observed testing large production runs using online mesh adaptation and full stencil modes.  Sometime segfaults were observed.  In the process, code to compute grid metrics was restructured to improve scalability.  This code adds some new utility routines to distribute_container.h which is used by the more performant metric computation code.  