### PR TITLE
Add initial CI pipeline

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-quicktest.yaml
+++ b/.github/workflows/build-quicktest.yaml
@@ -73,19 +73,17 @@ jobs:
         spack develop --no-clone --path $(pwd) loci@develop
         spack concretize
 
-    - name: Compile and install Loci
+    - name: Compile, test, and install Loci
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
-        spack install
+        spack install --test=root
 
-    - name: Run quickTest
-      shell: spack-bash {0}
-      run: |
-        spack env activate -p loci_build
-        mpic++ --version
-        mpic++ -show
-        make test
+    # - name: Run quickTest
+    #   shell: spack-bash {0}
+    #   run: |
+    #     spack env activate -p loci_build
+    #     make test
 
     - name: Get build stage output directory
       if: ${{ failure() }}

--- a/.github/workflows/build-quicktest.yaml
+++ b/.github/workflows/build-quicktest.yaml
@@ -79,6 +79,14 @@ jobs:
         spack env activate -p loci_build
         spack install
 
+    - name: Run quickTest
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        mpic++ --version
+        mpic++ -show
+        make test
+
     - name: Get build stage output directory
       if: ${{ failure() }}
       shell: spack-bash {0}
@@ -91,17 +99,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: buildlog-${{ inputs.partitioner }}-${{ inputs.compiler }}-${{ inputs.mpi }}-${{ inputs.runs-on }}
-        path: ${{ env.stageOutputDir }}
+        path: |
+          ${{ env.stageOutputDir }}
+          OBJ/*.conf
         if-no-files-found: ignore
-
-    - name: Run quickTest
-      shell: spack-bash {0}
-      run: |
-        spack env activate -p loci_build
-        cat OBJ/Loci.conf
-        cat OBJ/sys.conf
-        cat OBJ/comp.conf
-        mpic++ --version
-        mpic++ -show
-        cd OBJ/
-        make test

--- a/.github/workflows/build-quicktest.yaml
+++ b/.github/workflows/build-quicktest.yaml
@@ -77,7 +77,8 @@ jobs:
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
-        spack install --test=root
+        sed -i "s/MPINUMPROC=3/MPINUMPROC=1/g" quickTest/test.conf
+        spack install --test=root --dirty
 
     # - name: Run quickTest
     #   shell: spack-bash {0}

--- a/.github/workflows/build-quicktest.yaml
+++ b/.github/workflows/build-quicktest.yaml
@@ -18,7 +18,7 @@ on:
         type: string
       mpi:
         default: 'openmpi'
-        required: true
+        required: false
         type: string
 
 jobs:

--- a/.github/workflows/build-quicktest.yaml
+++ b/.github/workflows/build-quicktest.yaml
@@ -1,0 +1,92 @@
+name: Build Loci and run quickTest
+
+on:
+  # Reusable workflow for use in CI
+  workflow_call:
+    inputs:
+      runs-on:
+        default: 'ubuntu-24.04'
+        required: false
+        type: string
+      partitioner:
+        default: 'parmetis'
+        required: false
+        type: string
+      compiler:
+        default: 'gcc_all'
+        required: false
+        type: string
+      mpi:
+        default: 'openmpi'
+        required: true
+        type: string
+
+jobs:
+  build-loci:
+    name: Test with ${{ inputs.partitioner }} partitioner, ${{ inputs.compiler }}, and ${{ inputs.mpi }} on ${{ inputs.runs-on }}
+    runs-on: ${{ inputs.runs-on }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Spack
+      uses: spack/setup-spack@v2
+      with:
+        ref: develop      # Spack version (examples: develop, releases/v0.23)
+        color: true       # Force color output (SPACK_COLOR=always)
+        path: spack       # Where to clone Spack
+
+    - name: Find built-in compilers
+      run: spack compiler find
+
+    - name: Set up a Spack environment
+      shell: spack-bash {0}
+      run: |
+        spack env create loci_build
+        spack env activate -p loci_build
+        spack config add -f .spack/mirrors.yaml
+        spack config add -f .spack/repos.yaml
+        spack config add -f .spack/toolchains.yaml
+        spack repo update
+
+    - name: Concretize the dependencies (serial Loci)
+      if: ${{ inputs.mpi == 'none' }}
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        spack add loci@develop +debug -petsc \
+          -mpi %${{ inputs.compiler }}
+        spack develop --no-clone --path $(pwd) loci@develop
+        spack concretize
+
+    - name: Concretize the dependencies (parallel Loci)
+      if: ${{ inputs.mpi != 'none' }}
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        spack add loci@develop +debug +petsc \
+          partitioner=${{ inputs.partitioner }} \
+          %${{ inputs.compiler }} ^${{ inputs.mpi }} %${{ inputs.compiler }}
+        spack develop --no-clone --path $(pwd) loci@develop
+        spack concretize
+
+    - name: Compile and install Loci
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        spack install
+
+    - name: Run quickTest
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        cat OBJ/Loci.conf
+        cat OBJ/sys.conf
+        cat OBJ/comp.conf
+        mpic++ --version
+        mpic++ -show
+        cd OBJ/
+        make test

--- a/.github/workflows/build-quicktest.yaml
+++ b/.github/workflows/build-quicktest.yaml
@@ -79,6 +79,21 @@ jobs:
         spack env activate -p loci_build
         spack install
 
+    - name: Get build stage output directory
+      if: ${{ failure() }}
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        echo "stageOutputDir=`spack location -s loci`" >> $GITHUB_ENV
+
+    - name: Upload build stage output files
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: buildlog-${{ inputs.partitioner }}-${{ inputs.compiler }}-${{ inputs.mpi }}-${{ inputs.runs-on }}
+        path: ${{ env.stageOutputDir }}
+        if-no-files-found: ignore
+
     - name: Run quickTest
       shell: spack-bash {0}
       run: |

--- a/.github/workflows/buildcache.yaml
+++ b/.github/workflows/buildcache.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, macos-14]
+        runs-on: [ubuntu-24.04] #, macos-14]
     permissions:
       packages: write
 
@@ -36,7 +36,9 @@ jobs:
       run: spack -e .spack/ compiler find
 
     - name: Concretize
-      run: spack -e .spack/ concretize
+      run: |
+        spack -e .spack/ mirror remove local-buildcache
+        spack -e .spack/ concretize
 
     - name: Install
       run: spack -e .spack/ install

--- a/.github/workflows/buildcache.yaml
+++ b/.github/workflows/buildcache.yaml
@@ -47,5 +47,9 @@ jobs:
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: spack -e .spack/ buildcache push --update-index local-buildcache
+      run: |
+        spack -e .spack/ mirror add --oci-username-variable GITHUB_USER \
+          --oci-password-variable GITHUB_TOKEN \
+          local-buildcache oci://ghcr.io/EdwardALuke/spack-buildcache
+        spack -e .spack/ buildcache push --update-index local-buildcache
       if: ${{ !cancelled() }}

--- a/.github/workflows/buildcache.yaml
+++ b/.github/workflows/buildcache.yaml
@@ -1,10 +1,13 @@
 name: Build and Cache Dependencies
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  # Allow manually triggering the workflow
+  workflow_dispatch:
+  # Run on pull requests when buildcache.yaml or spack.yaml are modified
+  # pull_request:
+  #   paths:
+  #     - .github/workflows/buildcache.yaml
+  #     - .spack/spack.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/buildcache.yaml
+++ b/.github/workflows/buildcache.yaml
@@ -36,9 +36,7 @@ jobs:
       run: spack -e .spack/ compiler find
 
     - name: Concretize
-      run: |
-        spack -e .spack/ mirror remove local-buildcache
-        spack -e .spack/ concretize
+      run: spack -e .spack/ concretize
 
     - name: Install
       run: spack -e .spack/ install
@@ -47,9 +45,5 @@ jobs:
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        spack -e .spack/ mirror add --oci-username-variable GITHUB_USER \
-          --oci-password-variable GITHUB_TOKEN \
-          local-buildcache oci://ghcr.io/EdwardALuke/spack-buildcache
-        spack -e .spack/ buildcache push --update-index local-buildcache
+      run: spack -e .spack/ buildcache push --update-index local-buildcache
       if: ${{ !cancelled() }}

--- a/.github/workflows/buildcache.yaml
+++ b/.github/workflows/buildcache.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup Spack
       uses: spack/setup-spack@v2

--- a/.github/workflows/buildcache.yaml
+++ b/.github/workflows/buildcache.yaml
@@ -1,0 +1,49 @@
+name: Build and Cache Dependencies
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-deps:
+    name: Build dependencies on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-24.04, macos-14]
+    permissions:
+      packages: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Spack
+      uses: spack/setup-spack@v2
+      with:
+        ref: develop      # Spack version (examples: develop, releases/v0.23)
+        color: true       # Force color output (SPACK_COLOR=always)
+        path: spack       # Where to clone Spack
+
+    - name: Find built-in compilers
+      run: spack -e .spack/ compiler find
+
+    - name: Concretize
+      run: spack -e .spack/ concretize
+
+    - name: Install
+      run: spack -e .spack/ install
+
+    - name: Push packages and update index
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: spack -e .spack/ buildcache push --update-index local-buildcache
+      if: ${{ !cancelled() }}

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -27,12 +27,12 @@ jobs:
         partitioner: [space-filling, scotch, parmetis]
         compiler: [gcc_all, llvm_gfortran]
         mpi: [none, mpich, openmpi] # mvapich2,
-    # Don't run partitioner variations on serial builds
-    exclude:
-      - mpi: none
-        partitioner: scotch
-      - mpi: none
-        partitioner: parmetis
+        # Don't run partitioner variations on serial builds
+        exclude:
+          - mpi: none
+            partitioner: scotch
+          - mpi: none
+            partitioner: parmetis
     uses: ./.github/workflows/build-quicktest.yaml
     with:
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -1,0 +1,41 @@
+name: Full Test Matrix
+
+on:
+  # Allow manually triggering the workflow
+  workflow_dispatch:
+  # push:
+  #   # Build on tags that look like releases
+  #   tags:
+  #     - v*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Many color libraries just need this variable to be set to any value.
+  # Set it to 3 to support 8-bit color graphics (256 colors per channel)
+  # for libraries that care about the value set.
+  FORCE_COLOR: 3
+
+jobs:
+  full-matrix-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-24.04] #, macos-14]
+        partitioner: [space-filling, scotch, parmetis]
+        compiler: [gcc_all, llvm_gfortran]
+        mpi: [none, mpich, openmpi] # mvapich2,
+    # Don't run partitioner variations on serial builds
+    exclude:
+      - mpi: none
+        partitioner: scotch
+      - mpi: none
+        partitioner: parmetis
+    uses: ./.github/workflows/build-quicktest.yaml
+    with:
+      runs-on: ${{ matrix.runs-on }}
+      partitioner: ${{ matrix.partitioner }}
+      compiler: ${{ matrix.compiler }}
+      mpi: ${{ matrix.mpi }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,16 @@
 name: CI
 
 on:
+  # Allow manually triggering the workflow
+  workflow_dispatch:
   push:
     # Build on tags that look like releases
     tags:
       - v*
-  pull_request:
-    # Build when a pull request targets the dev branch
-    branches:
-      - dev
+  # pull_request:
+  #   # Build when a pull request targets the dev branch
+  #   branches:
+  #     - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +32,13 @@ jobs:
         runs-on: [ubuntu-24.04] #, macos-14]
         partitioner: [space-filling, scotch, parmetis]
         compiler: [gcc_all, llvm_gfortran]
-        mpi: [mpich, openmpi] # mvapich2,
+        mpi: [none, mpich, openmpi] # mvapich2,
+    # Don't run partitioner variations on serial builds
+    exclude:
+      - mpi: none
+        partitioner: scotch
+      - mpi: none
+        partitioner: parmetis
 
     steps:
     - name: Checkout
@@ -58,7 +66,18 @@ jobs:
         spack config add -f .spack/toolchains.yaml
         spack repo update
 
-    - name: Concretize the dependencies
+    - name: Concretize the dependencies (serial Loci)
+      if: ${{ matrix.mpi == 'none' }}
+      shell: spack-bash {0}
+      run: |
+        spack env activate -p loci_build
+        spack add loci@develop +debug -petsc \
+          -mpi %${{ matrix.compiler }}
+        spack develop --no-clone --path $(pwd) loci@develop
+        spack concretize
+
+    - name: Concretize the dependencies (parallel Loci)
+      if: ${{ matrix.mpi != 'none' }}
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,10 @@ env:
 
 jobs:
   build-loci:
-    name: Build Loci on ${{ matrix.runs-on }}
+    name: Test with ${{ matrix.partitioner }} partitioner, ${{ matrix.compiler }}, and ${{ matrix.mpi }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04] #, macos-14]
         partitioner: [space-filling, scotch, parmetis]
@@ -78,4 +78,5 @@ jobs:
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
+        cd OBJ/
         make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
-        spack add loci@develop +petsc +cgns \
+        spack add loci@develop +debug +petsc \
           partitioner=${{ matrix.partitioner }} \
           %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
         spack develop --no-clone --path $(pwd) loci@develop

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,6 @@ name: CI
 on:
   # Allow manually triggering the workflow
   workflow_dispatch:
-  push:
-    # Build on tags that look like releases
-    tags:
-      - v*
   # pull_request:
   #   # Build when a pull request targets the dev branch
   #   branches:
@@ -23,23 +19,6 @@ env:
   FORCE_COLOR: 3
 
 jobs:
-  full-matrix-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ubuntu-24.04] #, macos-14]
-        partitioner: [space-filling, scotch, parmetis]
-        compiler: [gcc_all, llvm_gfortran]
-        mpi: [none, mpich, openmpi] # mvapich2,
-    # Don't run partitioner variations on serial builds
-    exclude:
-      - mpi: none
-        partitioner: scotch
-      - mpi: none
-        partitioner: parmetis
+  run-quicktest:
+    # Default values for all options.
     uses: ./.github/workflows/build-quicktest.yaml
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      partitioner: ${{ matrix.partitioner }}
-      compiler: ${{ matrix.compiler }}
-      mpi: ${{ matrix.mpi }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,11 +56,6 @@ jobs:
         spack config add -f .spack/mirrors.yaml
         spack config add -f .spack/repos.yaml
         spack config add -f .spack/toolchains.yaml
-        echo "Sources for current settings:"
-        spack config blame mirrors
-        spack config blame repos
-        spack config blame toolchains
-        spack repo list
         spack repo update
 
     - name: Concretize the dependencies
@@ -78,9 +73,9 @@ jobs:
       run: |
         spack env activate -p loci_build
         spack install
-        ls OBJ/
 
     - name: Run quickTest
+      shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
         make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,38 +45,27 @@ jobs:
         color: true       # Force color output (SPACK_COLOR=always)
         path: spack       # Where to clone Spack
 
-    - name: Set user scope directory
-      run: |
-        echo "SPACK_DISABLE_LOCAL_CONFIG=" >> $GITHUB_ENV
-        echo "SPACK_USER_CONFIG_PATH=$(pwd)/.spack" >> $GITHUB_ENV
-
-    - name: Set up loci_spack repo
-      shell: spack-bash {0}
-      run: |
-        echo $SPACK_DISABLE_LOCAL_CONFIG
-        echo $SPACK_USER_CONFIG_PATH
-        echo "Check if repos.yaml was modified:"
-        cat ${SPACK_USER_CONFIG_PATH}/repos.yaml
-        echo
-        pwd
-        ls
-        echo "Current scopes:"
-        spack config scopes -p
-        echo "Sources for current settings:"
-        spack config blame toolchains
-        spack config blame mirrors
-        spack mirror list
-        spack config blame repos
-        spack repo list
-        spack repo update
-
     - name: Find built-in compilers
       run: spack compiler find
 
-    - name: Set up Spack environment
+    - name: Set up a Spack environment
       shell: spack-bash {0}
       run: |
         spack env create loci_build
+        spack env activate -p loci_build
+        spack config add -f .spack/mirrors.yaml
+        spack config add -f .spack/repos.yaml
+        spack config add -f .spack/toolchains.yaml
+        echo "Sources for current settings:"
+        spack config blame mirrors
+        spack config blame repos
+        spack config blame toolchains
+        spack repo list
+        spack repo update
+
+    - name: Concretize the dependencies
+      shell: spack-bash {0}
+      run: |
         spack env activate -p loci_build
         spack develop --no-clone --path=$(pwd) loci \
           +hdf5 +petsc +cgns partitioner=${{ matrix.partitioner }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,6 @@ jobs:
         partitioner: [space-filling, scotch, parmetis]
         compiler: [gcc_all, llvm_gfortran]
         mpi: [mpich, openmpi] # mvapich2,
-    env:
-      SPACK_USER_CONFIG_PATH: ".spack"
 
     steps:
     - name: Checkout
@@ -47,16 +45,29 @@ jobs:
         color: true       # Force color output (SPACK_COLOR=always)
         path: spack       # Where to clone Spack
 
-    - name: Undo setting from setup-spack
-      run: echo "SPACK_DISABLE_LOCAL_CONFIG=0" >> $GITHUB_ENV
+    - name: Set user scope directory
+      run: |
+        echo "SPACK_DISABLE_LOCAL_CONFIG=" >> $GITHUB_ENV
+        echo "SPACK_USER_CONFIG_PATH=$(pwd)/.spack" >> $GITHUB_ENV
 
     - name: Set up loci_spack repo
       shell: spack-bash {0}
       run: |
         echo $SPACK_DISABLE_LOCAL_CONFIG
         echo $SPACK_USER_CONFIG_PATH
-        spack repo list
+        echo "Check if repos.yaml was modified:"
+        cat ${SPACK_USER_CONFIG_PATH}/repos.yaml
+        echo
+        pwd
+        ls
+        echo "Current scopes:"
+        spack config scopes -p
+        echo "Sources for current settings:"
+        spack config blame toolchains
+        spack config blame mirrors
         spack mirror list
+        spack config blame repos
+        spack repo list
         spack repo update
 
     - name: Find built-in compilers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,5 +78,10 @@ jobs:
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
+        cat OBJ/Loci.conf
+        cat OBJ/sys.conf
+        cat OBJ/comp.conf
+        mpic++ --version
+        mpic++ -show
         cd OBJ/
         make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    # Build on tags that look like releases
+    tags:
+      - v*
+  pull_request:
+    # Build when a pull request targets the dev branch
+    branches:
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Many color libraries just need this variable to be set to any value.
+  # Set it to 3 to support 8-bit color graphics (256 colors per channel)
+  # for libraries that care about the value set.
+  FORCE_COLOR: 3
+
+jobs:
+  build-loci:
+    name: Build Loci on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: true
+      matrix:
+        runs-on: [ubuntu-24.04] #, macos-14]
+        partitioner: [space-filling, scotch, parmetis]
+        compiler: [gcc_all, llvm_gfortran]
+        mpi: [mpich, openmpi] # mvapich2,
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Spack
+      uses: spack/setup-spack@v2
+      with:
+        ref: develop      # Spack version (examples: develop, releases/v0.23)
+        color: true       # Force color output (SPACK_COLOR=always)
+        path: spack       # Where to clone Spack
+
+    - name: Set up loci_spack repo
+      shell: spack-bash {0}
+      run: |
+        export SPACK_USER_CONFIG_PATH=".spack"
+        spack repo update
+
+    - name: Find built-in compilers
+      run: spack compiler find
+
+    - name: Set up Spack environment
+      shell: spack-bash {0}
+      run: |
+        spack env create loci_build
+        spack env activate -p loci_build
+        spack develop --no-clone --path=. loci \
+          +hdf5 +petsc +cgns partitioner=${{ matrix.partitioner }} \
+          %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
+        spack concretize
+
+    - name: Compile and install Loci
+      shell: spack-bash {0}
+      run: spack install
+
+    - name: Run quickTest
+      run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
         partitioner: [space-filling, scotch, parmetis]
         compiler: [gcc_all, llvm_gfortran]
         mpi: [mpich, openmpi] # mvapich2,
+    env:
+      SPACK_USER_CONFIG_PATH: ".spack"
 
     steps:
     - name: Checkout
@@ -47,9 +49,7 @@ jobs:
 
     - name: Set up loci_spack repo
       shell: spack-bash {0}
-      run: |
-        export SPACK_USER_CONFIG_PATH=".spack"
-        spack repo update
+      run: spack repo update
 
     - name: Find built-in compilers
       run: spack compiler find
@@ -59,7 +59,7 @@ jobs:
       run: |
         spack env create loci_build
         spack env activate -p loci_build
-        spack develop --no-clone --path=. loci \
+        spack develop --no-clone --path=$(pwd) loci \
           +hdf5 +petsc +cgns partitioner=${{ matrix.partitioner }} \
           %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
         spack concretize

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,10 +67,10 @@ jobs:
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
-        spack add loci@develop +hdf5 +petsc +cgns \
+        spack add loci@develop +petsc +cgns \
           partitioner=${{ matrix.partitioner }} \
           %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
-        spack develop loci@develop --no-clone --path $(pwd)
+        spack develop --no-clone --path $(pwd) loci@develop
         spack concretize
 
     - name: Compile and install Loci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,18 +47,13 @@ jobs:
         color: true       # Force color output (SPACK_COLOR=always)
         path: spack       # Where to clone Spack
 
-    - name: Check environment setup
-      shell: spack-bash {0}
-      run: |
-        echo $SPACK_USER_CONFIG_PATH
-        spack repo list
-        spack mirror list
+    - name: Undo setting from setup-spack
+      run: echo "SPACK_DISABLE_LOCAL_CONFIG=0" >> $GITHUB_ENV
 
     - name: Set up loci_spack repo
-      env:
-        SPACK_USER_CONFIG_PATH: ".spack"
       shell: spack-bash {0}
       run: |
+        echo $SPACK_DISABLE_LOCAL_CONFIG
         echo $SPACK_USER_CONFIG_PATH
         spack repo list
         spack mirror list
@@ -72,9 +67,6 @@ jobs:
       run: |
         spack env create loci_build
         spack env activate -p loci_build
-        echo $SPACK_USER_CONFIG_PATH
-        spack repo list
-        spack mirror list
         spack develop --no-clone --path=$(pwd) loci \
           +hdf5 +petsc +cgns partitioner=${{ matrix.partitioner }} \
           %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,22 @@ jobs:
         color: true       # Force color output (SPACK_COLOR=always)
         path: spack       # Where to clone Spack
 
-    - name: Set up loci_spack repo
+    - name: Check environment setup
       shell: spack-bash {0}
-      run: spack repo update
+      run: |
+        echo $SPACK_USER_CONFIG_PATH
+        spack repo list
+        spack mirror list
+
+    - name: Set up loci_spack repo
+      env:
+        SPACK_USER_CONFIG_PATH: ".spack"
+      shell: spack-bash {0}
+      run: |
+        echo $SPACK_USER_CONFIG_PATH
+        spack repo list
+        spack mirror list
+        spack repo update
 
     - name: Find built-in compilers
       run: spack compiler find
@@ -59,6 +72,9 @@ jobs:
       run: |
         spack env create loci_build
         spack env activate -p loci_build
+        echo $SPACK_USER_CONFIG_PATH
+        spack repo list
+        spack mirror list
         spack develop --no-clone --path=$(pwd) loci \
           +hdf5 +petsc +cgns partitioner=${{ matrix.partitioner }} \
           %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
@@ -66,7 +82,12 @@ jobs:
 
     - name: Compile and install Loci
       shell: spack-bash {0}
-      run: spack install
+      run: |
+        spack env activate -p loci_build
+        spack install
+        ls OBJ/
 
     - name: Run quickTest
-      run: make test
+      run: |
+        spack env activate -p loci_build
+        make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,9 +67,10 @@ jobs:
       shell: spack-bash {0}
       run: |
         spack env activate -p loci_build
-        spack develop --no-clone --path=$(pwd) loci \
-          +hdf5 +petsc +cgns partitioner=${{ matrix.partitioner }} \
+        spack add loci@develop +hdf5 +petsc +cgns \
+          partitioner=${{ matrix.partitioner }} \
           %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
+        spack develop loci@develop --no-clone --path $(pwd)
         spack concretize
 
     - name: Compile and install Loci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,7 @@ env:
   FORCE_COLOR: 3
 
 jobs:
-  build-loci:
-    name: Test with ${{ matrix.partitioner }} partitioner, ${{ matrix.compiler }}, and ${{ matrix.mpi }} on ${{ matrix.runs-on }}
-    runs-on: ${{ matrix.runs-on }}
+  full-matrix-test:
     strategy:
       fail-fast: false
       matrix:
@@ -39,68 +37,9 @@ jobs:
         partitioner: scotch
       - mpi: none
         partitioner: parmetis
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Setup Spack
-      uses: spack/setup-spack@v2
-      with:
-        ref: develop      # Spack version (examples: develop, releases/v0.23)
-        color: true       # Force color output (SPACK_COLOR=always)
-        path: spack       # Where to clone Spack
-
-    - name: Find built-in compilers
-      run: spack compiler find
-
-    - name: Set up a Spack environment
-      shell: spack-bash {0}
-      run: |
-        spack env create loci_build
-        spack env activate -p loci_build
-        spack config add -f .spack/mirrors.yaml
-        spack config add -f .spack/repos.yaml
-        spack config add -f .spack/toolchains.yaml
-        spack repo update
-
-    - name: Concretize the dependencies (serial Loci)
-      if: ${{ matrix.mpi == 'none' }}
-      shell: spack-bash {0}
-      run: |
-        spack env activate -p loci_build
-        spack add loci@develop +debug -petsc \
-          -mpi %${{ matrix.compiler }}
-        spack develop --no-clone --path $(pwd) loci@develop
-        spack concretize
-
-    - name: Concretize the dependencies (parallel Loci)
-      if: ${{ matrix.mpi != 'none' }}
-      shell: spack-bash {0}
-      run: |
-        spack env activate -p loci_build
-        spack add loci@develop +debug +petsc \
-          partitioner=${{ matrix.partitioner }} \
-          %${{ matrix.compiler }} ^${{ matrix.mpi }} %${{ matrix.compiler }}
-        spack develop --no-clone --path $(pwd) loci@develop
-        spack concretize
-
-    - name: Compile and install Loci
-      shell: spack-bash {0}
-      run: |
-        spack env activate -p loci_build
-        spack install
-
-    - name: Run quickTest
-      shell: spack-bash {0}
-      run: |
-        spack env activate -p loci_build
-        cat OBJ/Loci.conf
-        cat OBJ/sys.conf
-        cat OBJ/comp.conf
-        mpic++ --version
-        mpic++ -show
-        cd OBJ/
-        make test
+    uses: ./.github/workflows/build-quicktest.yaml
+    with:
+      runs-on: ${{ matrix.runs-on }}
+      partitioner: ${{ matrix.partitioner }}
+      compiler: ${{ matrix.compiler }}
+      mpi: ${{ matrix.mpi }}

--- a/.spack/mirrors.yaml
+++ b/.spack/mirrors.yaml
@@ -1,0 +1,7 @@
+mirrors:
+  local-buildcache:
+    url: oci://ghcr.io/EdwardALuke/spack-buildcache
+    signed: false
+    access_pair:
+      id_variable: GITHUB_USER
+      secret_variable: GITHUB_TOKEN

--- a/.spack/repos.yaml
+++ b/.spack/repos.yaml
@@ -1,4 +1,4 @@
 repos:
-  loci_spack_repo:
+  loci_spack:
     git: https://github.com/TimothyEDawson/loci_spack.git
     branch: automatic-cloning

--- a/.spack/repos.yaml
+++ b/.spack/repos.yaml
@@ -1,0 +1,4 @@
+repos:
+  loci_spack_repo:
+    git: https://github.com/TimothyEDawson/loci_spack.git
+    branch: automatic-cloning

--- a/.spack/spack.yaml
+++ b/.spack/spack.yaml
@@ -6,7 +6,7 @@ spack:
   - compilers: [gcc_all, llvm_gfortran]
   - mpis: [mpich, openmpi] # mvapich2,
 
-  view: loci_view
+  view: false
   specs:
   - autoconf
   - automake
@@ -17,15 +17,15 @@ spack:
   - matrix:
     - - metis
     - [$%compilers]
-  # - matrix:
-  #   - - cgns
-  #     - hdf5 +cxx +fortran +mpi
-  #     - parmetis
-  #     - petsc@3.23.3 ~superlu-dist
-  #     - petsc@3.23.3 ~superlu-dist +ptscotch ~metis
-  #     - scotch+metis~threads
-  #   - [$^mpis]
-  #   - [$%compilers]
+  - matrix:
+    - - cgns
+      - hdf5 +cxx +fortran +mpi
+      - parmetis
+      - petsc@3.23.3 ~superlu-dist
+      - petsc@3.23.3 ~superlu-dist +ptscotch ~metis
+      - scotch+metis~threads
+    - [$^mpis]
+    - [$%compilers]
   concretizer:
     unify: false
 

--- a/.spack/spack.yaml
+++ b/.spack/spack.yaml
@@ -6,11 +6,10 @@ spack:
   - compilers: [gcc_all, llvm_gfortran]
   - mpis: [mpich, openmpi] # mvapich2,
 
-  view: false
+  view: loci_view
   specs:
   - autoconf
   - automake
-  - git
   - cmake
   - matrix:
     - [$mpis]
@@ -18,15 +17,15 @@ spack:
   - matrix:
     - - metis
     - [$%compilers]
-  - matrix:
-    - - cgns
-      - hdf5 +cxx +fortran +mpi
-      - parmetis
-      - petsc@3.23.3 ~superlu-dist
-      - petsc@3.23.3 ~superlu-dist +ptscotch ~metis
-      - scotch+metis~threads
-    - [$^mpis]
-    - [$%compilers]
+  # - matrix:
+  #   - - cgns
+  #     - hdf5 +cxx +fortran +mpi
+  #     - parmetis
+  #     - petsc@3.23.3 ~superlu-dist
+  #     - petsc@3.23.3 ~superlu-dist +ptscotch ~metis
+  #     - scotch+metis~threads
+  #   - [$^mpis]
+  #   - [$%compilers]
   concretizer:
     unify: false
 
@@ -34,13 +33,13 @@ spack:
     install_tree:
       root: .spack/spack_root
       padded_length: 128
-  # mirrors:
-  #   local-buildcache:
-  #     url: oci://ghcr.io/EdwardALuke/spack-buildcache
-  #     signed: false
-  #     access_pair:
-  #       id_variable: GITHUB_USER
-  #       secret_variable: GITHUB_TOKEN
+  mirrors:
+    local-buildcache:
+      url: oci://ghcr.io/EdwardALuke/spack-buildcache
+      signed: false
+      access_pair:
+        id_variable: GITHUB_USER
+        secret_variable: GITHUB_TOKEN
 
   packages:
     gcc:

--- a/.spack/spack.yaml
+++ b/.spack/spack.yaml
@@ -1,6 +1,7 @@
 spack:
   include:
   - toolchains.yaml
+  - mirrors.yaml
 
   definitions:
   - compilers: [gcc_all, llvm_gfortran]
@@ -33,13 +34,6 @@ spack:
     install_tree:
       root: .spack/spack_root
       padded_length: 128
-  mirrors:
-    local-buildcache:
-      url: oci://ghcr.io/EdwardALuke/spack-buildcache
-      signed: false
-      access_pair:
-        id_variable: GITHUB_USER
-        secret_variable: GITHUB_TOKEN
 
   packages:
     gcc:

--- a/.spack/spack.yaml
+++ b/.spack/spack.yaml
@@ -4,7 +4,7 @@ spack:
 
   definitions:
   - compilers: [gcc_all, llvm_gfortran]
-  - mpis: [mpich, mvapich2, openmpi]
+  - mpis: [mpich, openmpi] # mvapich2,
 
   view: false
   specs:
@@ -32,15 +32,15 @@ spack:
 
   config:
     install_tree:
-      root: /opt/spack
+      root: .spack/spack_root
       padded_length: 128
-  mirrors:
-    local-buildcache:
-      url: oci://ghcr.io/EdwardALuke/spack-buildcache
-      signed: false
-      access_pair:
-        id_variable: GITHUB_USER
-        secret_variable: GITHUB_TOKEN
+  # mirrors:
+  #   local-buildcache:
+  #     url: oci://ghcr.io/EdwardALuke/spack-buildcache
+  #     signed: false
+  #     access_pair:
+  #       id_variable: GITHUB_USER
+  #       secret_variable: GITHUB_TOKEN
 
   packages:
     gcc:

--- a/.spack/spack.yaml
+++ b/.spack/spack.yaml
@@ -1,0 +1,51 @@
+spack:
+  include:
+  - toolchains.yaml
+
+  definitions:
+  - compilers: [gcc_all, llvm_gfortran]
+  - mpis: [mpich, mvapich2, openmpi]
+
+  view: false
+  specs:
+  - autoconf
+  - automake
+  - git
+  - cmake
+  - matrix:
+    - [$mpis]
+    - [$%compilers]
+  - matrix:
+    - - metis
+    - [$%compilers]
+  - matrix:
+    - - cgns
+      - hdf5 +cxx +fortran +mpi
+      - parmetis
+      - petsc@3.23.3 ~superlu-dist
+      - petsc@3.23.3 ~superlu-dist +ptscotch ~metis
+      - scotch+metis~threads
+    - [$^mpis]
+    - [$%compilers]
+  concretizer:
+    unify: false
+
+  config:
+    install_tree:
+      root: /opt/spack
+      padded_length: 128
+  mirrors:
+    local-buildcache:
+      url: oci://ghcr.io/EdwardALuke/spack-buildcache
+      signed: false
+      access_pair:
+        id_variable: GITHUB_USER
+        secret_variable: GITHUB_TOKEN
+
+  packages:
+    gcc:
+      externals: []
+    llvm:
+      externals: []
+    all:
+      require: target=x86_64_v3

--- a/.spack/toolchains.yaml
+++ b/.spack/toolchains.yaml
@@ -1,0 +1,15 @@
+toolchains:
+  llvm_gfortran:
+  - spec: "%c=llvm"
+    when: "%c"
+  - spec: "%cxx=llvm"
+    when: "%cxx"
+  - spec: "%fortran=gcc"
+    when: "%fortran"
+  gcc_all:
+  - spec: "%c=gcc"
+    when: "%c"
+  - spec: "%cxx=gcc"
+    when: "%cxx"
+  - spec: "%fortran=gcc"
+    when: "%fortran"


### PR DESCRIPTION
This will add the initial infrastructure for a Github Actions-based CI workflow. The current scope is to build and cache the Loci dependencies, build Loci with different options, and run `make test`. Planned options for the test matrix include:

- Serial build
- Parallel builds with different mesh partitioners (space-filling curve, Parmetis, and PTScotch)
- GNU (gcc) and LLVM (clang) compilers
- Different MPI libraries (Openmpi, mpich, maybe mvapich2)
- Linux (Ubuntu 24.04) and Mac (MacOS 14) operating systems