### PR TITLE
Update to add conditionals to loci preprocessor

### DIFF
--- a/src/Tools/expr.cc
+++ b/src/Tools/expr.cc
@@ -1569,6 +1569,193 @@ namespace Loci {
     return 0 ;
   }
 
+  int expression::evaluate(const std::map<std::string, int> &varmap) const
+  {
+    std::map<std::string, int>::const_iterator mi;
+    int tmp ;
+    exprList::const_iterator li ;
+
+    switch(op)
+      {
+      case OP_INT:
+        return int_val ;
+      case OP_DOUBLE:
+        return int(real_val) ;
+      case OP_PLUS:
+        tmp = 0 ;
+        for(li=expr_list.begin();li!=expr_list.end();++li) {
+          tmp += (*li)->evaluate(varmap) ;
+        }
+        return tmp ;
+      case OP_MINUS:
+        tmp = 0 ;
+        li = expr_list.begin() ;
+        if(li!=expr_list.end())
+          tmp = (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp -= (*li)->evaluate(varmap) ;
+        }
+        return tmp ;
+      case OP_TIMES:
+        tmp = 1 ;
+        for(li=expr_list.begin();li!=expr_list.end();++li) {
+          tmp *= (*li)->evaluate(varmap) ;
+        }
+        return tmp ;
+      case OP_DIVIDE:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp /= (*li)->evaluate(varmap) ;
+        }
+        return tmp ;
+      case OP_LT:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp < (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_GT:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp > (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_GE:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp >= (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_LE:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp <= (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_EQUAL:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp == (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_NOT_EQUAL:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp != (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_LOGICAL_AND:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp && (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_LOGICAL_OR:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp || (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_OR:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp | (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_AND:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp & (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_EXOR:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp ^ (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_SHIFT_RIGHT:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp >> (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_SHIFT_LEFT:
+        li = expr_list.begin() ;
+        tmp = 1 ;
+        if(li!=expr_list.end())
+          tmp =  (*li)->evaluate(varmap) ;
+        for(++li;li!=expr_list.end();++li) {
+          tmp = (tmp << (*li)->evaluate(varmap)) ;
+        }
+        return tmp ;
+      case OP_FUNC:
+        if(name == "defined") {
+          li = expr_list.begin() ;
+          if((*li)->op != OP_NAME)
+            throw exprError("syntax error","defined expecting name",ERR_UNDEF) ;
+          return (varmap.find((*li)->name) != varmap.end()) ;
+        } else {
+          string msg = "in expression evaluation, function " + name
+            + " has no definition";
+          throw exprError("Undefined",msg,ERR_UNDEF) ;
+        }
+      case OP_NAME:
+        mi = varmap.find(name) ;
+        if(mi != varmap.end()) {
+          return mi->second ;
+        } else {
+          string msg = "in expression evaluation, variable " + name
+            + " has no definition";
+          throw exprError("Undefined",msg,ERR_UNDEF) ;
+        }
+      default:
+        throw exprError("Undefined","operation not defined in evaluate()",ERR_UNDEF) ;
+        return 0 ;
+      }
+
+    return 0 ;
+  }
+
 
   exprP const_group(exprP p) {
     exprList lgroup,lmgroup ;

--- a/src/include/Tools/expr.h
+++ b/src/include/Tools/expr.h
@@ -222,6 +222,7 @@ namespace Loci {
 
     void Print(std::ostream &s) const ;
     double evaluate(const std::map<std::string,double> &varmap) const;
+    int evaluate(const std::map<std::string,int> & varmap) const ;
     exprP simplify() const ; // Simplify the expression
     exprP substitute(exprP s, exprP r) const ; // Substitute all s for r
     exprP derivative(std::string var) const ; // symbolic differentation

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -2852,6 +2852,38 @@ void parseFile::setup_Rule(std::ostream &outputFile, const string &comment) {
 }
 
 
+void parseFile::skip_lpp_conditional(std::ostream &outputFile) {
+  int nesting = 1 ;
+  char c ;
+
+  bool elseblock = false ;
+  do {
+    killsp() ;
+    while(is.peek() != '$') {
+      is.get(c) ;
+      killsp() ;
+      if(is.eof())
+        throw parseError("Unexpected EOF processing $if directives") ;
+    }
+    is.get(c) ;
+    if(is_name(is)) {
+      string key = get_name(is) ;
+      if((nesting == 1 && key == "else") || key == "endif") {
+        nesting-- ;
+      }
+      if(key == "if" || key == "ifdef" || key == "ifndef") {
+        nesting++ ;
+      }
+      elseblock = (key == "else") ;
+    }
+    killsp() ;
+  } while(nesting != 0) ;
+  if(elseblock) {
+    outputFile << "// $else block output" << endl;
+  }
+}
+
+
 void parseFile::processFile(string file, ostream &outputFile,
 			    parseSharedInfo &parseInfo,int level) {
   bool error = false ;
@@ -2900,6 +2932,9 @@ void parseFile::processFile(string file, ostream &outputFile,
     outputFile << "extern const char *" << docvarname << "[] ;" << endl ;
   }
   syncFile(outputFile) ;
+  bool mapset = false ;
+  std::map<std::string,int> systemvarmap ;
+    
   do {
     string comment = killspout(outputFile) ;
     //    cout << "comment:"<< comment << endl ;
@@ -2958,7 +2993,67 @@ void parseFile::processFile(string file, ostream &outputFile,
             } else {
 	      outputFile << "//$include \"" << newfile << '"' << endl ;
 	    }
+          } else if(key == "define") {
+            killsp() ;
+            if(!is_name(is))
+              throw parseError("syntax error parsing $define") ;
+            string var = get_name(is) ;
+            killsp() ;
+            string val ;
+            if(is_string(is))
+              val = get_string(is) ;
+            setSystemVar(var,val) ;
+            mapset = false ;
+            outputFile << "// $define " << var << " \"" << val <<"\"" << endl ;
+          } else if(key == "if" || key == "ifdef" || key == "ifndef") {
+            killsp() ;
+            if(key == "ifdef" && !is_name(is))
+              throw parseError("syntax error parsing $ifdef") ;
+            if(key == "ifndef" && !is_name(is))
+              throw parseError("syntax error parsing $ifndef") ;
+            bool check = false ;
+            string var ;
+            if(key == "ifdef") {
+              var = get_name(is) ;
+              check = checkSystemVar(var) ;
+            } else if(key == "ifndef") {
+              var = get_name(is) ;
+              check = !checkSystemVar(var) ;
+            } else {
+              while(is.peek() != '\n' && is.peek() != '\r') {
+                is.get(c) ;
+                if(is.eof())
+                  break ;
+                var += c ;
+              }
+              exprP C = expression::create(var) ;
+              if(!mapset)
+                evalSystemVars(systemvarmap) ;
+              mapset = true ;
+              check = C->evaluate(systemvarmap);
+            }
+
+            if(!check) {
+              // if check not true, parse forward until else or endif
+              // keeping track of nesting
+              skip_lpp_conditional(outputFile) ;
+            } else {
+              outputFile << "// $" << key << " " << var << " true" <<endl ;
+            }
+              syncFile(outputFile) ;
+              
+          } else if(key == "else") {
+            killsp() ;
+            // We got to the else which means the first part was true, so
+            // skip nested part
+            skip_lpp_conditional(outputFile) ;
             
+            syncFile(outputFile) ;
+
+          } else if(key == "endif") {
+            killsp() ;
+            outputFile << "// $endif"<< endl  ;
+            syncFile(outputFile) ;
           } else {
             throw parseError("syntax error: unknown key") ;
           }

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -2998,10 +2998,19 @@ void parseFile::processFile(string file, ostream &outputFile,
             if(!is_name(is))
               throw parseError("syntax error parsing $define") ;
             string var = get_name(is) ;
-            killsp() ;
+            while(is.peek() == ' ' || is.peek() == '\t')
+              is.get(c) ;
             string val ;
-            if(is_string(is))
+            if(is_string(is)) {
               val = get_string(is) ;
+            }
+            
+            while((is.peek() == ' ') || (is.peek() == '\t')) {
+              is.get(c) ;
+            }
+            if(is.peek() != '\r' && is.peek() != '\n')
+              throw parseError("extraneous text after $define statement") ;
+            
             setSystemVar(var,val) ;
             mapset = false ;
             outputFile << "// $define " << var << " \"" << val <<"\"" << endl ;
@@ -3024,13 +3033,37 @@ void parseFile::processFile(string file, ostream &outputFile,
                 is.get(c) ;
                 if(is.eof())
                   break ;
-                var += c ;
+                // check if it might be a continuation line
+                if(c == '\\') {
+                  // it is continuation line, so eat \n \r characters
+                  if(is.peek() == '\n' || is.peek() == '\r') {
+                    is.get(c) ;
+                    if(c == '\n') {
+                      line_no++ ;
+                    } else {
+                      // Handle case of \r\n
+                      if(is.peek() == '\n') {
+                        is.get(c) ;
+                        line_no++ ;
+                      }
+                    }
+                  } else // otherwise add \ to string
+                    var += '\\' ;
+                } else { // not part of continuation line, add to expression
+                  var += c ;
+                }
+
               }
-              exprP C = expression::create(var) ;
-              if(!mapset)
-                evalSystemVars(systemvarmap) ;
-              mapset = true ;
-              check = C->evaluate(systemvarmap);
+              try {
+                exprP C = expression::create(var) ;
+                if(!mapset)
+                  evalSystemVars(systemvarmap) ;
+                mapset = true ;
+                check = C->evaluate(systemvarmap);
+              } catch(exprError &err) {
+                err.Print(cerr) ;
+                throw parseError("syntax error parsing $if expression") ;
+              }
             }
 
             if(!check) {

--- a/src/lpp/lpp.h
+++ b/src/lpp/lpp.h
@@ -150,6 +150,7 @@ class parseFile {
   void setup_Rule(std::ostream &outputFile,const std::string &comment) ;
   void setup_cudaRule(std::ostream &outputFile,const std::string &comment) ;
 
+  void skip_lpp_conditional(std::ostream &outputFile) ;
   void setup_Test(std::ostream &outputFile) ;
 public:
   parseFile() {
@@ -180,5 +181,11 @@ public:
 } ;
 
 extern std::list<std::string> include_dirs ;
+
+void setSystemVar(const std::string &var, const std::string &val) ;
+bool checkSystemVar(const std::string &var) ;
+std::string getSystemVar(const std::string &var) ;
+void evalSystemVars(std::map<std::string,int> &varmap) ;
+
 
 #endif

--- a/src/lpp/main.cc
+++ b/src/lpp/main.cc
@@ -39,6 +39,54 @@ namespace {
   }
 }
 
+
+/// Storage for system variables
+std::map<std::string,std::string> lpp_vars ;
+
+// --------------------------------------------------------------------------
+/// @brief setSystemVar() function to set system variable value in database
+/// @param [var] - input variable to set
+/// @param [val] - input value to assign to variable, replaces previous
+/// definition of variable, or creates new variable if one doesn't exist
+void setSystemVar(const std::string &var, const std::string &val) {
+  lpp_vars[var] = val ;
+}
+
+// --------------------------------------------------------------------------
+/// @brief checkSystemVar() returns true if provided variable exists
+/// @param [var] - input variable
+/// @returns boolean indicating existence of variable
+bool checkSystemVar(const std::string &var) {
+  return lpp_vars.find(var) != lpp_vars.end() ;
+}
+
+// --------------------------------------------------------------------------
+/// @brief getSystemVar() returns value assigned to provided system variable
+/// @param [var] - input variable
+/// @returns string contained in the database for [var]
+std::string getSystemVar(const std::string &var) {
+  auto fp = lpp_vars.find(var) ;
+  if(fp != lpp_vars.end())
+    return fp->second ;
+  return "" ;
+}
+
+
+// --------------------------------------------------------------------------
+/// @brief evalSystemVar() evaluates system variables as integers
+/// @param [varmap] - output map giving integer values to every variable
+void evalSystemVars(std::map<string,int> &varmap) {
+  for(auto ip=lpp_vars.begin();ip!=lpp_vars.end();++ip) {
+    string name = ip->first ;
+    int val = 0 ;
+    if(ip->second.size() > 0 && ip->second[0]>='0' && ip->second[0]<='9') {
+      val = atoi(ip->second.c_str()) ;
+    }
+    varmap[name] = val ;
+  }
+}
+    
+
 void Usage(int argc, char *argv[]) {
   cerr << "Loci Pre-Processor Usage:" << endl ;
   cerr << argv[0] <<" -I<dir> filename.loci -o filename.cc" << endl ;
@@ -47,8 +95,19 @@ void Usage(int argc, char *argv[]) {
 
 bool no_cuda = false ;
 
-int main(int argc, char *argv[]) {
+// --------------------------------------------------------------------------
+/// @brief intToString() is a utility routine for converting an integer to
+/// its string representation
+/// @param [val] input integer
+/// @returns string representation of [val]
 
+std::string intToString(int val) {
+  std::ostringstream oss ;
+  oss << val ;
+  return std::string(oss.str()) ;
+}
+
+int main(int argc, char *argv[]) {
 
   bool file_given = false;
   string filename ;
@@ -74,7 +133,15 @@ int main(int argc, char *argv[]) {
       } else if(argv[i][1] == 'V') {
         cout << "Loci version: " << version() << endl ;
       } else if(argv[i][1] == 'D') {
-	// ignore this option
+        string var ;
+        string val ;
+        for(int j=2;argv[i][j] != '\0';++j) {
+          if(argv[i][j] == '=') {
+            val = string(&argv[i][j+1]) ;
+          }
+          var += argv[i][j] ;
+        }
+        setSystemVar(var,val) ;
       } else {
 	cerr << "Warning: Unknown option " << argv[i] << endl ;
 	//	exit(-1) ;
@@ -88,6 +155,10 @@ int main(int argc, char *argv[]) {
       file_given = true ;
     }
   }
+  // Add system version variables to system vars
+  setSystemVar("LOCI_VERSION_MAJOR",intToString(LOCI_VERSION_MAJOR)) ;
+  setSystemVar("LOCI_VERSION_MINOR",intToString(LOCI_VERSION_MINOR)) ;
+
   if(!file_given) {
     cerr << "no filename" << endl ;
     Usage(argc,argv) ;


### PR DESCRIPTION
It is not possible to use c preprocessor features to disable compilation of Loci preprocessor code as lpp runs before the C preprocessor.  This makes it impossible to implement guards such as

\#if LOCI_VERSION_MAJOR <= 4 && LOCI_VERSION_MINOR <=1
\#else
\#endif

This update adds the same features to lpp allowing $if, $ifdef $ifndef $else $endif and $define so that it will be possible to write code to conform to changing Loci versions.  It also automatically defined LOCI_VERSION_MAJOR and LOCI_VERSION_MINOR to be used for controlling specifications according the the version of Loci you are compiling with.

