### PR TITLE
lpp translation of petsc FVMMod interface

### DIFF
--- a/src/FVMMod/petsc.loci
+++ b/src/FVMMod/petsc.loci
@@ -47,7 +47,6 @@ using Loci::pointwise_rule;
 using Loci::unit_rule;
 using Loci::apply_rule;
 using Loci::singleton_rule;
-using Loci::register_rule;
 
 using Loci::entitySet;
 using Loci::sequence;
@@ -72,13 +71,13 @@ $include "FVM.lh"
 #endif
 
 #if PETSC_VERSION_GE(3,15,0)
-  #define LociPetscCall(expr) PetscCall(expr)
+#define LociPetscCall(expr) PetscCall(expr)
 #else
-  #define LociPetscCall(expr) do { PetscErrorCode _ierr = (expr); CHKERRQ(_ierr); } while (0)
+#define LociPetscCall(expr) do { PetscErrorCode _ierr = (expr); CHKERRQ(_ierr); } while (0)
 #endif
 
 #ifndef PETSC_CURRENT
- #define PETSC_CURRENT PETSC_DEFAULT
+#define PETSC_CURRENT PETSC_DEFAULT
 #endif
 
 enum PetscMatrixType {
@@ -224,1376 +223,1266 @@ namespace Petsc {
 
 namespace Loci {
 
-typedef double real;
+  typedef double real;
 
-//-----------------------------------------------------------------------------
-// Wrapper classes for PETSC objects. These have been created primarily to
-// handle memory management.
+  //-----------------------------------------------------------------------------
+  // Wrapper classes for PETSC objects. These have been created primarily to
+  // handle memory management.
 
-class PetscScalarVector {
-private:
-  bool created;
-  mutable Petsc::Vec v;
+  class PetscScalarVector {
+  private:
+    bool created;
+    mutable Petsc::Vec v;
 
-public:
-  PetscScalarVector() : created(false) {}
+  public:
+    PetscScalarVector() : created(false) {}
 
-  ~PetscScalarVector() {
-    if(created) {
+    ~PetscScalarVector() {
+      if(created) {
 #ifdef PETSC_32_API
-      VecDestroy(&v);
+        VecDestroy(&v);
 #else
-      VecDestroy(v);
+        VecDestroy(v);
 #endif
+      }
     }
-  }
 
-  int AssemblyBegin() const {
-    LociPetscCall(VecAssemblyBegin(v));
-    return 0;
-  }
-
-  int AssemblyEnd() const {
-    LociPetscCall(VecAssemblyEnd(v));
-    return 0;
-  }
-
-  int CreateCOO(
-    PetscInt const n, PetscInt const N,
-    PetscCount const ncoo, PetscInt const * coo_i,
-    char const * system_name,
-    char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(VecSetType(v, VECMPI));
-    } else {
-      LociPetscCall(VecSetType(v, VECSEQ));
+    int AssemblyBegin() const {
+      LociPetscCall(VecAssemblyBegin(v));
+      return 0;
     }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
-    LociPetscCall(VecSetFromOptions(v));
-    VecType vec_type;
-    LociPetscCall(VecGetType(v, &vec_type));
-    if(vec_type != nullptr) {
+
+    int AssemblyEnd() const {
+      LociPetscCall(VecAssemblyEnd(v));
+      return 0;
+    }
+
+    int CreateCOO(
+                  PetscInt const n, PetscInt const N,
+                  PetscCount const ncoo, PetscInt const * coo_i,
+                  char const * system_name,
+                  char const * options_prefix
+                  ) {
+      if(created) return 0;
+
+      LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
       if(Loci::MPI_processes > 1) {
-        if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+        LociPetscCall(VecSetType(v, VECMPI));
+      } else {
+        LociPetscCall(VecSetType(v, VECSEQ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
+      LociPetscCall(VecSetFromOptions(v));
+      VecType vec_type;
+      LociPetscCall(VecGetType(v, &vec_type));
+      if(vec_type != nullptr) {
+        if(Loci::MPI_processes > 1) {
+          if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+            if(Loci::MPI_rank == 0) {
+              std::cerr << "PETSc parallel vector type is required for system '"
+                        << system_name << "," << std::endl;
+            }
+            Loci::Abort();
+          }
+        }
+      }
+      LociPetscCall(VecSetSizes(v, n, N));
+      LociPetscCall(VecSetPreallocationCOO(v, ncoo, coo_i));
+
+      created = true;
+      return 0;
+    }
+
+    int Create(
+               PetscInt n, PetscInt N,
+               char const * system_name,
+               char const * options_prefix
+               ) {
+      if(created) return 0;
+
+      LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
+      if(Loci::MPI_processes > 1) {
+        LociPetscCall(VecSetType(v, VECMPI));
+      } else {
+        LociPetscCall(VecSetType(v, VECSEQ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
+      LociPetscCall(VecSetFromOptions(v));
+      VecType vec_type;
+      LociPetscCall(VecGetType(v, &vec_type));
+      if(vec_type != nullptr) {
+        if(Loci::MPI_processes > 1) {
+          if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+            if(Loci::MPI_rank == 0) {
+              std::cerr << "PETSc parallel vector type is required for system '"
+                        << system_name << "," << std::endl;
+            }
+            Loci::Abort();
+          }
+        }
+      }
+      LociPetscCall(VecSetSizes(v, n, N));
+      LociPetscCall(VecSetUp(v));
+
+      created = true;
+      return 0;
+    }
+
+    Petsc::Vec const & Data() const { return v; }
+
+    int GetArray(PetscScalar ** array) const {
+      LociPetscCall(VecGetArray(v, array));
+      return 0;
+    }
+
+    int GetOwnershipRange(PetscInt * low, PetscInt * high) const {
+      LociPetscCall(VecGetOwnershipRange(v, low, high));
+      return 0;
+    }
+
+    int RestoreArray(PetscScalar ** array) const {
+      LociPetscCall(VecRestoreArray(v, array));
+      return 0;
+    }
+
+    int SetValue(PetscInt const index, PetscScalar const * value) const {
+      LociPetscCall(VecSetValues(v, 1, &index, value, INSERT_VALUES));
+      return 0;
+    }
+
+    int SetValue(PetscScalar value) {
+      LociPetscCall(VecSet(v, value));
+      return 0;
+    }
+
+    int SetValuesCOO(PetscScalar const * values) {
+      LociPetscCall(VecSetValuesCOO(v, values, INSERT_VALUES));
+      return 0;
+    }
+
+    int Print(char const * filename) const {
+      PetscViewer viewer;
+      LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
+      LociPetscCall(VecView(v, viewer));
+      LociPetscCall(PetscViewerDestroy(&viewer));
+      return 0;
+    }
+  };
+
+  class PetscBlockedVector {
+  private:
+    bool created;
+    mutable Petsc::Vec v;
+
+  public:
+    PetscBlockedVector() : created(false) {}
+
+    ~PetscBlockedVector() {
+      if(created) {
+#ifdef PETSC_32_API
+        VecDestroy(&v);
+#else
+        VecDestroy(v);
+#endif
+      }
+    }
+
+    int AssemblyBegin() const {
+      LociPetscCall(VecAssemblyBegin(v));
+      return 0;
+    }
+
+    int AssemblyEnd() const {
+      LociPetscCall(VecAssemblyEnd(v));
+      return 0;
+    }
+
+    int CreateCOO(
+                  PetscInt bsz, PetscInt n, PetscInt N,
+                  PetscInt const ncoo, PetscInt const * coo_i,
+                  char const * system_name,
+                  char const * options_prefix
+                  ) {
+      if(created) return 0;
+
+      LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
+      if(Loci::MPI_processes > 1) {
+        LociPetscCall(VecSetType(v, VECMPI));
+      } else {
+        LociPetscCall(VecSetType(v, VECSEQ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
+      LociPetscCall(VecSetFromOptions(v));
+      VecType vec_type;
+      LociPetscCall(VecGetType(v, &vec_type));
+      if(vec_type != nullptr) {
+        if(Loci::MPI_processes > 1) {
+          if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+            if(Loci::MPI_rank == 0) {
+              std::cerr << "PETSc parallel vector type is required for system '"
+                        << system_name << "," << std::endl;
+            }
+            Loci::Abort();
+          }
+        }
+      }
+      LociPetscCall(VecSetSizes(v, n*bsz, N*bsz));
+      LociPetscCall(VecSetBlockSize(v, bsz));
+      LociPetscCall(VecSetPreallocationCOO(v, ncoo, coo_i));
+
+      created = true;
+      return 0;
+    }
+
+    int Create(
+               PetscInt bsz, PetscInt n, PetscInt N,
+               char const * system_name,
+               char const * options_prefix
+               ) {
+      if(created) return 0;
+
+      LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
+      if(Loci::MPI_processes > 1) {
+        LociPetscCall(VecSetType(v, VECMPI));
+      } else {
+        LociPetscCall(VecSetType(v, VECSEQ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
+      LociPetscCall(VecSetFromOptions(v));
+      VecType vec_type;
+      LociPetscCall(VecGetType(v, &vec_type));
+      if(vec_type != nullptr) {
+        if(Loci::MPI_processes > 1) {
+          if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+            if(Loci::MPI_rank == 0) {
+              std::cerr << "PETSc parallel vector type is required for system '"
+                        << system_name << "," << std::endl;
+            }
+            Loci::Abort();
+          }
+        }
+      }
+      LociPetscCall(VecSetSizes(v, n*bsz, N*bsz));
+      LociPetscCall(VecSetBlockSize(v, bsz));
+      LociPetscCall(VecSetUp(v));
+
+      created = true;
+      return 0;
+    }
+
+    Petsc::Vec const & Data() const { return v; }
+
+    int GetArray(PetscScalar ** array) const {
+      LociPetscCall(VecGetArray(v, array));
+      return 0;
+    }
+
+    int GetOwnershipRange(PetscInt * low, PetscInt * high) const {
+      LociPetscCall(VecGetOwnershipRange(v, low, high));
+      return 0;
+    }
+
+    int RestoreArray(PetscScalar ** array) const {
+      LociPetscCall(VecRestoreArray(v, array));
+      return 0;
+    }
+
+    int SetValue(PetscInt const index, PetscScalar const * value) const {
+      LociPetscCall(VecSetValuesBlocked(v, 1, &index, value, INSERT_VALUES));
+      return 0;
+    }
+
+    int SetValue(PetscScalar value) {
+      LociPetscCall(VecSet(v, value));
+      return 0;
+    }
+
+    int SetValuesCOO(PetscScalar const * values) {
+      LociPetscCall(VecSetValuesCOO(v, values, INSERT_VALUES));
+      return 0;
+    }
+
+    int Print(char const * filename) const {
+      PetscViewer viewer;
+      LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
+      LociPetscCall(VecView(v, viewer));
+      LociPetscCall(PetscViewerDestroy(&viewer));
+      return 0;
+    }
+  };
+
+  class PetscScalarMatrix {
+  private:
+    bool created;
+    mutable Petsc::Mat m;
+    PetscMatrixType mtype;
+
+  public:
+    PetscScalarMatrix() : created(false) {}
+
+    ~PetscScalarMatrix() {
+      if(created) {
+#ifdef PETSC_32_API
+        MatDestroy(&m);
+#else
+        MatDestroy(m);
+#endif
+      }
+    }
+
+    int AssemblyBegin() const {
+      LociPetscCall(MatAssemblyBegin(m, MAT_FINAL_ASSEMBLY));
+      return 0;
+    }
+
+    int AssemblyEnd() const {
+      LociPetscCall(MatAssemblyEnd(m, MAT_FINAL_ASSEMBLY));
+      return 0;
+    }
+
+    int CreateCOO(
+                  PetscInt const n, PetscInt const N,
+                  PetscCount const ncoo, PetscInt * coo_i, PetscInt * coo_j,
+                  char const * system_name, char const * options_prefix
+                  ) {
+      if(created) return 0;
+
+      LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
+      if(Loci::MPI_processes > 1) {
+        LociPetscCall(MatSetType(m, MATMPIAIJ));
+      } else {
+        LociPetscCall(MatSetType(m, MATSEQAIJ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
+      LociPetscCall(MatSetFromOptions(m));
+      MatType mat_type;
+      LociPetscCall(MatGetType(m, &mat_type));
+      mtype = PetscGetMatrixType(mat_type);
+      if(Loci::MPI_processes > 1) {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_PAR_SCALAR:
+          break;
+        default:
           if(Loci::MPI_rank == 0) {
-            std::cerr << "PETSc parallel vector type is required for system '"
-              << system_name << "," << std::endl;
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscParScalarMatrixTypes()
+                      << std::endl;
           }
           Loci::Abort();
+          break;
         }
-      }
-    }
-    LociPetscCall(VecSetSizes(v, n, N));
-    LociPetscCall(VecSetPreallocationCOO(v, ncoo, coo_i));
-
-    created = true;
-    return 0;
-  }
-
-  int Create(
-    PetscInt n, PetscInt N,
-    char const * system_name,
-    char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(VecSetType(v, VECMPI));
-    } else {
-      LociPetscCall(VecSetType(v, VECSEQ));
-    }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
-    LociPetscCall(VecSetFromOptions(v));
-    VecType vec_type;
-    LociPetscCall(VecGetType(v, &vec_type));
-    if(vec_type != nullptr) {
-      if(Loci::MPI_processes > 1) {
-        if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+      } else {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+          break;
+        default:
           if(Loci::MPI_rank == 0) {
-            std::cerr << "PETSc parallel vector type is required for system '"
-              << system_name << "," << std::endl;
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscSeqScalarMatrixTypes()
+                      << std::endl;
           }
           Loci::Abort();
+          break;
         }
       }
+      LociPetscCall(MatSetSizes(m, n, n, N, N));
+      LociPetscCall(MatSetPreallocationCOO(m, ncoo, coo_i, coo_j));
+
+      created = true;
+      return 0;
     }
-    LociPetscCall(VecSetSizes(v, n, N));
-    LociPetscCall(VecSetUp(v));
 
-    created = true;
-    return 0;
-  }
+    int Create(
+               PetscInt n, PetscInt N,
+               PetscInt const * dnnz, PetscInt const * onnz,
+               char const * system_name, char const * options_prefix
+               ) {
+      if(created) return 0;
 
-  Petsc::Vec const & Data() const { return v; }
-
-  int GetArray(PetscScalar ** array) const {
-    LociPetscCall(VecGetArray(v, array));
-    return 0;
-  }
-
-  int GetOwnershipRange(PetscInt * low, PetscInt * high) const {
-    LociPetscCall(VecGetOwnershipRange(v, low, high));
-    return 0;
-  }
-
-  int RestoreArray(PetscScalar ** array) const {
-    LociPetscCall(VecRestoreArray(v, array));
-    return 0;
-  }
-
-  int SetValue(PetscInt const index, PetscScalar const * value) const {
-    LociPetscCall(VecSetValues(v, 1, &index, value, INSERT_VALUES));
-    return 0;
-  }
-
-  int SetValue(PetscScalar value) {
-    LociPetscCall(VecSet(v, value));
-    return 0;
-  }
-
-  int SetValuesCOO(PetscScalar const * values) {
-    LociPetscCall(VecSetValuesCOO(v, values, INSERT_VALUES));
-    return 0;
-  }
-
-  int Print(char const * filename) const {
-    PetscViewer viewer;
-    LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
-    LociPetscCall(VecView(v, viewer));
-    LociPetscCall(PetscViewerDestroy(&viewer));
-    return 0;
-  }
-};
-
-class PetscBlockedVector {
-private:
-  bool created;
-  mutable Petsc::Vec v;
-
-public:
-  PetscBlockedVector() : created(false) {}
-
-  ~PetscBlockedVector() {
-    if(created) {
-#ifdef PETSC_32_API
-      VecDestroy(&v);
-#else
-      VecDestroy(v);
-#endif
-    }
-  }
-
-  int AssemblyBegin() const {
-    LociPetscCall(VecAssemblyBegin(v));
-    return 0;
-  }
-
-  int AssemblyEnd() const {
-    LociPetscCall(VecAssemblyEnd(v));
-    return 0;
-  }
-
-  int CreateCOO(
-    PetscInt bsz, PetscInt n, PetscInt N,
-    PetscInt const ncoo, PetscInt * coo_i,
-    char const * system_name,
-    char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(VecSetType(v, VECMPI));
-    } else {
-      LociPetscCall(VecSetType(v, VECSEQ));
-    }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
-    LociPetscCall(VecSetFromOptions(v));
-    VecType vec_type;
-    LociPetscCall(VecGetType(v, &vec_type));
-    if(vec_type != nullptr) {
+      LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
       if(Loci::MPI_processes > 1) {
-        if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+        LociPetscCall(MatSetType(m, MATMPIAIJ));
+      } else {
+        LociPetscCall(MatSetType(m, MATSEQAIJ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
+      LociPetscCall(MatSetFromOptions(m));
+      MatType mat_type;
+      LociPetscCall(MatGetType(m, &mat_type));
+      mtype = PetscGetMatrixType(mat_type);
+      if(Loci::MPI_processes > 1) {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_PAR_SCALAR:
+          break;
+        default:
           if(Loci::MPI_rank == 0) {
-            std::cerr << "PETSc parallel vector type is required for system '"
-              << system_name << "," << std::endl;
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscParScalarMatrixTypes()
+                      << std::endl;
           }
           Loci::Abort();
+          break;
         }
-      }
-    }
-    LociPetscCall(VecSetSizes(v, n*bsz, N*bsz));
-    LociPetscCall(VecSetBlockSize(v, bsz));
-    LociPetscCall(VecSetPreallocationCOO(v, ncoo, coo_i));
-
-    created = true;
-    return 0;
-  }
-
-  int Create(
-    PetscInt bsz, PetscInt n, PetscInt N,
-    char const * system_name,
-    char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(VecCreate(MPI_COMM_WORLD, &v));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(VecSetType(v, VECMPI));
-    } else {
-      LociPetscCall(VecSetType(v, VECSEQ));
-    }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)v, options_prefix));
-    LociPetscCall(VecSetFromOptions(v));
-    VecType vec_type;
-    LociPetscCall(VecGetType(v, &vec_type));
-    if(vec_type != nullptr) {
-      if(Loci::MPI_processes > 1) {
-        if(strncmp(vec_type, VECSEQ, strlen(VECSEQ)) == 0) {
+      } else {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+          break;
+        default:
           if(Loci::MPI_rank == 0) {
-            std::cerr << "PETSc parallel vector type is required for system '"
-              << system_name << "," << std::endl;
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscSeqScalarMatrixTypes()
+                      << std::endl;
           }
           Loci::Abort();
+          break;
         }
       }
-    }
-    LociPetscCall(VecSetSizes(v, n*bsz, N*bsz));
-    LociPetscCall(VecSetBlockSize(v, bsz));
-    LociPetscCall(VecSetUp(v));
-
-    created = true;
-    return 0;
-  }
-
-  Petsc::Vec const & Data() const { return v; }
-
-  int GetArray(PetscScalar ** array) const {
-    LociPetscCall(VecGetArray(v, array));
-    return 0;
-  }
-
-  int GetOwnershipRange(PetscInt * low, PetscInt * high) const {
-    LociPetscCall(VecGetOwnershipRange(v, low, high));
-    return 0;
-  }
-
-  int RestoreArray(PetscScalar ** array) const {
-    LociPetscCall(VecRestoreArray(v, array));
-    return 0;
-  }
-
-  int SetValue(PetscInt const index, PetscScalar const * value) const {
-    LociPetscCall(VecSetValuesBlocked(v, 1, &index, value, INSERT_VALUES));
-    return 0;
-  }
-
-  int SetValue(PetscScalar value) {
-    LociPetscCall(VecSet(v, value));
-    return 0;
-  }
-
-  int SetValuesCOO(PetscScalar const * values) {
-    LociPetscCall(VecSetValuesCOO(v, values, INSERT_VALUES));
-    return 0;
-  }
-
-  int Print(char const * filename) const {
-    PetscViewer viewer;
-    LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
-    LociPetscCall(VecView(v, viewer));
-    LociPetscCall(PetscViewerDestroy(&viewer));
-    return 0;
-  }
-};
-
-class PetscScalarMatrix {
-private:
-  bool created;
-  mutable Petsc::Mat m;
-  PetscMatrixType mtype;
-
-public:
-  PetscScalarMatrix() : created(false) {}
-
-  ~PetscScalarMatrix() {
-    if(created) {
-#ifdef PETSC_32_API
-      MatDestroy(&m);
-#else
-      MatDestroy(m);
-#endif
-    }
-  }
-
-  int AssemblyBegin() const {
-    LociPetscCall(MatAssemblyBegin(m, MAT_FINAL_ASSEMBLY));
-    return 0;
-  }
-
-  int AssemblyEnd() const {
-    LociPetscCall(MatAssemblyEnd(m, MAT_FINAL_ASSEMBLY));
-    return 0;
-  }
-
-  int CreateCOO(
-    PetscInt const n, PetscInt const N,
-    PetscCount const ncoo, PetscInt * coo_i, PetscInt * coo_j,
-    char const * system_name, char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(MatSetType(m, MATMPIAIJ));
-    } else {
-      LociPetscCall(MatSetType(m, MATSEQAIJ));
-    }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
-    LociPetscCall(MatSetFromOptions(m));
-    MatType mat_type;
-    LociPetscCall(MatGetType(m, &mat_type));
-    mtype = PetscGetMatrixType(mat_type);
-    if(Loci::MPI_processes > 1) {
+      LociPetscCall(MatSetSizes(m, n, n, N, N));
       switch(mtype) {
       case PETSC_MATRIX_TYPE_PAR_SCALAR:
+        LociPetscCall(MatMPIAIJSetPreallocation(m, 0, dnnz, 0, onnz));
         break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscParScalarMatrixTypes()
-            << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    } else {
-      switch(mtype) {
       case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+        LociPetscCall(MatSeqAIJSetPreallocation(m, 0, dnnz));
         break;
       default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscSeqScalarMatrixTypes()
-            << std::endl;
-        }
-        Loci::Abort();
         break;
       }
+      LociPetscCall(MatSetUp(m));
+
+      created = true;
+      return 0;
     }
-    LociPetscCall(MatSetSizes(m, n, n, N, N));
-    LociPetscCall(MatSetPreallocationCOO(m, ncoo, coo_i, coo_j));
 
-    created = true;
-    return 0;
-  }
+    Petsc::Mat const & Data() const { return m; }
 
-  int Create(
-    PetscInt n, PetscInt N,
-    PetscInt const * dnnz, PetscInt const * onnz,
-    char const * system_name, char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(MatSetType(m, MATMPIAIJ));
-    } else {
-      LociPetscCall(MatSetType(m, MATSEQAIJ));
+    int GetOwnershipRange(PetscInt * firstRow, PetscInt * lastRow) {
+      LociPetscCall(MatGetOwnershipRange(m, firstRow, lastRow));
+      return 0;
     }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
-    LociPetscCall(MatSetFromOptions(m));
-    MatType mat_type;
-    LociPetscCall(MatGetType(m, &mat_type));
-    mtype = PetscGetMatrixType(mat_type);
-    if(Loci::MPI_processes > 1) {
-      switch(mtype) {
-      case PETSC_MATRIX_TYPE_PAR_SCALAR:
-        break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscParScalarMatrixTypes()
-            << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    } else {
-      switch(mtype) {
-      case PETSC_MATRIX_TYPE_SEQ_SCALAR:
-        break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscSeqScalarMatrixTypes()
-            << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    }
-    LociPetscCall(MatSetSizes(m, n, n, N, N));
-    switch(mtype) {
-    case PETSC_MATRIX_TYPE_PAR_SCALAR:
-      LociPetscCall(MatMPIAIJSetPreallocation(m, 0, dnnz, 0, onnz));
-      break;
-    case PETSC_MATRIX_TYPE_SEQ_SCALAR:
-      LociPetscCall(MatSeqAIJSetPreallocation(m, 0, dnnz));
-      break;
-    default:
-      break;
-    }
-    LociPetscCall(MatSetUp(m));
 
-    created = true;
-    return 0;
-  }
-
-  Petsc::Mat const & Data() const { return m; }
-
-  int GetOwnershipRange(PetscInt * firstRow, PetscInt * lastRow) {
-    LociPetscCall(MatGetOwnershipRange(m, firstRow, lastRow));
-    return 0;
-  }
-
-  int SetRowValues(
-    PetscInt const rowidx, PetscInt const ncols, PetscInt const * colidx,
-    PetscScalar const * colvals
-  ) const {
-    LociPetscCall(MatSetValues(
-      m, 1, &rowidx, ncols, colidx, colvals, INSERT_VALUES
-    ));
-    return 0;
-  }
-
-  int SetValuesCOO(PetscScalar const * values) {
-    LociPetscCall(MatSetValuesCOO(m, values, INSERT_VALUES));
-    return 0;
-  }
-
-  int Print(char const * filename) const {
-    PetscViewer viewer;
-    LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
-    LociPetscCall(MatView(m, viewer));
-    LociPetscCall(PetscViewerDestroy(&viewer));
-    return 0;
-  }
-};
-
-class PetscBlockedMatrix {
-private:
-  bool created;
-  mutable Petsc::Mat m;
-  PetscMatrixType mtype;
-
-public:
-  PetscBlockedMatrix() : created(false) {}
-
-  ~PetscBlockedMatrix() {
-    if(created) {
-#ifdef PETSC_32_API
-      MatDestroy(&m);
-#else
-      MatDestroy(m);
-#endif
-    }
-  }
-
-  int AssemblyBegin() const {
-    LociPetscCall(MatAssemblyBegin(m, MAT_FINAL_ASSEMBLY));
-    return 0;
-  }
-
-  int AssemblyEnd() const {
-    LociPetscCall(MatAssemblyEnd(m, MAT_FINAL_ASSEMBLY));
-    return 0;
-  }
-
-  int CreateCOO(
-    PetscInt bsz, PetscInt n, PetscInt N,
-    PetscInt const ncoo, PetscInt * coo_i, PetscInt * coo_j,
-    char const * system_name, char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(MatSetType(m, MATMPIBAIJ));
-    } else {
-      LociPetscCall(MatSetType(m, MATSEQBAIJ));
-    }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
-    LociPetscCall(MatSetFromOptions(m));
-    MatType mat_type;
-    LociPetscCall(MatGetType(m, &mat_type));
-    mtype = PetscGetMatrixType(mat_type);
-    if(Loci::MPI_processes > 1) {
-      switch(mtype) {
-      case PETSC_MATRIX_TYPE_PAR_SCALAR:
-      case PETSC_MATRIX_TYPE_PAR_BLOCKED:
-        break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscParScalarMatrixTypes()
-            << ", " << PetscParBlockedMatrixTypes() << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    } else {
-      switch(mtype) {
-      case PETSC_MATRIX_TYPE_SEQ_SCALAR:
-      case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
-        break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscSeqScalarMatrixTypes()
-            << ", " << PetscSeqBlockedMatrixTypes() << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    }
-    LociPetscCall(MatSetSizes(m, n*bsz, n*bsz, N*bsz, N*bsz));
-    LociPetscCall(MatSetBlockSize(m, bsz));
-    LociPetscCall(MatSetPreallocationCOO(m, ncoo, coo_i, coo_j));
-
-    created = true;
-    return 0;
-  }
-
-  int Create(
-    PetscInt bsz, PetscInt n, PetscInt N,
-    PetscInt const * dnnz, PetscInt const * onnz,
-    PetscInt const * dnnzs, PetscInt const * onnzs,
-    char const * system_name, char const * options_prefix
-  ) {
-    if(created) return 0;
-
-    LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
-    if(Loci::MPI_processes > 1) {
-      LociPetscCall(MatSetType(m, MATMPIBAIJ));
-    } else {
-      LociPetscCall(MatSetType(m, MATSEQBAIJ));
-    }
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
-    LociPetscCall(MatSetFromOptions(m));
-    MatType mat_type;
-    LociPetscCall(MatGetType(m, &mat_type));
-    mtype = PetscGetMatrixType(mat_type);
-    if(Loci::MPI_processes > 1) {
-      switch(mtype) {
-      case PETSC_MATRIX_TYPE_PAR_SCALAR:
-      case PETSC_MATRIX_TYPE_PAR_BLOCKED:
-        break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscParScalarMatrixTypes()
-            << ", " << PetscParBlockedMatrixTypes() << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    } else {
-      switch(mtype) {
-      case PETSC_MATRIX_TYPE_SEQ_SCALAR:
-      case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
-        break;
-      default:
-        if(Loci::MPI_rank == 0) {
-          std::cerr << "Supported matrix types for system '"
-            << system_name << "' are: " << PetscSeqScalarMatrixTypes()
-            << ", " << PetscSeqBlockedMatrixTypes() << std::endl;
-        }
-        Loci::Abort();
-        break;
-      }
-    }
-    LociPetscCall(MatSetSizes(m, n*bsz, n*bsz, N*bsz, N*bsz));
-    LociPetscCall(MatSetBlockSize(m, bsz));
-    //switch(mtype) {
-    //case PETSC_MATRIX_TYPE_PAR_BLOCKED:
-    //case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
-    //  LociPetscCall(MatSetBlockSize(m, bsz));
-    //  break;
-    //default:
-    //  break;
-    //}
-    switch(mtype) {
-    case PETSC_MATRIX_TYPE_PAR_BLOCKED:
-      LociPetscCall(MatMPIBAIJSetPreallocation(m, bsz, 0, dnnz, 0, onnz));
-      break;
-    case PETSC_MATRIX_TYPE_PAR_SCALAR:
-      LociPetscCall(MatMPIAIJSetPreallocation(m, 0, dnnzs, 0, onnzs));
-      break;
-    case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
-      LociPetscCall(MatSeqBAIJSetPreallocation(m, bsz, 0, dnnz));
-      break;
-    case PETSC_MATRIX_TYPE_SEQ_SCALAR:
-      LociPetscCall(MatSeqAIJSetPreallocation(m, 0, dnnzs));
-      break;
-    default:
-      break;
-    }
-    LociPetscCall(MatSetUp(m));
-
-    created = true;
-    return 0;
-  }
-
-  bool isCreated() const {
-    return created;
-  }
-
-  Petsc::Mat const & Data() const { return m; }
-
-  int GetOwnershipRange(PetscInt * firstRow, PetscInt * lastRow) {
-    LociPetscCall(MatGetOwnershipRange(m, firstRow, lastRow));
-    return 0;
-  }
-
-  int SetRowValues(
-    PetscInt const bsz, PetscInt const rowidx, PetscInt const * rowsidx,
-    PetscInt const ncols, PetscInt const * colidx, PetscInt const * colsidx,
-    PetscScalar const * colvals
-  ) const {
-    switch(mtype) {
-    case PETSC_MATRIX_TYPE_SEQ_SCALAR:
-    case PETSC_MATRIX_TYPE_PAR_SCALAR:
+    int SetRowValues(
+                     PetscInt const rowidx, PetscInt const ncols, PetscInt const * colidx,
+                     PetscScalar const * colvals
+                     ) const {
       LociPetscCall(MatSetValues(
-        m, bsz, rowsidx, ncols*bsz, colsidx, colvals, INSERT_VALUES
-      ));
-      break;
-    case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
-    case PETSC_MATRIX_TYPE_PAR_BLOCKED:
-      LociPetscCall(MatSetValuesBlocked(
-        m, 1, &rowidx, ncols, colidx, colvals, INSERT_VALUES
-      ));
-      break;
-    default:
-      break;
+                                 m, 1, &rowidx, ncols, colidx, colvals, INSERT_VALUES
+                                 ));
+      return 0;
     }
-    return 0;
-  }
 
-  int SetValuesCOO(PetscScalar const * values) {
-    LociPetscCall(MatSetValuesCOO(m, values, INSERT_VALUES));
-    return 0;
-  }
+    int SetValuesCOO(PetscScalar const * values) {
+      LociPetscCall(MatSetValuesCOO(m, values, INSERT_VALUES));
+      return 0;
+    }
 
-  int Print(char const * filename) const {
-    PetscViewer viewer;
-    LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
-    LociPetscCall(MatView(m, viewer));
-    LociPetscCall(PetscViewerDestroy(&viewer));
-    return 0;
-  }
-};
+    int Print(char const * filename) const {
+      PetscViewer viewer;
+      LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
+      LociPetscCall(MatView(m, viewer));
+      LociPetscCall(PetscViewerDestroy(&viewer));
+      return 0;
+    }
+  };
 
-class PetscKspSolver {
-private:
-  bool created;
-  mutable Petsc::KSP ksp;
+  class PetscBlockedMatrix {
+  private:
+    bool created;
+    mutable Petsc::Mat m;
+    PetscMatrixType mtype;
 
-public:
-  PetscKspSolver() : created(false) {}
+  public:
+    PetscBlockedMatrix() : created(false) {}
 
-  ~PetscKspSolver() {
-    if(created) {
+    ~PetscBlockedMatrix() {
+      if(created) {
 #ifdef PETSC_32_API
-      KSPDestroy(&ksp);
+        MatDestroy(&m);
 #else
-      KSPDestroy(ksp);
+        MatDestroy(m);
 #endif
+      }
     }
-  }
 
-  int Create(
-    PetscReal reltol, PetscReal abstol, PetscInt maxit,
-    char const * options_prefix
-  ) {
-    if(created) return 0;
+    int AssemblyBegin() const {
+      LociPetscCall(MatAssemblyBegin(m, MAT_FINAL_ASSEMBLY));
+      return 0;
+    }
 
-    LociPetscCall(KSPCreate(MPI_COMM_WORLD, &ksp));
-    LociPetscCall(KSPSetTolerances(
-      ksp, reltol, abstol, PETSC_CURRENT, maxit
-    ));
-    LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)ksp, options_prefix));
-    LociPetscCall(KSPSetFromOptions(ksp));
+    int AssemblyEnd() const {
+      LociPetscCall(MatAssemblyEnd(m, MAT_FINAL_ASSEMBLY));
+      return 0;
+    }
 
-    created = true;
-    return 0;
-  }
+    int CreateCOO(
+                  PetscInt bsz, PetscInt n, PetscInt N,
+                  PetscInt const ncoo, PetscInt * coo_i, PetscInt * coo_j,
+                  char const * system_name, char const * options_prefix
+                  ) {
+      if(created) return 0;
 
-  int GetIterationNumber() const {
-    int numIterations;
-    LociPetscCall(KSPGetIterationNumber(ksp, &numIterations));
-    return numIterations;
-  }
+      LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
+      if(Loci::MPI_processes > 1) {
+        LociPetscCall(MatSetType(m, MATMPIBAIJ));
+      } else {
+        LociPetscCall(MatSetType(m, MATSEQBAIJ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
+      LociPetscCall(MatSetFromOptions(m));
+      MatType mat_type;
+      LociPetscCall(MatGetType(m, &mat_type));
+      mtype = PetscGetMatrixType(mat_type);
+      if(Loci::MPI_processes > 1) {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_PAR_SCALAR:
+        case PETSC_MATRIX_TYPE_PAR_BLOCKED:
+          break;
+        default:
+          if(Loci::MPI_rank == 0) {
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscParScalarMatrixTypes()
+                      << ", " << PetscParBlockedMatrixTypes() << std::endl;
+          }
+          Loci::Abort();
+          break;
+        }
+      } else {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+        case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
+          break;
+        default:
+          if(Loci::MPI_rank == 0) {
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscSeqScalarMatrixTypes()
+                      << ", " << PetscSeqBlockedMatrixTypes() << std::endl;
+          }
+          Loci::Abort();
+          break;
+        }
+      }
+      LociPetscCall(MatSetSizes(m, n*bsz, n*bsz, N*bsz, N*bsz));
+      LociPetscCall(MatSetBlockSize(m, bsz));
+      LociPetscCall(MatSetPreallocationCOO(m, ncoo, coo_i, coo_j));
 
-  int SetFromOptions() {
-    LociPetscCall(KSPSetFromOptions(ksp));
-    return 0;
-  }
+      created = true;
+      return 0;
+    }
 
-  int SetOperators(PetscBlockedMatrix const & m) const {
-#ifdef PETSC_35_API
-    LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data()));
+    int Create(
+               PetscInt bsz, PetscInt n, PetscInt N,
+               PetscInt const * dnnz, PetscInt const * onnz,
+               PetscInt const * dnnzs, PetscInt const * onnzs,
+               char const * system_name, char const * options_prefix
+               ) {
+      if(created) return 0;
+
+      LociPetscCall(MatCreate(MPI_COMM_WORLD, &m));
+      if(Loci::MPI_processes > 1) {
+        LociPetscCall(MatSetType(m, MATMPIBAIJ));
+      } else {
+        LociPetscCall(MatSetType(m, MATSEQBAIJ));
+      }
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)m, options_prefix));
+      LociPetscCall(MatSetFromOptions(m));
+      MatType mat_type;
+      LociPetscCall(MatGetType(m, &mat_type));
+      mtype = PetscGetMatrixType(mat_type);
+      if(Loci::MPI_processes > 1) {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_PAR_SCALAR:
+        case PETSC_MATRIX_TYPE_PAR_BLOCKED:
+          break;
+        default:
+          if(Loci::MPI_rank == 0) {
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscParScalarMatrixTypes()
+                      << ", " << PetscParBlockedMatrixTypes() << std::endl;
+          }
+          Loci::Abort();
+          break;
+        }
+      } else {
+        switch(mtype) {
+        case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+        case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
+          break;
+        default:
+          if(Loci::MPI_rank == 0) {
+            std::cerr << "Supported matrix types for system '"
+                      << system_name << "' are: " << PetscSeqScalarMatrixTypes()
+                      << ", " << PetscSeqBlockedMatrixTypes() << std::endl;
+          }
+          Loci::Abort();
+          break;
+        }
+      }
+      LociPetscCall(MatSetSizes(m, n*bsz, n*bsz, N*bsz, N*bsz));
+      LociPetscCall(MatSetBlockSize(m, bsz));
+      //switch(mtype) {
+      //case PETSC_MATRIX_TYPE_PAR_BLOCKED:
+      //case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
+      //  LociPetscCall(MatSetBlockSize(m, bsz));
+      //  break;
+      //default:
+      //  break;
+      //}
+      switch(mtype) {
+      case PETSC_MATRIX_TYPE_PAR_BLOCKED:
+        LociPetscCall(MatMPIBAIJSetPreallocation(m, bsz, 0, dnnz, 0, onnz));
+        break;
+      case PETSC_MATRIX_TYPE_PAR_SCALAR:
+        LociPetscCall(MatMPIAIJSetPreallocation(m, 0, dnnzs, 0, onnzs));
+        break;
+      case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
+        LociPetscCall(MatSeqBAIJSetPreallocation(m, bsz, 0, dnnz));
+        break;
+      case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+        LociPetscCall(MatSeqAIJSetPreallocation(m, 0, dnnzs));
+        break;
+      default:
+        break;
+      }
+      LociPetscCall(MatSetUp(m));
+
+      created = true;
+      return 0;
+    }
+
+    bool isCreated() const {
+      return created;
+    }
+
+    Petsc::Mat const & Data() const { return m; }
+
+    int GetOwnershipRange(PetscInt * firstRow, PetscInt * lastRow) {
+      LociPetscCall(MatGetOwnershipRange(m, firstRow, lastRow));
+      return 0;
+    }
+
+    int SetRowValues(
+                     PetscInt const bsz, PetscInt const rowidx, PetscInt const * rowsidx,
+                     PetscInt const ncols, PetscInt const * colidx, PetscInt const * colsidx,
+                     PetscScalar const * colvals
+                     ) const {
+      switch(mtype) {
+      case PETSC_MATRIX_TYPE_SEQ_SCALAR:
+      case PETSC_MATRIX_TYPE_PAR_SCALAR:
+        LociPetscCall(MatSetValues(
+                                   m, bsz, rowsidx, ncols*bsz, colsidx, colvals, INSERT_VALUES
+                                   ));
+        break;
+      case PETSC_MATRIX_TYPE_SEQ_BLOCKED:
+      case PETSC_MATRIX_TYPE_PAR_BLOCKED:
+        LociPetscCall(MatSetValuesBlocked(
+                                          m, 1, &rowidx, ncols, colidx, colvals, INSERT_VALUES
+                                          ));
+        break;
+      default:
+        break;
+      }
+      return 0;
+    }
+
+    int SetValuesCOO(PetscScalar const * values) {
+      LociPetscCall(MatSetValuesCOO(m, values, INSERT_VALUES));
+      return 0;
+    }
+
+    int Print(char const * filename) const {
+      PetscViewer viewer;
+      LociPetscCall(PetscViewerASCIIOpen(MPI_COMM_WORLD, filename, &viewer));
+      LociPetscCall(MatView(m, viewer));
+      LociPetscCall(PetscViewerDestroy(&viewer));
+      return 0;
+    }
+  };
+
+  class PetscKspSolver {
+  private:
+    bool created;
+    mutable Petsc::KSP ksp;
+
+  public:
+    PetscKspSolver() : created(false) {}
+
+    ~PetscKspSolver() {
+      if(created) {
+#ifdef PETSC_32_API
+        KSPDestroy(&ksp);
 #else
-    LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data(),SAME_NONZERO_PATTERN));
+        KSPDestroy(ksp);
 #endif
-    return 0;
-  }
+      }
+    }
 
-  int SetOperators(PetscScalarMatrix const & m) const {
+    int Create(
+               PetscReal reltol, PetscReal abstol, PetscInt maxit,
+               char const * options_prefix
+               ) {
+      if(created) return 0;
+
+      LociPetscCall(KSPCreate(MPI_COMM_WORLD, &ksp));
+      LociPetscCall(KSPSetTolerances(
+                                     ksp, reltol, abstol, PETSC_CURRENT, maxit
+                                     ));
+      LociPetscCall(PetscObjectSetOptionsPrefix((PetscObject)ksp, options_prefix));
+      LociPetscCall(KSPSetFromOptions(ksp));
+
+      created = true;
+      return 0;
+    }
+
+    int GetIterationNumber() const {
+      int numIterations;
+      LociPetscCall(KSPGetIterationNumber(ksp, &numIterations));
+      return numIterations;
+    }
+
+    int SetFromOptions() {
+      LociPetscCall(KSPSetFromOptions(ksp));
+      return 0;
+    }
+
+    int SetOperators(PetscBlockedMatrix const & m) const {
 #ifdef PETSC_35_API
-    LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data()));
+      LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data()));
 #else
-    LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data(),SAME_NONZERO_PATTERN));
+      LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data(),SAME_NONZERO_PATTERN));
 #endif
-    return 0;
+      return 0;
+    }
+
+    int SetOperators(PetscScalarMatrix const & m) const {
+#ifdef PETSC_35_API
+      LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data()));
+#else
+      LociPetscCall(KSPSetOperators(ksp,m.Data(),m.Data(),SAME_NONZERO_PATTERN));
+#endif
+      return 0;
+    }
+
+    int SetTolerances(
+                      real relativeTolerance, real absoluteTolerance, int maxIterations
+                      ) const {
+      LociPetscCall(KSPSetTolerances(
+                                     ksp, relativeTolerance, absoluteTolerance, PETSC_DEFAULT, maxIterations
+                                     ));
+      return 0;
+    }
+
+    int Solve(PetscScalarVector const & b, PetscScalarVector & x) const {
+      LociPetscCall(KSPSolve(ksp, b.Data(), x.Data()));
+      return 0;
+    }
+
+    int Solve(PetscBlockedVector const & b, PetscBlockedVector & x) const {
+      LociPetscCall(KSPSolve(ksp, b.Data(), x.Data()));
+      return 0;
+    }
+  };
+
+  struct PetscScalarSystem {
+    PetscScalarMatrix matrix;
+    PetscScalarVector rhs;
+    PetscKspSolver solver;
+  };
+
+  struct PetscBlockedSystem {
+    PetscBlockedMatrix matrix;
+    PetscBlockedVector rhs;
+    PetscKspSolver solver;
+  };
+
+  //-----------------------------------------------------------------------------
+  // Rules for setting up the PETSC data.
+
+  $type petscDummy param<bool>;
+
+  // Gets the number of cells assigned on all processes. This rule is
+  // definitely not in the Loci spirit since we are collecting data from
+  // other processes.
+  $type petscNumCell param<vector<int> >;
+  $type petscLocalCell  param<entitySet>;
+
+  // cuda device number
+  $type petscDevice blackbox<int>;
+
+  // name of the linear system
+  $type petscMatrixName(X) param<std::string>;
+
+  // petsc options prefix for the linear system
+  $type petscOptionsPrefix(X) param<std::string>;
+
+  // petsc options for various linear systems
+  $type PETSCSolverControls param<options_list>;
+
+  // cell to row map
+  $type petscCellToRow store<int>;
+
+  // diagonal nnz without periodic DoF
+  $type petscNumDiagonal store<int>;
+
+  // diagonal nnz due to owened periodic DoF
+  $type petscNumDiagonalFromPeriodic store<int>;
+
+  // number of diagonal nnz per local cell
+  $type petscDNNZ store<int>;
+
+  // number of off-diagonal nnz per local cell
+  $type petscONNZ store<int>;
+
+  $rule default(petscDummy) {
+    $petscDummy = true;
   }
 
-  int SetTolerances(
-    real relativeTolerance, real absoluteTolerance, int maxIterations
-  ) const {
-    LociPetscCall(KSPSetTolerances(
-      ksp, relativeTolerance, absoluteTolerance, PETSC_DEFAULT, maxIterations
-    ));
-    return 0;
+  $rule default(PETSCSolverControls) {
+    $PETSCSolverControls = options_list();
   }
 
-  int Solve(PetscScalarVector const & b, PetscScalarVector & x) const {
-    LociPetscCall(KSPSolve(ksp, b.Data(), x.Data()));
-    return 0;
+  $type PETSCDeviceDiag param<int> ;
+  $rule default(PETSCDeviceDiag) {
+    $PETSCDeviceDiag = 0 ;
   }
+  $rule blackbox(petscDevice<-PETSCSolverControls,PETSCDeviceDiag), prelude {
 
-  int Solve(PetscBlockedVector const & b, PetscBlockedVector & x) const {
-    LociPetscCall(KSPSolve(ksp, b.Data(), x.Data()));
-    return 0;
-  }
-};
-
-struct PetscScalarSystem {
-  PetscScalarMatrix matrix;
-  PetscScalarVector rhs;
-  PetscKspSolver solver;
-};
-
-struct PetscBlockedSystem {
-  PetscBlockedMatrix matrix;
-  PetscBlockedVector rhs;
-  PetscKspSolver solver;
-};
-
-//-----------------------------------------------------------------------------
-// Rules for setting up the PETSC data.
-
-$type petscDummy param<bool>;
-
-// Gets the number of cells assigned on all processes. This rule is
-// definitely not in the Loci spirit since we are collecting data from
-// other processes.
-$type petscNumCell param<vector<int> >;
-$type petscLocalCell  param<entitySet>;
-
-// cuda device number
-$type petscDevice blackbox<int>;
-
-// name of the linear system
-$type petscMatrixName(X) param<std::string>;
-
-// petsc options prefix for the linear system
-$type petscOptionsPrefix(X) param<std::string>;
-
-// petsc options for various linear systems
-$type PETSCSolverControls param<options_list>;
-
-// cell to row map
-$type petscCellToRow store<int>;
-
-// diagonal nnz without periodic DoF
-$type petscNumDiagonal store<int>;
-
-// diagonal nnz due to owened periodic DoF 
-$type petscNumDiagonalFromPeriodic store<int>;
-
-// number of diagonal nnz per local cell
-$type petscDNNZ store<int>;
-
-// number of off-diagonal nnz per local cell
-$type petscONNZ store<int>;
-
-$rule default(petscDummy) {
-  $petscDummy = true;
-}
-
-$rule default(PETSCSolverControls) {
-  $PETSCSolverControls = options_list();
-}
-
-class PetscDeviceSetup : public blackbox_rule {
-private:
-  const_param<bool> petscDummy;
-  blackbox<int> petscDevice;
-
-public:
-  PetscDeviceSetup() {
-    name_store("petscDevice", petscDevice);
-    name_store("petscDummy", petscDummy);
-
-    output("petscDevice");
-
-    input("petscDummy");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
 #if PETSC_VERSION_GE(3, 18, 0)
-    PetscDeviceContext ctx;
-    PetscDevice dev;
-    PetscDeviceType dev_type;
-    PetscInt dev_id;
+    if(*$PETSCDeviceDiag > 0) {
+      PetscDeviceContext ctx;
+      PetscDevice dev;
+      PetscDeviceType dev_type;
+      PetscInt dev_id;
 
-    PetscDeviceContextGetCurrentContext(&ctx);
-    PetscDeviceContextGetDevice(ctx, &dev);
-    PetscDeviceGetType(dev, &dev_type);
-    PetscDeviceGetDeviceId(dev, &dev_id);
 
-    PetscSynchronizedPrintf(
-      MPI_COMM_WORLD, "MPI rank %d: device=%d, type=%d\n",
-      Loci::MPI_rank, (int)dev_id, (int)dev_type
-    );
-    PetscSynchronizedFlush(MPI_COMM_WORLD, PETSC_STDOUT);
-#else
-    if(Loci::MPI_rank == 0) {
-      std::cout << "Device API not supported in the configured version of PETSc" << std::endl;
+      $[Once] { cerr<< " before get context" << endl ; }
+      PetscDeviceContextGetCurrentContext(&ctx);
+      $[Once] { cerr<< " before get device" << endl ; }
+      PetscDeviceContextGetDevice(ctx, &dev);
+      $[Once] { cerr<< " before get type" << endl ; }
+      PetscDeviceGetType(dev, &dev_type);
+      $[Once] { cerr<< " before get id" << endl ; }
+      PetscDeviceGetDeviceId(dev, &dev_id);
+      $[Once] { cerr<< " finished" << endl ; }
+
+      Loci::debugout << "CUDA: device=" << int(dev_id)
+                     << ", type=" << int(dev_type)
+                     << endl ;
+      PetscSynchronizedPrintf(
+                              MPI_COMM_WORLD,
+                              "MPI rank %d: device=%d, type=%d\n",
+                              Loci::MPI_rank, (int)dev_id, (int)dev_type
+                              );
+      PetscSynchronizedFlush(MPI_COMM_WORLD, PETSC_STDOUT);
     }
 #endif
 
-    *petscDevice = 1;
+    *$petscDevice = 1;
+
+  } ;
+
+
+
+  $type petscCOOAssembly param<int>;
+  $rule default(petscCOOAssembly) {
+    $petscCOOAssembly = 0;
   }
-};
 
-register_rule<PetscDeviceSetup> register_PetscDeviceSetup;
+  $type usePetscCOOAssembly Constraint;
+  $type usePetscAssembly Constraint;
 
-$type petscCOOAssembly param<int>;
-$rule default(petscCOOAssembly) {
-  $petscCOOAssembly = 0;
-}
-
-$type usePetscCOOAssembly Constraint;
-$type usePetscAssembly Constraint;
-
-$rule constraint(usePetscCOOAssembly, usePetscAssembly <- petscCOOAssembly) {
-  if($petscCOOAssembly) {
-    $usePetscCOOAssembly = ~EMPTY;
-    $usePetscAssembly = EMPTY;
-  } else {
-    $usePetscCOOAssembly = EMPTY;
-    $usePetscAssembly = ~EMPTY;
+  $rule constraint(usePetscCOOAssembly, usePetscAssembly <- petscCOOAssembly) {
+    if($petscCOOAssembly) {
+      $usePetscCOOAssembly = ~EMPTY;
+      $usePetscAssembly = EMPTY;
+    } else {
+      $usePetscCOOAssembly = EMPTY;
+      $usePetscAssembly = ~EMPTY;
+    }
   }
-}
 
-struct PetscVecCOO {
-  int size;
-  size_t coo_size;
-  vector<PetscInt> rowidx;
-  vector<Entity> entity;
-};
+  struct PetscVecCOO {
+    int size;
+    size_t coo_size;
+    vector<PetscInt> rowidx;
+    vector<Entity> entity;
+  };
 
-struct PetscVecCoords {
-  PetscCount size;
-  vector<PetscInt> rowidx;
-};
+  struct PetscVecCoords {
+    PetscCount size;
+    vector<PetscInt> rowidx;
+  };
 
-struct PetscVecEntities {
-  size_t size;
-  vector<Entity> entity;
-};
+  struct PetscVecEntities {
+    size_t size;
+    vector<Entity> entity;
+  };
 
-struct PetscMatCOO {
-  int size;
-  size_t coo_size;
-  vector<PetscInt> rowidx;
-  vector<PetscInt> colidx;
-  vector<Entity> entity;
-  Array<int, 4> off;
-};
+  struct PetscMatCOO {
+    int size;
+    size_t coo_size;
+    vector<PetscInt> rowidx;
+    vector<PetscInt> colidx;
+    vector<Entity> entity;
+    Array<int, 4> off;
+  };
 
-struct PetscMatCoords {
-  PetscCount size;
-  vector<PetscInt> rowidx;
-  vector<PetscInt> colidx;
-};
+  struct PetscMatCoords {
+    PetscCount size;
+    vector<PetscInt> rowidx;
+    vector<PetscInt> colidx;
+  };
 
-struct PetscMatEntities {
-  size_t size;
-  Array<size_t, 4> off;
-  vector<Entity> row_cell;
-  vector<Entity> col_cell;
-  vector<Entity> value_entity;
-};
+  struct PetscMatEntities {
+    size_t size;
+    Array<size_t, 4> off;
+    vector<Entity> row_cell;
+    vector<Entity> col_cell;
+    vector<Entity> value_entity;
+  };
 
-$type petscGenericOptions blackbox<int>;
+  $type petscGenericOptions blackbox<int>;
 
-$rule singleton(petscGenericOptions <- PETSCSolverControls), option(disable_threading) {
-  if($PETSCSolverControls.optionExists("generic")) {
-    Loci::option_value_type type = $PETSCSolverControls.getOptionValueType("generic");
-    Loci::option_values value = $PETSCSolverControls.getOption("generic");
-    Loci::options_list::arg_list value_list;
-    switch(type) {
-    case FUNCTION:
-      {
-        value.get_value(value_list);
-        Loci::options_list ol;
-        ol.Input(value_list);
-        options_list::option_namelist nl = ol.getOptionNameList();
-        options_list::option_namelist::const_iterator nliter = nl.begin();
-        while(nliter != nl.end()) {
-          std::string option_name("-" + *nliter);
-          Loci::option_value_type valtype = ol.getOptionValueType(*nliter);
-          switch(valtype) {
-          case Loci::REAL:
-            {
-              double value;
-              ol.getOption(*nliter, value);
-              std::stringstream ss;
-              ss << value;
-              $[Once] {
-                std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
-                  << option_name << ' ' << ss.str() << std::endl;
+  $rule singleton(petscGenericOptions <- PETSCSolverControls), option(disable_threading) {
+    if($PETSCSolverControls.optionExists("generic")) {
+      Loci::option_value_type type = $PETSCSolverControls.getOptionValueType("generic");
+      Loci::option_values value = $PETSCSolverControls.getOption("generic");
+      Loci::options_list::arg_list value_list;
+      switch(type) {
+      case FUNCTION:
+        {
+          value.get_value(value_list);
+          Loci::options_list ol;
+          ol.Input(value_list);
+          options_list::option_namelist nl = ol.getOptionNameList();
+          options_list::option_namelist::const_iterator nliter = nl.begin();
+          while(nliter != nl.end()) {
+            std::string option_name("-" + *nliter);
+            Loci::option_value_type valtype = ol.getOptionValueType(*nliter);
+            switch(valtype) {
+            case Loci::REAL:
+              {
+                double value;
+                ol.getOption(*nliter, value);
+                std::stringstream ss;
+                ss << value;
+                $[Once] {
+                  std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
+                            << option_name << ' ' << ss.str() << std::endl;
+                }
+                PetscOptionsSetValue(NULL, option_name.c_str(), ss.str().c_str());
               }
-              PetscOptionsSetValue(NULL, option_name.c_str(), ss.str().c_str());
-            }
-            break;
-          case Loci::NAME:
-          case Loci::STRING:
-            {
-              std::string value;
-              ol.getOption(*nliter, value);
-              $[Once] {
-                std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
-                  << option_name << ' ' << value << std::endl;
+              break;
+            case Loci::NAME:
+            case Loci::STRING:
+              {
+                std::string value;
+                ol.getOption(*nliter, value);
+                $[Once] {
+                  std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
+                            << option_name << ' ' << value << std::endl;
+                }
+                PetscOptionsSetValue(NULL, option_name.c_str(), value.c_str());
               }
-              PetscOptionsSetValue(NULL, option_name.c_str(), value.c_str());
-            }
-            break;
-          case Loci::BOOLEAN:
-            {
-              $[Once] {
-                std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
-                  << option_name << std::endl;
+              break;
+            case Loci::BOOLEAN:
+              {
+                $[Once] {
+                  std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
+                            << option_name << std::endl;
+                }
+                PetscOptionsSetValue(NULL, option_name.c_str(), NULL);
               }
-              PetscOptionsSetValue(NULL, option_name.c_str(), NULL);
+              break;
+            default:
+              $[Once] {
+                std::cerr << "invalid type for petsc option: " << option_name
+                          << ", type: " << (int)valtype << std::endl;
+              }
+              break;
             }
-            break;
-          default:
-            $[Once] {
-              std::cerr << "invalid type for petsc option: " << option_name
-                << ", type: " << (int)valtype << std::endl;
-            }
-            break;
+            ++nliter;
           }
-          ++nliter;
         }
+        break;
+      default:
+        $[Once] {
+          std::cerr << "function expected for option 'generic'" << std::endl;
+        }
+        break;
       }
-      break;
-    default:
-      $[Once] {
-        std::cerr << "function expected for option 'generic'" << std::endl;
-      }
-      break;
     }
+
+    $petscGenericOptions = 1;
   }
 
-  $petscGenericOptions = 1;
-}
+  $type petscOptions(X) blackbox<int>;
 
-$type petscOptions(X) blackbox<int>;
-
-$rule singleton(petscOptions(X) <- PETSCSolverControls,
-petscMatrixName(X), petscOptionsPrefix(X), petscGenericOptions),
-option(disable_threading) {
-  std::string name = $petscMatrixName(X);
-  if($PETSCSolverControls.optionExists(name)) {
-    Loci::option_value_type type = $PETSCSolverControls.getOptionValueType(name);
-    Loci::option_values value = $PETSCSolverControls.getOption(name);
-    Loci::options_list::arg_list value_list;
-    switch(type) {
-    case FUNCTION:
-      {
-        value.get_value(value_list);
-        Loci::options_list ol;
-        ol.Input(value_list);
-        options_list::option_namelist nl = ol.getOptionNameList();
-        options_list::option_namelist::const_iterator nliter = nl.begin();
-        while(nliter != nl.end()) {
-          std::string option_name("-" + $petscOptionsPrefix(X) + *nliter);
-          Loci::option_value_type valtype = ol.getOptionValueType(*nliter);
-          switch(valtype) {
-          case Loci::REAL:
-            {
-              double value;
-              ol.getOption(*nliter, value);
-              std::stringstream ss;
-              ss << value;
-              $[Once] {
-                std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
-                  << option_name << ' ' << ss.str() << std::endl;
+  $rule singleton(petscOptions(X) <- PETSCSolverControls,
+                  petscMatrixName(X), petscOptionsPrefix(X), petscGenericOptions),
+  option(disable_threading) {
+    std::string name = $petscMatrixName(X);
+    if($PETSCSolverControls.optionExists(name)) {
+      Loci::option_value_type type = $PETSCSolverControls.getOptionValueType(name);
+      Loci::option_values value = $PETSCSolverControls.getOption(name);
+      Loci::options_list::arg_list value_list;
+      switch(type) {
+      case FUNCTION:
+        {
+          value.get_value(value_list);
+          Loci::options_list ol;
+          ol.Input(value_list);
+          options_list::option_namelist nl = ol.getOptionNameList();
+          options_list::option_namelist::const_iterator nliter = nl.begin();
+          while(nliter != nl.end()) {
+            std::string option_name("-" + $petscOptionsPrefix(X) + *nliter);
+            Loci::option_value_type valtype = ol.getOptionValueType(*nliter);
+            switch(valtype) {
+            case Loci::REAL:
+              {
+                double value;
+                ol.getOption(*nliter, value);
+                std::stringstream ss;
+                ss << value;
+                $[Once] {
+                  std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
+                            << option_name << ' ' << ss.str() << std::endl;
+                }
+                PetscOptionsSetValue(NULL, option_name.c_str(), ss.str().c_str());
               }
-              PetscOptionsSetValue(NULL, option_name.c_str(), ss.str().c_str());
-            }
-            break;
-          case Loci::NAME:
-          case Loci::STRING:
-            {
-              std::string value;
-              ol.getOption(*nliter, value);
-              $[Once] {
-                std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
-                  << option_name << ' ' << value << std::endl;
+              break;
+            case Loci::NAME:
+            case Loci::STRING:
+              {
+                std::string value;
+                ol.getOption(*nliter, value);
+                $[Once] {
+                  std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
+                            << option_name << ' ' << value << std::endl;
+                }
+                PetscOptionsSetValue(NULL, option_name.c_str(), value.c_str());
               }
-              PetscOptionsSetValue(NULL, option_name.c_str(), value.c_str());
-            }
-            break;
-          case Loci::BOOLEAN:
-            {
-              $[Once] {
-                std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
-                  << option_name << std::endl;
+              break;
+            case Loci::BOOLEAN:
+              {
+                $[Once] {
+                  std::cout << "(MPI rank " << Loci::MPI_rank << ") Adding petsc option "
+                            << option_name << std::endl;
+                }
+                PetscOptionsSetValue(NULL, option_name.c_str(), NULL);
               }
-              PetscOptionsSetValue(NULL, option_name.c_str(), NULL);
+              break;
+            default:
+              $[Once] {
+                std::cerr << "invalid type for petsc option: " << *nliter
+                          << ", type: " << (int)valtype << std::endl;
+              }
+              break;
             }
-            break;
-          default:
-            $[Once] {
-              std::cerr << "invalid type for petsc option: " << *nliter
-                << ", type: " << (int)valtype << std::endl;
-            }
-            break;
+            ++nliter;
           }
-          ++nliter;
         }
+        break;
+      default:
+        $[Once] {
+          std::cerr << "function expected for option '" << name << "'" << std::endl;
+        }
+        break;
       }
-      break;
-    default:
+    }
+
+    $petscOptions(X) = 1;
+  }
+
+  $rule singleton(petscMatrixName(X)), constraint(UNIVERSE),
+  option(disable_threading) {
+    Loci::rule_impl::info const & info = get_info();
+    Loci::variableSet outset = info.output_vars();
+    Loci::variable out = *outset.begin();
+    std::string name = "X";
+    if(out.get_arg_list().size() != 1) {
       $[Once] {
-        std::cerr << "function expected for option '" << name << "'" << std::endl;
+        std::cerr << "Unexpected fault: " << "variable " << out
+                  << " should be petscMatrixName(X)!" << std::endl;
       }
-      break;
+      Loci::Abort();
     }
+    Loci::variable varg = Loci::variable(out.get_arg_list()[0]);
+    Loci::variable::info const & vinfo = varg.get_info();
+    name = vinfo.name;
+    $petscMatrixName(X) = name;
   }
 
-  $petscOptions(X) = 1;
-}
-
-$rule singleton(petscMatrixName(X)), constraint(UNIVERSE),
-option(disable_threading) {
-  Loci::rule_impl::info const & info = get_info();
-  Loci::variableSet outset = info.output_vars();
-  Loci::variable out = *outset.begin();
-  std::string name = "X";
-  if(out.get_arg_list().size() != 1) {
-    $[Once] {
-      std::cerr << "Unexpected fault: " << "variable " << out
-        << " should be petscMatrixName(X)!" << std::endl;
-    }
-    Loci::Abort();
+  $rule singleton(petscOptionsPrefix(X) <- petscMatrixName(X)),
+  constraint(UNIVERSE), option(disable_threading) {
+    $petscOptionsPrefix(X) = $petscMatrixName(X) + "_";
   }
-  Loci::variable varg = Loci::variable(out.get_arg_list()[0]);
-  Loci::variable::info const & vinfo = varg.get_info();
-  name = vinfo.name;
-  $petscMatrixName(X) = name;
-}
 
-$rule singleton(petscOptionsPrefix(X) <- petscMatrixName(X)),
-constraint(UNIVERSE), option(disable_threading) {
-  $petscOptionsPrefix(X) = $petscMatrixName(X) + "_";
-}
+  // Gets the number of cells assigned on all processes. This rule is
+  // definitely not in the Loci spirit since we are collecting data from
+  // other processes.
+  $rule singleton(
+                  petscNumCell, petscLocalCell <- petscDummy, petscDevice
+                  ), constraint(geom_cells), option(disable_threading) {
+    // Get the collection of entities assigned to this processor
+    storeRepP myEntities=
+      Loci::exec_current_fact_db->get_variable("my_entities");
+    entitySet localEntities=~EMPTY;
+    if(myEntities!=0) localEntities = (*myEntities).domain();
 
-// Gets the number of cells assigned on all processes. This rule is
-// definitely not in the Loci spirit since we are collecting data from
-// other processes.
-$rule singleton(
-  petscNumCell, petscLocalCell <- petscDummy, petscDevice
-), constraint(geom_cells), option(disable_threading) {
-  // Get the collection of entities assigned to this processor
-  storeRepP myEntities=
-    Loci::exec_current_fact_db->get_variable("my_entities");
-  entitySet localEntities=~EMPTY;
-  if(myEntities!=0) localEntities = (*myEntities).domain();
+    entitySet localCellWithGhost=entitySet(seq);
 
-  entitySet localCellWithGhost=entitySet(seq);
+    // Get the local cells, not including the ghost cells.
+    $petscLocalCell= (localEntities & localCellWithGhost);
 
-  // Get the local cells, not including the ghost cells.
-  $petscLocalCell= (localEntities & localCellWithGhost);
-
-  // Distribute the number of cells to all processes.
-  $petscNumCell = Loci::all_collect_sizes(($petscLocalCell).size());
+    // Distribute the number of cells to all processes.
+    $petscNumCell = Loci::all_collect_sizes(($petscLocalCell).size());
 
 #ifdef VERBOSE
     for(size_t i=0;i<$petscNumCell.size();++i)
       cerr << "process,numCell: " << i << " " << $petscNumCell[i] << endl;
 #endif
-}
+  }
 
-$rule pointwise(petscCellToRow<-petscNumCell), constraint(geom_cells),
-option(disable_threading), prelude {
-  // Compute the row offset for this process.
-  int offset = 0;
-  for(int i = 0; i < Loci::MPI_rank; ++i)
-    offset+=(*$petscNumCell)[i];
+  $rule pointwise(petscCellToRow<-petscNumCell), constraint(geom_cells),
+  option(disable_threading), prelude {
+    // Compute the row offset for this process.
+    int offset = 0;
+    for(int i = 0; i < Loci::MPI_rank; ++i)
+      offset+=(*$petscNumCell)[i];
 
     // Assign row number.
     sequence::const_iterator cellPtr = seq.begin();
     for(int i = 0; i < (*$petscNumCell)[Loci::MPI_rank]; ++cellPtr, ++i){
       $petscCellToRow[*cellPtr]=offset+i;
     }
-};
+  };
 
-// Rule that copies petscCellToRow for periodic boundaries
-$rule pointwise(cr->petscCellToRow<-pmap->cl->petscCellToRow) {
-  $cr->$petscCellToRow = $pmap->$cl->$petscCellToRow;
-}
+  // Rule that copies petscCellToRow for periodic boundaries
+  $rule pointwise(cr->petscCellToRow<-pmap->cl->petscCellToRow) {
+    $cr->$petscCellToRow = $pmap->$cl->$petscCellToRow;
+  }
 
-// Determines the number of non-zero entries in the local portion of
-// the Petsc matrix for each cell. The local portion is defined as the
-// square row/column sub-block of the PETSC matrix whose rows map to
-// cells local to the process.
-$rule pointwise(petscNumDiagonal <- petscLocalCell, upper->cr, lower->cl),
-constraint(geom_cells) {
-  int cnt = 1; // Diagonal
-  for(int i = 0; i < $lower.size(); ++i) {
-    if($petscLocalCell.inSet($lower[i]->$cl)) {
-      cnt++;
+  // Determines the number of non-zero entries in the local portion of
+  // the Petsc matrix for each cell. The local portion is defined as the
+  // square row/column sub-block of the PETSC matrix whose rows map to
+  // cells local to the process.
+  $rule pointwise(petscNumDiagonal <- petscLocalCell, upper->cr, lower->cl),
+  constraint(geom_cells) {
+    int cnt = 1; // Diagonal
+    for(int i = 0; i < $lower.size(); ++i) {
+      if($petscLocalCell.inSet($lower[i]->$cl)) {
+        cnt++;
+      }
+    }
+    for(int i=0;i<$upper.size();++i) {
+      if($petscLocalCell.inSet($upper[i]->$cr)) {
+        cnt++;
+      }
+    }
+    $petscNumDiagonal = cnt;
+  }
+
+  // For cases with periodic boundary conditions where both cells in a
+  // periodic pair are local, the number of non-zeros in the row must
+  // increase by 1 to account for a cell's periodic partner. Use
+  // unit/apply because some cells may have multiple periodic pairs.
+  $rule unit(petscNumDiagonalFromPeriodic), constraint(geom_cells) {
+    $petscNumDiagonalFromPeriodic = 0;
+  }
+  $rule apply(petscNumDiagonalFromPeriodic)[Loci::Summation], constraint(geom_cells) ,prelude { } ;
+
+
+  $rule apply(
+              cl->petscNumDiagonalFromPeriodic <- cl->petscLocalCell, cl, pmap->cl
+              )[Loci::Summation], constraint(periodicFaces) {
+    // if both cells in a periodic pair are local, increase diagonal
+    if ($cl->$petscLocalCell.inSet($cl) &&
+        $cl->$petscLocalCell.inSet($pmap->$cl)) {
+      join($cl->$petscNumDiagonalFromPeriodic, 1);
     }
   }
-  for(int i=0;i<$upper.size();++i) {
-    if($petscLocalCell.inSet($upper[i]->$cr)) {
-      cnt++;
-    }
-  }
-  $petscNumDiagonal = cnt;
-}
 
-// For cases with periodic boundary conditions where both cells in a
-// periodic pair are local, the number of non-zeros in the row must
-// increase by 1 to account for a cell's periodic partner. Use
-// unit/apply because some cells may have multiple periodic pairs.
-$rule unit(petscNumDiagonalFromPeriodic), constraint(geom_cells) {
-  $petscNumDiagonalFromPeriodic = 0;
-}
-$rule apply(petscNumDiagonalFromPeriodic)[Loci::Summation], constraint(geom_cells) {
-  join($petscNumDiagonalFromPeriodic, 0);
-}
-
-$rule apply(
-  cl->petscNumDiagonalFromPeriodic <- cl->petscLocalCell, cl, pmap->cl
-)[Loci::Summation], constraint(periodicFaces) {
-  // if both cells in a periodic pair are local, increase diagonal
-  if ($cl->$petscLocalCell.inSet($cl) &&
-      $cl->$petscLocalCell.inSet($pmap->$cl)) {
-    join($cl->$petscNumDiagonalFromPeriodic, 1);
-  }
-}
-
-$rule pointwise(petscDNNZ <- petscNumDiagonal, petscNumDiagonalFromPeriodic),
-constraint(geom_cells) {
-  $petscDNNZ = $petscNumDiagonal + $petscNumDiagonalFromPeriodic;
-}
-
-$rule pointwise(petscONNZ<-upper->cr,lower->cl,petscDNNZ), constraint(geom_cells) {
-  $petscONNZ = $upper.size() + $lower.size() + 1 - $petscDNNZ;
-}
-
-// =============================================================================
-
-class PetscDNNZVectorUnit : public unit_rule {
-private:
-  blackbox<std::vector<int> > dnnz_vector;
-
-public:
-  PetscDNNZVectorUnit() {
-    name_store("petscDNNZVector", dnnz_vector);
-    output("petscDNNZVector");
-    constraint("geom_cells");
-    disable_threading();
+  $rule pointwise(petscDNNZ <- petscNumDiagonal, petscNumDiagonalFromPeriodic),
+  constraint(geom_cells) {
+    $petscDNNZ = $petscNumDiagonal + $petscNumDiagonalFromPeriodic;
   }
 
-  void compute(sequence const & seq) {
-    (*dnnz_vector) = std::vector<int>();
-  }
-};
-
-register_rule<PetscDNNZVectorUnit> register_PetscDNNZVectorUnit;
-
-class PetscDNNZVectorApply : public apply_rule<
-  blackbox<std::vector<int> >,
-  Loci::NullOp<std::vector<int> >
-> {
-private:
-  blackbox<std::vector<int> > dnnz_vector;
-  const_store<int> dnnz;
-  const_param<std::vector<int> > num_cells;
-
-public:
-  PetscDNNZVectorApply() {
-    name_store("petscDNNZVector", dnnz_vector);
-    name_store("petscDNNZ", dnnz);
-    name_store("petscNumCell", num_cells);
-
-    output("petscDNNZVector");
-
-    input("petscDNNZ");
-    input("petscNumCell");
-
-    disable_threading();
+  $rule pointwise(petscONNZ<-upper->cr,lower->cl,petscDNNZ), constraint(geom_cells) {
+    $petscONNZ = $upper.size() + $lower.size() + 1 - $petscDNNZ;
   }
 
-  void compute(sequence const & seq) {
-    int const n = (*num_cells)[Loci::MPI_rank];
+  // ==========================================================================
+  $type petscDNNZVector blackbox<std::vector<int> > ;
+
+  $rule unit(petscDNNZVector),constraint(geom_cells),
+  option(disable_threading), prelude {
+    *$petscDNNZVector = std::vector<int>() ;
+  } ;
+
+  $rule apply(petscDNNZVector<-petscDNNZ,petscNumCell)[Loci::NullOp],
+  option(disable_threading), prelude {
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
     int count = 0;
-    (*dnnz_vector).resize(n);
+    (*$petscDNNZVector).resize(n);
     sequence::const_iterator siter = seq.begin();
     while(siter != seq.end()) {
-      (*dnnz_vector)[count] = dnnz[*siter];
+      (*$petscDNNZVector)[count] = $petscDNNZ[*siter];
       ++siter;
       ++count;
     }
-  }
-};
+  } ;
 
-register_rule<PetscDNNZVectorApply> register_PetscDNNZVectorApply;
+  // ==========================================================================
+  $type petscONNZVector blackbox<std::vector<int> > ;
 
-// =============================================================================
+  $rule unit(petscONNZVector),constraint(geom_cells),
+  option(disable_threading),prelude {
+    *$petscONNZVector = std::vector<int>() ;
+  } ;
 
-class PetscONNZVectorUnit : public unit_rule {
-private:
-  blackbox<std::vector<int> > onnz_vector;
-
-public:
-  PetscONNZVectorUnit() {
-    name_store("petscONNZVector", onnz_vector);
-    output("petscONNZVector");
-    constraint("geom_cells");
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    (*onnz_vector) = std::vector<int>();
-  }
-};
-
-register_rule<PetscONNZVectorUnit> register_PetscONNZVectorUnit;
-
-class PetscONNZVectorApply : public apply_rule<
-  blackbox<std::vector<int> >,
-  Loci::NullOp<std::vector<int> >
-> {
-private:
-  blackbox<std::vector<int> > onnz_vector;
-  const_store<int> onnz;
-  const_param<std::vector<int> > num_cells;
-
-public:
-  PetscONNZVectorApply() {
-    name_store("petscONNZVector", onnz_vector);
-    name_store("petscONNZ", onnz);
-    name_store("petscNumCell", num_cells);
-
-    output("petscONNZVector");
-
-    input("petscONNZ");
-    input("petscNumCell");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule apply(petscONNZVector<-petscONNZ,petscNumCell)[Loci::NullOp],
+  option(disable_threading),prelude {
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
     int count = 0;
-    (*onnz_vector).resize(n);
+    (*$petscONNZVector).resize(n);
     sequence::const_iterator siter = seq.begin();
     while(siter != seq.end()) {
-      (*onnz_vector)[count] = onnz[*siter];
+      (*$petscONNZVector)[count] = $petscONNZ[*siter];
       ++siter;
       ++count;
     }
-  }
-};
+  } ;
 
-register_rule<PetscONNZVectorApply> register_PetscONNZVectorApply;
 
-// =============================================================================
+  // ==========================================================================
+  $type petscScalarSystem(X) blackbox<PetscScalarSystem> ;
 
-class PetscScalarSystemUnit : public unit_rule {
-private:
-  blackbox<PetscScalarSystem> system;
-  const_param<vector<int> > num_cells;
-  const_blackbox<vector<int> > dnnz_vector;
-  const_blackbox<vector<int> > onnz_vector;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
-
-public:
-  PetscScalarSystemUnit() {
-    name_store("petscScalarSystem(X)", system);
-    name_store("petscNumCell", num_cells);
-    name_store("petscDNNZVector", dnnz_vector);
-    name_store("petscONNZVector", onnz_vector);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscScalarSystem(X)");
-
-    input("petscNumCell");
-    input("petscDNNZVector");
-    input("petscONNZVector");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule unit(petscScalarSystem(X)<-petscNumCell,petscDNNZVector,
+             petscONNZVector,petscOptions(X),
+             petscMatrixName(X),petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscAssembly), option(disable_threading),
+  prelude {
     PetscErrorCode err;
 
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    err = system->rhs.Create(n, N, matrix_name->c_str(), options_prefix->c_str());
+    err = $petscScalarSystem(X)->rhs.Create(n, N, $petscMatrixName(X)->c_str(),
+                                            $petscOptionsPrefix(X)->c_str());
+
     if(err) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error creating PETSc scalar system rhs: " << err << endl;
@@ -1601,10 +1490,13 @@ public:
       Loci::Abort();
     }
 
-    err = system->matrix.Create(
-      n, N, &(*dnnz_vector)[0], &(*onnz_vector)[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    err =
+      $petscScalarSystem(X)->matrix.Create(
+                                           n, N, &(*$petscDNNZVector)[0],
+                                           &(*$petscONNZVector)[0],
+                                           $petscMatrixName(X)->c_str(),
+                                           $petscOptionsPrefix(X)->c_str()
+                                           );
     if(err) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error creating PETSc scalar system matrix: " << err << endl;
@@ -1612,184 +1504,113 @@ public:
       Loci::Abort();
     }
 
-    err = system->solver.Create(1e-5, 1e-18, 100, options_prefix->c_str());
+    err = $petscScalarSystem(X)->solver.Create(1e-5, 1e-18, 100,
+                                               $petscOptionsPrefix(X)->c_str());
     if(err) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error creating PETSc scalar solver: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarSystemUnit> register_PetscScalarSystemUnit;
+  $type X_B store<real> ;
+  $type X_D store<real> ;
+  $type X_L store<real> ;
+  $type X_U store<real> ;
 
-class PetscScalarSystemApply : public apply_rule<
-  blackbox<PetscScalarSystem>, NullOp<PetscScalarSystem>
-> {
-private:
-  blackbox<PetscScalarSystem> system;
-  const_store<int> cell2row;
-  const_multiMap lower, upper;
-  const_Map cl, cr;
-  const_store<real> xB, xD, xL, xU;
+  $rule apply(petscScalarSystem(X)<- petscCellToRow,max_fpc,
+              upper->cr->petscCellToRow,lower->cl->petscCellToRow,
+              X_B,X_D,lower->X_L,upper->X_U)[Loci::NullOp],
+  constraint(geom_cells,usePetscAssembly),
+    option(disable_threading), prelude {
 
-  PetscInt * colidx;
-  PetscScalar * values;
+    entitySet dom = entitySet(seq) ;
+    int mxcol = *$max_fpc + 1 ;
+    vector<PetscInt> colidx(mxcol) ;
+    vector<PetscScalar> values(mxcol) ;
 
-public:
-  PetscScalarSystemApply() {
-    name_store("petscScalarSystem(X)", system);
-    name_store("petscCellToRow", cell2row);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("X_B", xB);
-    name_store("X_D", xD);
-    name_store("X_L", xL);
-    name_store("X_U", xU);
+    FORALL(dom, cell) {
+      PetscInt rowidx = $petscCellToRow[cell];
+      PetscInt count = 0;
 
-    output("petscScalarSystem(X)");
+      int const nl = $lower.num_elems(cell);
+      int const nu = $upper.num_elems(cell);
 
-    input("petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("X_B");
-    input("X_D");
-    input("lower->X_L");
-    input("upper->X_U");
+      for(int l = 0; l < nl; ++l, ++count) {
+        Entity fc = $lower[cell][l];
+        Entity lc = $cl[fc];
+        colidx[count] = $petscCellToRow[lc];
+        values[count] = $X_L[fc];
+      }
+      colidx[count] = $petscCellToRow[cell];
+      values[count] = $X_D[cell];
+      ++count;
+      for(int u = 0; u < nu; ++u, ++count) {
+        Entity fc = $upper[cell][u];
+        Entity rc = $cr[fc];
+        if($petscCellToRow[rc] != $petscCellToRow[cell]) {
+          colidx[count] = $petscCellToRow[rc];
+          values[count] = $X_U[fc];
+        }
+      }
+      $petscScalarSystem(X)->matrix.SetRowValues(rowidx, count,
+                                                 &colidx[0], &values[0]);
+    } ENDFORALL ;
 
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err1, err2;
-
-    colidx = new PetscInt[100];
-    values = new PetscScalar[100];
-
-    do_loop(seq, this, &PetscScalarSystemApply::AssembleMatrix);
-    err1 = system->matrix.AssemblyBegin();
-    err2 = system->matrix.AssemblyEnd();
+    PetscErrorCode err1 = $petscScalarSystem(X)->matrix.AssemblyBegin();
+    PetscErrorCode err2 = $petscScalarSystem(X)->matrix.AssemblyEnd();
     if(err1 || err2) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error assembling PETSc scalar system matrix: "
-          << err1 << ", " << err2 << endl;
+             << err1 << ", " << err2 << endl;
       }
       Loci::Abort();
     }
 
-    do_loop(seq, this, &PetscScalarSystemApply::AssembleRHS);
-    err1 = system->rhs.AssemblyBegin();
-    err2 = system->rhs.AssemblyEnd();
+    FORALL(dom, cell) {
+      PetscInt const rowidx = $petscCellToRow[cell];
+      PetscScalar const value = $X_B[cell];
+      $petscScalarSystem(X)->rhs.SetValue(rowidx, &value);
+    } ENDFORALL ;
+    err1 = $petscScalarSystem(X)->rhs.AssemblyBegin();
+    err2 = $petscScalarSystem(X)->rhs.AssemblyEnd();
     if(err1 || err2) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error assembling PETSc scalar system rhs: "
-          << err1 << ", " << err2 << endl;
+             << err1 << ", " << err2 << endl;
       }
       Loci::Abort();
     }
 
-    delete[] colidx;
-    delete[] values;
-
-    err1 = system->solver.SetOperators(system->matrix);
+    err1 = $petscScalarSystem(X)->
+      solver.SetOperators($petscScalarSystem(X)->matrix);
     if(err1) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error setting PETSc scalar solver operator: " << err1 << endl;
       }
       Loci::Abort();
     }
+  } ;
 
-    //std::stringstream matrixss, rhsss;
-    //matrixss << "matrix-" << *matrix_name << ".dat";
-    //rhsss << "rhs-" << *matrix_name << ".dat";
-    //system->matrix.Print(matrixss.str().c_str());
-    //system->rhs.Print(rhsss.str().c_str());
-  }
+  $type petscScalarSolveBB(X) blackbox<PetscScalarVector> ;
 
-  void AssembleMatrix(Entity cell) {
-    PetscInt rowidx = cell2row[cell];
-    PetscInt count = 0;
-
-    int const nl = lower.num_elems(cell);
-    int const nu = upper.num_elems(cell);
-
-    for(int l = 0; l < nl; ++l, ++count) {
-      Entity fc = lower[cell][l];
-      Entity lc = cl[fc];
-      colidx[count] = cell2row[lc];
-      values[count] = xL[fc];
-    }
-    colidx[count] = cell2row[cell];
-    values[count] = xD[cell];
-    ++count;
-    for(int u = 0; u < nu; ++u, ++count) {
-      Entity fc = upper[cell][u];
-      Entity rc = cr[fc];
-      if(cell2row[rc] != cell2row[cell]) {
-        colidx[count] = cell2row[rc];
-        values[count] = xU[fc];
-      }
-    }
-    system->matrix.SetRowValues(rowidx, count, colidx, values);
-  }
-
-  void AssembleRHS(Entity cell) {
-    PetscInt const rowidx = cell2row[cell];
-    PetscScalar const value = xB[cell];
-    system->rhs.SetValue(rowidx, &value);
-  }
-};
-
-register_rule<PetscScalarSystemApply> register_PetscScalarSystemApply;
-
-class PetscScalarSolveUnit : public unit_rule {
-private:
-  blackbox<PetscScalarVector> solution;
-  const_store<int> cell2row;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
-
-public:
-  PetscScalarSolveUnit() {
-    name_store("petscScalarSolveBB(X)", solution);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscNumCell", num_cells);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscScalarSolveBB(X)");
-
-    input("petscCellToRow");
-    input("petscNumCell");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule unit(petscScalarSolveBB(X)<-
+             petscCellToRow,petscNumCell,petscOptions(X),
+             petscMatrixName(X),petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscAssembly), option(disable_threading),
+  prelude {
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    err = solution->Create(n, N, matrix_name->c_str(), options_prefix->c_str());
+    PetscErrorCode err =
+      $petscScalarSolveBB(X)->Create(n, N,
+                                     $petscMatrixName(X)->c_str(),
+                                     $petscOptionsPrefix(X)->c_str());
+
     if(err) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error creating PETSc solution vector for scalar system: " << err << endl;
@@ -1797,443 +1618,207 @@ public:
       Loci::Abort();
     }
 
-    err = solution->SetValue(0.0);
+    err = $petscScalarSolveBB(X)->SetValue(0.0);
+
     if(err) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error initializing PETSc solution vector for scalar system: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarSolveUnit> register_PetscScalarSolveUnit;
 
-class PetscScalarSolveApply : public apply_rule<
-  blackbox<PetscScalarVector>, Loci::NullOp<PetscScalarVector>
-> {
-private:
-  blackbox<PetscScalarVector> solution;
-  const_blackbox<PetscScalarSystem> system;
-
-public:
-  PetscScalarSolveApply() {
-    name_store("petscScalarSolveBB(X)", solution);
-    name_store("petscScalarSystem(X)", system);
-
-    output("petscScalarSolveBB(X)");
-
-    input("petscScalarSystem(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-    err = system->solver.Solve(system->rhs, *solution);
+  $rule apply(petscScalarSolveBB(X)<-petscScalarSystem(X))[Loci::NullOp],
+  constraint(geom_cells,usePetscAssembly),
+    option(disable_threading),prelude {
+    PetscErrorCode err =
+      $petscScalarSystem(X)->solver.Solve($petscScalarSystem(X)->rhs,
+                                          *$petscScalarSolveBB(X)) ;
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error in PETSc scalar solve: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarSolveApply> register_PetscScalarSolveApply;
-
-class PetscScalarCopy : public pointwise_rule {
-private:
-  store<real> X_out;
-  const_blackbox<PetscScalarVector> petsc_X;
-
-public:
-  PetscScalarCopy() {
-    name_store("petscScalarSolveBB(X)", petsc_X);
-    name_store("petscScalarSolve(X)", X_out);
-
-    output("petscScalarSolve(X)");
-
-    input("petscScalarSolveBB(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule pointwise(petscScalarSolve(X)<-petscScalarSolveBB(X)),
+  constraint(geom_cells,usePetscAssembly),option(disable_threading),
+  prelude {
     if(seq.size() == 0) return;
 
     PetscInt minRowNum, maxRowNum;
-    petsc_X->GetOwnershipRange(&minRowNum, &maxRowNum);
+    $petscScalarSolveBB(X)->GetOwnershipRange(&minRowNum, &maxRowNum);
     PetscScalar * X_Copy;
-    petsc_X->GetArray(&X_Copy);
+    $petscScalarSolveBB(X)->GetArray(&X_Copy);
 
     sequence::const_iterator cellPtr = seq.begin();
     for(PetscInt row = minRowNum; row < maxRowNum; ++row, ++cellPtr) {
-      X_out[*cellPtr]= X_Copy[row-minRowNum];
+      $petscScalarSolve(X)[*cellPtr]= X_Copy[row-minRowNum];
     }
-    petsc_X->RestoreArray(&X_Copy);
-  }
-};
+    $petscScalarSolveBB(X)->RestoreArray(&X_Copy);
+  } ;
 
-register_rule<PetscScalarCopy> register_PetscScalarCopy;
+  $type petscVecEntities blackbox<PetscVecEntities> ;
 
-class PetscVecEntitiesUnit : public unit_rule {
-private:
-  blackbox<PetscVecEntities> vec_entities;
+  $rule unit(petscVecEntities),constraint(geom_cells),
+  option(disable_threading), prelude {
+    *$petscVecEntities = PetscVecEntities();
+  } ;
 
-public:
-  PetscVecEntitiesUnit() {
-    name_store("petscVecEntities", vec_entities);
-
-    output("petscVecEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *vec_entities = PetscVecEntities();
-  }
-};
-
-register_rule<PetscVecEntitiesUnit> register_PetscVecEntitiesUnit;
-
-class PetscVecEntitiesApply : public apply_rule<
-  blackbox<PetscVecEntities>, NullOp<PetscVecEntities>
-> {
-private:
-  blackbox<PetscVecEntities> vec_entities;
-
-public:
-  PetscVecEntitiesApply() {
-    name_store("petscVecEntities", vec_entities);
-
-    output("petscVecEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule apply(petscVecEntities)[Loci::NullOp],constraint(geom_cells),
+  option(disable_threading),prelude {
     size_t const size = seq.size();
-    vec_entities->entity.resize(size);
+    $petscVecEntities->entity.resize(size);
     sequence::const_iterator iter = seq.begin();
     size_t cnt = 0;
     while(iter != seq.end()) {
-      vec_entities->entity[cnt++] = *iter++;
+      $petscVecEntities->entity[cnt++] = *iter++;
     }
-    vec_entities->size = size;
-  }
-};
+    $petscVecEntities->size = size;
+  } ;
 
-register_rule<PetscVecEntitiesApply> register_PetscVecEntitiesApply;
 
-class PetscScalarVecCoordsUnit : public unit_rule {
-private:
-  blackbox<PetscVecCoords> vec_coords;
+  $type petscScalarVecCoords blackbox<PetscVecCoords> ;
 
-public:
-  PetscScalarVecCoordsUnit() {
-    name_store("petscScalarVecCoords", vec_coords);
+  $rule unit(petscScalarVecCoords),constraint(geom_cells),
+  option(disable_threading),prelude {
+    *$petscScalarVecCoords = PetscVecCoords();
+  } ;
 
-    output("petscScalarVecCoords");
 
-    constraint("geom_cells");
+  $rule apply(petscScalarVecCoords<-petscCellToRow,petscVecEntities)[Loci::NullOp],
+  constraint(geom_cells), option(disable_threading), prelude {
+    $petscScalarVecCoords->rowidx.resize($petscVecEntities->size);
 
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *vec_coords = PetscVecCoords();
-  }
-};
-
-register_rule<PetscScalarVecCoordsUnit> register_PetscScalarVecCoordsUnit;
-
-class PetscScalarVecCoordsApply : public apply_rule<
-  blackbox<PetscVecCoords>, NullOp<PetscVecCoords>
-> {
-private:
-  blackbox<PetscVecCoords> vec_coords;
-  const_store<int> cell2row;
-  const_blackbox<PetscVecEntities> vec_entities;
-
-public:
-  PetscScalarVecCoordsApply() {
-    name_store("petscScalarVecCoords", vec_coords);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscVecEntities", vec_entities);
-
-    output("petscScalarVecCoords");
-
-    input("petscCellToRow");
-    input("petscVecEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    vec_coords->rowidx.resize(vec_entities->size);
-
-    for(size_t i = 0; i < vec_entities->size; ++i) {
-      vec_coords->rowidx[i] = cell2row[vec_entities->entity[i]];
+    for(size_t i = 0; i < $petscVecEntities->size; ++i) {
+      $petscScalarVecCoords->rowidx[i] =
+        $petscCellToRow[$petscVecEntities->entity[i]];
     }
 
-    vec_coords->size = (PetscCount)(vec_entities->size);
-  }
-};
+    $petscScalarVecCoords->size = (PetscCount)($petscVecEntities->size);
+  } ;
 
-register_rule<PetscScalarVecCoordsApply> register_PetscScalarVecCoordsApply;
+  $type petscMatEntities blackbox<PetscMatEntities>  ;
+  $rule unit(petscMatEntities),constraint(geom_cells),
+  option(disable_threading), prelude {
+    *$petscMatEntities = PetscMatEntities();
+  } ;
 
-class PetscMatEntitiesUnit : public unit_rule {
-private:
-  blackbox<PetscMatEntities> mat_entities;
-
-public:
-  PetscMatEntitiesUnit() {
-    name_store("petscMatEntities", mat_entities);
-
-    output("petscMatEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *mat_entities = PetscMatEntities();
-  }
-};
-
-register_rule<PetscMatEntitiesUnit> register_PetscMatEntitiesUnit;
-
-class PetscMatEntitiesApply : public apply_rule<
-  blackbox<PetscMatEntities>, NullOp<PetscMatEntities>
-> {
-private:
-  blackbox<PetscMatEntities> mat_entities;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_store<int> cell2row;
-
-public:
-  PetscMatEntitiesApply() {
-    name_store("petscMatEntities", mat_entities);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("petscCellToRow", cell2row);
-
-    output("petscMatEntities");
-
-    input("petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("upper->cr->petscCellToRow");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    mat_entities->row_cell.clear();
-    mat_entities->col_cell.clear();
-    mat_entities->value_entity.clear();
+  $rule apply(petscMatEntities<-
+              petscCellToRow,lower->cl->petscCellToRow,
+              upper->cr->petscCellToRow)[Loci::NullOp],
+  constraint(geom_cells),option(disable_threading), prelude {
+    $petscMatEntities->row_cell.clear();
+    $petscMatEntities->col_cell.clear();
+    $petscMatEntities->value_entity.clear();
 
     size_t off = 0;
     sequence::const_iterator iter;
 
-    mat_entities->off[0] = off;
+    $petscMatEntities->off[0] = off;
 
     iter = seq.begin();
     while(iter != seq.end()) {
-      mat_entities->row_cell.push_back(*iter);
-      mat_entities->col_cell.push_back(*iter);
-      mat_entities->value_entity.push_back(*iter);
+      $petscMatEntities->row_cell.push_back(*iter);
+      $petscMatEntities->col_cell.push_back(*iter);
+      $petscMatEntities->value_entity.push_back(*iter);
       ++iter;
       ++off;
     }
 
-    mat_entities->off[1] = off;
+    $petscMatEntities->off[1] = off;
 
     iter = seq.begin();
     while(iter != seq.end()) {
       Entity cell = *iter;
-      int const nl = lower.num_elems(cell);
+      int const nl = $lower.num_elems(cell);
       for(int l = 0; l < nl; ++l) {
-        Entity fc = lower[cell][l];
-        Entity lc = cl[fc];
-        mat_entities->row_cell.push_back(cell);
-        mat_entities->col_cell.push_back(lc);
-        mat_entities->value_entity.push_back(fc);
+        Entity fc = $lower[cell][l];
+        Entity lc = $cl[fc];
+        $petscMatEntities->row_cell.push_back(cell);
+        $petscMatEntities->col_cell.push_back(lc);
+        $petscMatEntities->value_entity.push_back(fc);
         ++off;
       }
       ++iter;
     }
 
-    mat_entities->off[2] = off;
+    $petscMatEntities->off[2] = off;
 
     iter = seq.begin();
     while(iter != seq.end()) {
       Entity cell = *iter;
-      int const nu = upper.num_elems(cell);
+      int const nu = $upper.num_elems(cell);
       for(int u = 0; u < nu; ++u) {
-        Entity fc = upper[cell][u];
-        Entity rc = cr[fc];
-        if(cell2row[rc] != cell2row[cell]) {
-          mat_entities->row_cell.push_back(cell);
-          mat_entities->col_cell.push_back(rc);
-          mat_entities->value_entity.push_back(fc);
+        Entity fc = $upper[cell][u];
+        Entity rc = $cr[fc];
+        if($petscCellToRow[rc] != $petscCellToRow[cell]) {
+          $petscMatEntities->row_cell.push_back(cell);
+          $petscMatEntities->col_cell.push_back(rc);
+          $petscMatEntities->value_entity.push_back(fc);
         }
         ++off;
       }
       ++iter;
     }
 
-    mat_entities->off[3] = off;
+    $petscMatEntities->off[3] = off;
 
-    mat_entities->size = off;
-  }
-};
+    $petscMatEntities->size = off;
+  } ;
 
-register_rule<PetscMatEntitiesApply> register_PetscMatEntitiesApply;
+  $type petscScalarMatCoords  blackbox<PetscMatCoords> ;
 
-class PetscScalarMatCoordsUnit : public unit_rule {
-private:
-  blackbox<PetscMatCoords> mat_coords;
+  $rule unit(petscScalarMatCoords),
+  constraint(geom_cells),option(disable_threading), prelude {
+    *$petscScalarMatCoords = PetscMatCoords();
+  } ;
 
-public:
-  PetscScalarMatCoordsUnit() {
-    name_store("petscScalarMatCoords", mat_coords);
+  $rule apply(petscScalarMatCoords<- petscCellToRow,
+              lower->cl->petscCellToRow,upper->cr->petscCellToRow,
+              petscMatEntities)[Loci::NullOp], constraint(geom_cells),
+    option(disable_threading), prelude {
+    $petscScalarMatCoords->rowidx.resize($petscMatEntities->size);
+    $petscScalarMatCoords->colidx.resize($petscMatEntities->size);
 
-    output("petscScalarMatCoords");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *mat_coords = PetscMatCoords();
-  }
-};
-
-register_rule<PetscScalarMatCoordsUnit> register_PetscScalarMatCoordsUnit;
-
-class PetscScalarMatCoordsApply : public apply_rule<
-  blackbox<PetscMatCoords>, NullOp<PetscMatCoords>
-> {
-private:
-  blackbox<PetscMatCoords> mat_coords;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_store<int> cell2row;
-  const_blackbox<PetscMatEntities> mat_entities;
-
-public:
-  PetscScalarMatCoordsApply() {
-    name_store("petscScalarMatCoords", mat_coords);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscMatEntities", mat_entities);
-
-    output("petscScalarMatCoords");
-
-    input("petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("petscMatEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    mat_coords->rowidx.resize(mat_entities->size);
-    mat_coords->colidx.resize(mat_entities->size);
-
-    for(size_t i = 0; i < mat_entities->size; ++i) {
-      mat_coords->rowidx[i] = cell2row[mat_entities->row_cell[i]];
-      mat_coords->colidx[i] = cell2row[mat_entities->col_cell[i]];
+    for(size_t i = 0; i < $petscMatEntities->size; ++i) {
+      $petscScalarMatCoords->rowidx[i] =
+        $petscCellToRow[$petscMatEntities->row_cell[i]];
+      $petscScalarMatCoords->colidx[i] =
+        $petscCellToRow[$petscMatEntities->col_cell[i]];
     }
 
-    mat_coords->size = (PetscCount)(mat_entities->size);
-  }
-};
+    $petscScalarMatCoords->size = (PetscCount)($petscMatEntities->size);
+  } ;
 
-register_rule<PetscScalarMatCoordsApply> register_PetscScalarMatCoordsApply;
+  $type petscScalarSystemCOO(X) blackbox<PetscScalarSystem> ;
 
-class PetscScalarSystemCOOUnit : public unit_rule {
-private:
-  blackbox<PetscScalarSystem> system;
-  const_blackbox<PetscVecCoords> vec_coords;
-  const_blackbox<PetscMatCoords> mat_coords;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
+  $rule unit(petscScalarSystemCOO(X)<- petscScalarVecCoords,
+             petscScalarMatCoords, petscNumCell,
+             petscOptions(X),petscMatrixName(X),
+             petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscCOOAssembly), option(disable_threading),
+  prelude {
 
-public:
-  PetscScalarSystemCOOUnit() {
-    name_store("petscScalarSystemCOO(X)", system);
-    name_store("petscScalarVecCoords", vec_coords);
-    name_store("petscScalarMatCoords", mat_coords);
-    name_store("petscNumCell", num_cells);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscScalarSystemCOO(X)");
-
-    input("petscScalarVecCoords");
-    input("petscScalarMatCoords");
-    input("petscNumCell");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    vector<PetscInt> vec_rowidx = vec_coords->rowidx;
-    vector<PetscInt> mat_rowidx = mat_coords->rowidx;
-    vector<PetscInt> mat_colidx = mat_coords->colidx;
+    const vector<PetscInt> &vec_rowidx = $petscScalarVecCoords->rowidx;
+    vector<PetscInt> mat_rowidx = $petscScalarMatCoords->rowidx;
+    vector<PetscInt> mat_colidx = $petscScalarMatCoords->colidx;
 
-    err = system->rhs.CreateCOO(
-      n, N, vec_coords->size, &vec_rowidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err =
+      $petscScalarSystemCOO(X)->rhs.CreateCOO(
+                                              n, N, $petscScalarVecCoords->size,
+                                              &vec_rowidx[0],
+                                              $petscMatrixName(X)->c_str(),
+                                              $petscOptionsPrefix(X)->c_str()
+                                              );
     if(err) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error creating PETSc scalar system rhs: " << err << endl;
@@ -2241,2457 +1826,1312 @@ public:
       Loci::Abort();
     }
 
-    err = system->matrix.CreateCOO(
-      n, N, mat_coords->size, &mat_rowidx[0], &mat_colidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    err =
+      $petscScalarSystemCOO(X)->matrix.CreateCOO(
+                                                 n, N,
+                                                 $petscScalarMatCoords->size,
+                                                 &mat_rowidx[0], &mat_colidx[0],
+                                                 $petscMatrixName(X)->c_str(),
+                                                 $petscOptionsPrefix(X)->c_str()
+                                                 );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc scalar system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.Create(1e-5, 1e-18, 100, options_prefix->c_str());
+    err =
+      $petscScalarSystemCOO(X)->solver.Create(1e-5, 1e-18, 100,
+                                              $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc scalar solver: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarSystemCOOUnit> register_PetscScalarSystemCOOUnit;
+  $rule apply(petscScalarSystemCOO(X)<- petscVecEntities,petscMatEntities,
+              petscCellToRow, upper->cr->petscCellToRow,
+              lower->cl->petscCellToRow,
+              X_B, X_D, lower->X_L, upper->X_U)[Loci::NullOp],
+  constraint(geom_cells,usePetscCOOAssembly), option(disable_threading),
+    prelude {
+    vector<PetscScalar> vec_values($petscVecEntities->size, 0.0);
+    vector<PetscScalar> mat_values($petscMatEntities->size, 0.0);
 
-class PetscScalarSystemCOOApply : public apply_rule<
-  blackbox<PetscScalarSystem>, NullOp<PetscScalarSystem>
-> {
-private:
-  blackbox<PetscScalarSystem> system;
-  const_blackbox<PetscVecEntities> vec_entities;
-  const_blackbox<PetscMatEntities> mat_entities;
-  const_store<int> cell2row;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_store<real> xB;
-  const_store<real> xD;
-  const_store<real> xL;
-  const_store<real> xU;
-
-public:
-  PetscScalarSystemCOOApply() {
-    name_store("petscScalarSystemCOO(X)", system);
-    name_store("petscVecEntities", vec_entities);
-    name_store("petscMatEntities", mat_entities);
-    name_store("petscCellToRow", cell2row);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("X_B", xB);
-    name_store("X_D", xD);
-    name_store("X_L", xL);
-    name_store("X_U", xU);
-
-    output("petscScalarSystemCOO(X)");
-
-    input("petscVecEntities");
-    input("petscMatEntities");
-    input("petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("X_B");
-    input("X_D");
-    input("lower->X_L");
-    input("upper->X_U");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    vector<PetscScalar> vec_values(vec_entities->size, 0.0);
-    vector<PetscScalar> mat_values(mat_entities->size, 0.0);
-
-    for(size_t i = 0; i < vec_entities->size; ++i) {
-      vec_values[i] = xB[vec_entities->entity[i]];
+    for(size_t i = 0; i < $petscVecEntities->size; ++i) {
+      vec_values[i] = $X_B[$petscVecEntities->entity[i]];
     }
 
-    for(size_t i = mat_entities->off[0]; i < mat_entities->off[1]; ++i) {
-      mat_values[i] = xD[mat_entities->value_entity[i]];
+    for(size_t i = $petscMatEntities->off[0]; i < $petscMatEntities->off[1]; ++i) {
+      mat_values[i] = $X_D[$petscMatEntities->value_entity[i]];
     }
 
-    for(size_t i = mat_entities->off[1]; i < mat_entities->off[2]; ++i) {
-      mat_values[i] = xL[mat_entities->value_entity[i]];
+    for(size_t i = $petscMatEntities->off[1]; i < $petscMatEntities->off[2]; ++i) {
+      mat_values[i] = $X_L[$petscMatEntities->value_entity[i]];
     }
 
-    for(size_t i = mat_entities->off[2]; i < mat_entities->off[3]; ++i) {
-      mat_values[i] = xU[mat_entities->value_entity[i]];
+    for(size_t i = $petscMatEntities->off[2]; i < $petscMatEntities->off[3]; ++i) {
+      mat_values[i] = $X_U[$petscMatEntities->value_entity[i]];
     }
 
-    PetscErrorCode err;
-    err = system->rhs.SetValuesCOO(&vec_values[0]);
+    PetscErrorCode err =
+      $petscScalarSystemCOO(X)->rhs.SetValuesCOO(&vec_values[0]);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assigning values to PETSc scalar system rhs: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->matrix.SetValuesCOO(&mat_values[0]);
+    err = $petscScalarSystemCOO(X)->matrix.SetValuesCOO(&mat_values[0]);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assigning values to PETSc scalar system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.SetOperators(system->matrix);
+    err = $petscScalarSystemCOO(X)->solver.SetOperators($petscScalarSystemCOO(X)->matrix);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error setting PETSc scalar solver operator: " << err << endl;
       }
       Loci::Abort();
     }
 
-    //std::stringstream matrixss, rhsss;
-    //matrixss << "matrix-" << *matrix_name << ".dat";
-    //rhsss << "rhs-" << *matrix_name << ".dat";
-    //system->matrix.Print(matrixss.str().c_str());
-    //system->rhs.Print(rhsss.str().c_str());
-  }
-};
+  } ;
 
-register_rule<PetscScalarSystemCOOApply> register_PetscScalarSystemCOOApply;
+  $type petscScalarSolveCOOBB(X) blackbox<PetscScalarVector> ;
 
-class PetscSolveCOOUnit : public unit_rule {
-private:
-  blackbox<PetscScalarVector> solution;
-  const_store<int> cell2row;
-  const_param<vector<int> > num_cells;
-  const_blackbox<PetscVecCoords> vec_coords;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
 
-public:
-  PetscSolveCOOUnit() {
-    name_store("petscScalarSolveCOOBB(X)", solution);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscNumCell", num_cells);
-    name_store("petscScalarVecCoords", vec_coords);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscScalarSolveCOOBB(X)");
-
-    input("petscCellToRow");
-    input("petscNumCell");
-    input("petscScalarVecCoords");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule unit(petscScalarSolveCOOBB(X)<- petscCellToRow, petscNumCell,
+             petscScalarVecCoords, petscOptions(X), petscMatrixName(X),
+             petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    vector<PetscInt> rowidx = vec_coords->rowidx;
+    vector<PetscInt> rowidx = $petscScalarVecCoords->rowidx;
 
-    err = solution->CreateCOO(
-      n, N, vec_coords->size, &rowidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err =
+      $petscScalarSolveCOOBB(X)->CreateCOO(
+                                           n, N, $petscScalarVecCoords->size,
+                                           &rowidx[0],
+                                           $petscMatrixName(X)->c_str(),
+                                           $petscOptionsPrefix(X)->c_str()
+                                           );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc scalar solution vector: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = solution->SetValue(0.0);
+    err = $petscScalarSolveCOOBB(X)->SetValue(0.0);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error initializing PETSc scalar solution vector: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscSolveCOOUnit> register_PetscSolveCOOUnit;
 
-class PetscSolveCOOApply : public apply_rule<
-  blackbox<PetscScalarVector>, Loci::NullOp<PetscScalarVector>
-> {
-private:
-  blackbox<PetscScalarVector> solution;
-  const_blackbox<PetscScalarSystem> system;
-
-public:
-  PetscSolveCOOApply() {
-    name_store("petscScalarSolveCOOBB(X)", solution);
-    name_store("petscScalarSystemCOO(X)", system);
-
-    output("petscScalarSolveCOOBB(X)");
-
-    input("petscScalarSystemCOO(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-    err = system->solver.Solve(system->rhs, *solution);
+  $rule apply(petscScalarSolveCOOBB(X)<-petscScalarSystemCOO(X))[Loci::NullOp],
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+    prelude {
+    PetscErrorCode err = $petscScalarSystemCOO(X)->
+      solver.Solve($petscScalarSystemCOO(X)->rhs, *$petscScalarSolveCOOBB(X));
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error solving PETSc scalar system: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscSolveCOOApply> register_PetscSolveCOOApply;
-
-class PetscScalarCopyCOO : public pointwise_rule {
-private:
-  store<real> X_out;
-  const_blackbox<PetscScalarVector> petsc_X;
-
-public:
-  PetscScalarCopyCOO() {
-    name_store("petscScalarSolve(X)", X_out);
-    name_store("petscScalarSolveCOOBB(X)", petsc_X);
-
-    output("petscScalarSolve(X)");
-
-    input("petscScalarSolveCOOBB(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule pointwise(petscScalarSolve(X)<-petscScalarSolveCOOBB(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
     PetscInt minRowNum, maxRowNum;
-    petsc_X->GetOwnershipRange(&minRowNum, &maxRowNum);
+    $petscScalarSolveCOOBB(X)->GetOwnershipRange(&minRowNum, &maxRowNum);
     PetscScalar * X_Copy;
-    petsc_X->GetArray(&X_Copy);
+    $petscScalarSolveCOOBB(X)->GetArray(&X_Copy);
 
     sequence::const_iterator cellPtr = seq.begin();
     for(PetscInt row = minRowNum; row < maxRowNum; ++row, ++cellPtr) {
-      X_out[*cellPtr]= X_Copy[row-minRowNum];
+      $petscScalarSolve(X)[*cellPtr]= X_Copy[row-minRowNum];
     }
-    petsc_X->RestoreArray(&X_Copy);
-  }
-};
+    $petscScalarSolveCOOBB(X)->RestoreArray(&X_Copy);
+  } ;
 
-register_rule<PetscScalarCopyCOO> register_PetscScalarCopyCOO;
+  typedef float real_fj;
 
-namespace blockeds {
+  $untype X_B ;
+  $untype X_L ;
+  $untype X_U ;
+  $untype X_D ;
 
-typedef float real_fj;
+  $type X_B storeVec<real_fj> ;
+  $type X_L storeMat<real_fj> ;
+  $type X_U storeMat<real_fj> ;
+  $type X_D storeMat<real_fj> ;
 
-class PetscGetBlockSizeUnit : public unit_rule {
-private:
-  blackbox<int> block_size;
+  $type petscBlockSSize(X) blackbox<int> ;
 
-public:
-  PetscGetBlockSizeUnit() {
-    name_store("petscBlockSSize(X)", block_size);
-    constraint("X_B");
-    output("petscBlockSSize(X)");
-  }
+  $rule unit(petscBlockSSize(X)),constraint(X_B), prelude {
+    *$petscBlockSSize(X) = 0 ;
+  } ;
 
-  void compute(sequence const & seq) {
-    *block_size = 0;
-  }
-};
+  $rule apply(petscBlockSSize(X)<-X_B)[Loci::NullOp], prelude {
+    *$petscBlockSSize(X) = max(*$petscBlockSSize(X), $X_B.vecSize());
+  } ;
 
-register_rule<PetscGetBlockSizeUnit> register_PetscGetBlockSizeUnit;
+  $type petscScalarDNNZSVector(X) blackbox<std::vector<int> > ;
 
-class PetscGetBlockSizeApply : public apply_rule<
-  blackbox<int>, Loci::NullOp<int>
-> {
-  const_storeVec<real_fj> xB;
-  blackbox<int> block_size;
+  $rule unit(petscScalarDNNZSVector(X)),constraint(geom_cells),
+  option(disable_threading), prelude {
+    $petscScalarDNNZSVector(X) = std::vector<int>() ;
+  } ;
 
-public:
-  PetscGetBlockSizeApply() {
-    name_store("X_B", xB);
-    name_store("petscBlockSSize(X)", block_size);
-
-    output("petscBlockSSize(X)");
-
-    input("X_B");
-  }
-
-  void compute(sequence const & seq) {
-    *block_size = max(*block_size, xB.vecSize());
-  }
-};
-
-register_rule<PetscGetBlockSizeApply> register_PetscGetBlockSizeApply;
-
-class PetscScalarDNNZVectorUnit : public unit_rule {
-private:
-  blackbox<std::vector<int> > dnnz_vector;
-
-public:
-  PetscScalarDNNZVectorUnit() {
-    name_store("petscScalarDNNZSVector(X)", dnnz_vector);
-    output("petscScalarDNNZSVector(X)");
-    constraint("geom_cells");
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    (*dnnz_vector) = std::vector<int>();
-  }
-};
-
-register_rule<PetscScalarDNNZVectorUnit> register_PetscScalarDNNZVectorUnit;
-
-class PetscScalarDNNZApply : public apply_rule<
-  blackbox<std::vector<int> >,
-  Loci::NullOp<std::vector<int> >
-> {
-private:
-  blackbox<std::vector<int> > dnnz_vector;
-  const_store<int> dnnz;
-  const_param<std::vector<int> > num_cells;
-  const_blackbox<int> block_size;
-
-public:
-  PetscScalarDNNZApply() {
-    name_store("petscScalarDNNZSVector(X)", dnnz_vector);
-    name_store("petscDNNZ", dnnz);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSSize(X)", block_size);
-
-    output("petscScalarDNNZSVector(X)");
-
-    input("petscDNNZ");
-    input("petscNumCell");
-    input("petscBlockSSize(X)");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule apply(petscScalarDNNZSVector(X)<-petscDNNZ,
+              petscNumCell,petscBlockSSize(X))[Loci::NullOp],
+  constraint(geom_cells),option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSSize(X);
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
     int count = 0;
-    (*dnnz_vector).resize(n*bsz);
+    (*$petscScalarDNNZSVector(X)).resize(n*bsz);
     sequence::const_iterator siter = seq.begin();
     while(siter != seq.end()) {
       for(int i = 0; i < bsz; ++i) {
-        (*dnnz_vector)[count*bsz+i] = dnnz[*siter]*bsz;
+        (*$petscScalarDNNZSVector(X))[count*bsz+i] =$petscDNNZ[*siter]*bsz;
       }
       ++siter;
       ++count;
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarDNNZApply> register_PetscScalarDNNZApply;
+  $type petscScalarONNZSVector(X) blackbox<std::vector<int> > ;
+  $rule unit(petscScalarONNZSVector(X)),constraint(geom_cells),
+  option(disable_threading),prelude {
+    *$petscScalarONNZSVector(X) = std::vector<int>() ;
+  } ;
 
-class PetscScalarONNZVectorUnit : public unit_rule {
-private:
-  blackbox<std::vector<int> > onnz_vector;
-
-public:
-  PetscScalarONNZVectorUnit() {
-    name_store("petscScalarONNZSVector(X)", onnz_vector);
-    output("petscScalarONNZSVector(X)");
-    constraint("geom_cells");
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    (*onnz_vector) = std::vector<int>();
-  }
-};
-
-register_rule<PetscScalarONNZVectorUnit> register_PetscScalarONNZVectorUnit;
-
-class PetscScalarONNZVectorApply : public apply_rule<
-  blackbox<std::vector<int> >,
-  Loci::NullOp<std::vector<int> >
-> {
-private:
-  blackbox<std::vector<int> > onnz_vector;
-  const_store<int> onnz;
-  const_param<std::vector<int> > num_cells;
-  const_blackbox<int> block_size;
-
-public:
-  PetscScalarONNZVectorApply() {
-    name_store("petscScalarONNZSVector(X)", onnz_vector);
-    name_store("petscONNZ", onnz);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSSize(X)", block_size);
-
-    output("petscScalarONNZSVector(X)");
-
-    input("petscONNZ");
-    input("petscNumCell");
-    input("petscBlockSSize(X)");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule apply(petscScalarONNZSVector(X)<-petscONNZ,petscNumCell,
+              petscBlockSSize(X))[Loci::NullOp],
+  option(disable_threading),prelude {
+    int const bsz = *$petscBlockSSize(X);
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
     int count = 0;
-    (*onnz_vector).resize(n*bsz);
+    (*$petscScalarONNZSVector(X)).resize(n*bsz);
     sequence::const_iterator siter = seq.begin();
     while(siter != seq.end()) {
       for(int i = 0; i < bsz; ++i) {
-        (*onnz_vector)[count*bsz+i] = onnz[*siter]*bsz;
+        (*$petscScalarONNZSVector(X))[count*bsz+i] = $petscONNZ[*siter]*bsz;
       }
       ++siter;
       ++count;
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarONNZVectorApply> register_PetscScalarONNZVectorApply;
+  $type petscBlockedSSystem(X) blackbox<PetscBlockedSystem> ;
+  $rule unit(petscBlockedSSystem(X)<- petscNumCell,
+             petscBlockSSize(X), petscDNNZVector, petscONNZVector,
+             petscScalarDNNZSVector(X), petscScalarONNZSVector(X),
+             petscOptions(X), petscMatrixName(X), petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscAssembly),option(disable_threading),
+  prelude {
+    int const bsz = *$petscBlockSSize(X);
 
-class PetscBlockedSystemUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> block_size;
-  const_blackbox<vector<int> > dnnz_vector;
-  const_blackbox<vector<int> > onnz_vector;
-  const_blackbox<vector<int> > scalar_dnnz_vector;
-  const_blackbox<vector<int> > scalar_onnz_vector;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
-
-public:
-  PetscBlockedSystemUnit() {
-    name_store("petscBlockedSSystem(X)", system);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("petscDNNZVector", dnnz_vector);
-    name_store("petscONNZVector", onnz_vector);
-    name_store("petscScalarDNNZSVector(X)", scalar_dnnz_vector);
-    name_store("petscScalarONNZSVector(X)", scalar_onnz_vector);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSSystem(X)");
-
-    input("petscNumCell");
-    input("petscBlockSSize(X)");
-    input("petscDNNZVector");
-    input("petscONNZVector");
-    input("petscScalarDNNZSVector(X)");
-    input("petscScalarONNZSVector(X)");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    err = system->rhs.Create(bsz, n, N, matrix_name->c_str(), options_prefix->c_str());
+    PetscErrorCode err
+      = $petscBlockedSSystem(X)->rhs.Create(bsz, n, N,
+                                            $petscMatrixName(X)->c_str(),
+                                            $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system rhs: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->matrix.Create(
-      bsz, n, N, &(*dnnz_vector)[0], &(*onnz_vector)[0],
-      &(*scalar_dnnz_vector)[0], &(*scalar_onnz_vector)[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    err = $petscBlockedSSystem(X)->
+      matrix.Create(bsz, n, N, &(*$petscDNNZVector)[0],
+                    &(*$petscONNZVector)[0],
+                    &(*$petscScalarDNNZSVector(X))[0],
+                    &(*$petscScalarONNZSVector(X))[0],
+                    $petscMatrixName(X)->c_str(),
+                    $petscOptionsPrefix(X)->c_str()
+                    );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.Create(1e-5, 1e-18, 100, options_prefix->c_str());
+    err = $petscBlockedSSystem(X)->
+      solver.Create(1e-5, 1e-18, 100, $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked solver: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSystemUnit> register_PetscBlockedSystemUnit;
+  $rule apply(petscBlockedSSystem(X)<- petscCellToRow,
+              upper->cr->petscCellToRow,lower->cl->petscCellToRow,
+              petscBlockSSize(X),max_fpc,
+              X_B, X_D, lower->X_L, upper->X_U)[Loci::NullOp],
+  constraint(geom_cells,usePetscAssembly), option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSSize(X) ;
 
-class PetscBlockedSystemApply : public apply_rule<
-  blackbox<PetscBlockedSystem>, NullOp<PetscBlockedSystem>
-> {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_store<int> cell2row;
-  const_blackbox<int> block_size;
-  const_multiMap lower, upper;
-  const_Map cl, cr;
-  const_storeVec<real_fj> xB;
-  const_storeMat<real_fj> xD, xL, xU;
+    int mwidth = *$max_fpc+1 ;
+    vector<PetscInt> rowsidx(bsz) ;
+    vector<PetscInt> colidx(mwidth) ;
+    vector<PetscInt> colsidx(mwidth*bsz) ;
+    vector<PetscScalar> values(mwidth*bsz*bsz) ;
+    vector<PetscScalar> svalues(mwidth*bsz*bsz) ;
 
-  PetscInt * rowsidx;
-  PetscInt * colidx;
-  PetscInt * colsidx;
-  PetscScalar * values;
-  PetscScalar * svalues;
+    entitySet dom = entitySet(seq) ;
+    FORALL(dom,cell) {
+      PetscInt count = 0, scount = 0, cnt = 0;
+      PetscInt rowidx = $petscCellToRow[cell];
 
-public:
-  PetscBlockedSystemApply() {
-    name_store("petscBlockedSSystem(X)", system);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("X_B", xB);
-    name_store("X_D", xD);
-    name_store("X_L", xL);
-    name_store("X_U", xU);
+      int const nl = $lower.num_elems(cell);
+      int const nu = $upper.num_elems(cell);
 
-    output("petscBlockedSSystem(X)");
+      for(int i = 0; i < bsz; ++i) {
+        rowsidx[i] = $petscCellToRow[cell]*bsz+i;
+      }
 
-    input("petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("petscBlockSSize(X)");
-    input("X_B");
-    input("X_D");
-    input("lower->X_L");
-    input("upper->X_U");
+      for(int l = 0; l < nl; ++l) {
+        Entity fc = $lower[cell][l];
+        Entity lc = $cl[fc];
+        colidx[count++] = $petscCellToRow[lc];
+        for(int i = 0; i < bsz; ++i) {
+          colsidx[scount++] = $petscCellToRow[lc]*bsz+i;
+        }
+        for(int j = 0; j < bsz; ++j) {
+          for(int i = 0; i < bsz; ++i) {
+            values[cnt++] = $X_L[fc][i][j];
+          }
+        }
+      }
+      {
+        colidx[count++] = $petscCellToRow[cell];
+        for(int i = 0; i < bsz; ++i) {
+          colsidx[scount++] = $petscCellToRow[cell]*bsz+i;
+        }
+        for(int j = 0; j < bsz; ++j) {
+          for(int i = 0; i < bsz; ++i) {
+            values[cnt++] = $X_D[cell][i][j];
+          }
+        }
+      }
+      for(int u = 0; u < nu; ++u) {
+        Entity fc = $upper[cell][u];
+        Entity rc = $cr[fc];
+        if($petscCellToRow[cell] != $petscCellToRow[rc]) {
+          colidx[count++] = $petscCellToRow[rc];
+          for(int i = 0; i < bsz; ++i) {
+            colsidx[scount++] = $petscCellToRow[rc]*bsz+i;
+          }
+          for(int j = 0; j < bsz; ++j) {
+            for(int i = 0; i < bsz; ++i) {
+              values[cnt++] = $X_U[fc][i][j];
+            }
+          }
+        }
+      }
 
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
+      for(int i = 0; i < bsz; ++i) {
+        for(int k = 0; k < scount; ++k) {
+          svalues[i*scount+k] = values[k*bsz+i];
+        }
+      }
 
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err1, err2;
-
-    int const bsz = *block_size;
-
-    rowsidx = new PetscInt[bsz];
-    colidx = new PetscInt[100];
-    colsidx = new PetscInt[100*bsz];
-    values = new PetscScalar[100*bsz*bsz];
-    svalues = new PetscScalar[100*bsz*bsz];
-
-    do_loop(seq, this, &PetscBlockedSystemApply::AssembleMatrix);
-    err1 = system->matrix.AssemblyBegin();
-    err2 = system->matrix.AssemblyEnd();
+      $petscBlockedSSystem(X)->
+        matrix.SetRowValues(
+                            bsz, rowidx, &rowsidx[0], count,
+                            &colidx[0], &colsidx[0], &svalues[0]
+                            );
+    } ENDFORALL ;
+    PetscErrorCode err1 = $petscBlockedSSystem(X)->matrix.AssemblyBegin();
+    PetscErrorCode err2 = $petscBlockedSSystem(X)->matrix.AssemblyEnd();
     if(err1 || err2) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error assembling PETSc blocked system matrix: "
-          << err1 << ", " << err2 << endl;
+             << err1 << ", " << err2 << endl;
       }
       Loci::Abort();
     }
 
-    do_loop(seq, this, &PetscBlockedSystemApply::AssembleRHS);
-    err1 = system->rhs.AssemblyBegin();
-    err2 = system->rhs.AssemblyEnd();
+    FORALL(dom,cell) {
+      PetscInt const row = $petscCellToRow[cell];
+      int cnt = 0;
+      for(int i = 0; i < bsz; ++i) {
+        values[cnt++] = $X_B[cell][i];
+      }
+      $petscBlockedSSystem(X)->rhs.SetValue(row, &values[0]);
+    } ENDFORALL ;
+    err1 = $petscBlockedSSystem(X)->rhs.AssemblyBegin();
+    err2 = $petscBlockedSSystem(X)->rhs.AssemblyEnd();
     if(err1 || err2) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error assembling PETSc blocked system rhs: "
-          << err1 << ", " << err2 << endl;
+             << err1 << ", " << err2 << endl;
       }
       Loci::Abort();
     }
 
-    delete[] rowsidx;
-    delete[] colidx;
-    delete[] colsidx;
-    delete[] values;
-    delete[] svalues;
-
-    err1 = system->solver.SetOperators(system->matrix);
+    err1 = $petscBlockedSSystem(X)->solver.SetOperators($petscBlockedSSystem(X)->matrix);
     if(err1) {
       if(Loci::MPI_rank == 0) {
         cerr << "Error setting PETSc blocked solver operator: " << err1 << endl;
       }
       Loci::Abort();
     }
-  }
+  } ;
+  $type petscBlockedSSolveBB(X) blackbox<PetscBlockedVector> ;
 
-  void AssembleMatrix(Entity cell) {
-    PetscInt const bsz = *block_size;
-    PetscInt count = 0, scount = 0, cnt = 0;
-    PetscInt rowidx = cell2row[cell];
+  $rule unit(petscBlockedSSolveBB(X)<- petscBlockSSize(X),
+             petscCellToRow, petscNumCell, petscOptions(X),
+             petscMatrixName(X), petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscAssembly),option(disable_threading),
+  prelude {
+    int const bsz = *$petscBlockSSize(X);
 
-    int const nl = lower.num_elems(cell);
-    int const nu = upper.num_elems(cell);
-
-    for(int i = 0; i < bsz; ++i) {
-      rowsidx[i] = cell2row[cell]*bsz+i;
-    }
-
-    for(int l = 0; l < nl; ++l) {
-      Entity fc = lower[cell][l];
-      Entity lc = cl[fc];
-      colidx[count++] = cell2row[lc];
-      for(int i = 0; i < bsz; ++i) {
-        colsidx[scount++] = cell2row[lc]*bsz+i;
-      }
-      for(int j = 0; j < bsz; ++j) {
-        for(int i = 0; i < bsz; ++i) {
-          values[cnt++] = xL[fc][i][j];
-        }
-      }
-    }
-    {
-      colidx[count++] = cell2row[cell];
-      for(int i = 0; i < bsz; ++i) {
-        colsidx[scount++] = cell2row[cell]*bsz+i;
-      }
-      for(int j = 0; j < bsz; ++j) {
-        for(int i = 0; i < bsz; ++i) {
-          values[cnt++] = xD[cell][i][j];
-        }
-      }
-    }
-    for(int u = 0; u < nu; ++u) {
-      Entity fc = upper[cell][u];
-      Entity rc = cr[fc];
-      if(cell2row[cell] != cell2row[rc]) {
-        colidx[count++] = cell2row[rc];
-        for(int i = 0; i < bsz; ++i) {
-          colsidx[scount++] = cell2row[rc]*bsz+i;
-        }
-        for(int j = 0; j < bsz; ++j) {
-          for(int i = 0; i < bsz; ++i) {
-            values[cnt++] = xU[fc][i][j];
-          }
-        }
-      }
-    }
-
-    for(int i = 0; i < bsz; ++i) {
-      for(int k = 0; k < scount; ++k) {
-        svalues[i*scount+k] = values[k*bsz+i];
-      }
-    }
-
-    system->matrix.SetRowValues(
-      bsz, rowidx, rowsidx, count, colidx, colsidx, svalues
-    );
-  }
-
-  void AssembleRHS(Entity cell) {
-    PetscInt const bsz = *block_size;
-    PetscInt const row = cell2row[cell];
-    int cnt = 0;
-    for(int i = 0; i < bsz; ++i) {
-      values[cnt++] = xB[cell][i];
-    }
-    system->rhs.SetValue(row, values);
-  }
-};
-
-register_rule<PetscBlockedSystemApply> register_PetscBlockedSystemApply;
-
-class PetscBlockedSolveUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<int> block_size;
-  const_store<int> cell2row;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> petsc_options;
-  const_param<std::string> matrix_name;
-  const_param<std::string> options_prefix;
-
-public:
-  PetscBlockedSolveUnit() {
-    name_store("petscBlockedSSolveBB(X)", solution);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscNumCell", num_cells);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSSolveBB(X)");
-
-    input("petscBlockSSize(X)");
-    input("petscCellToRow");
-    input("petscNumCell");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    err = solution->Create(
-      bsz, n, N, matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err = $petscBlockedSSolveBB(X)->
+      Create(
+             bsz, n, N, $petscMatrixName(X)->c_str(),
+             $petscOptionsPrefix(X)->c_str()
+             );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc solution vector for blocked system: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = solution->SetValue(0.0);
+    err = $petscBlockedSSolveBB(X)->SetValue(0.0);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error initializing PETSc solution vector for blocked system: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveUnit> register_PetscBlockedSolveUnit;
-
-class PetscBlockedSolveApply : public apply_rule<
-  blackbox<PetscBlockedVector>, Loci::NullOp<PetscBlockedVector>
-> {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<PetscBlockedSystem> system;
-
-public:
-  PetscBlockedSolveApply() {
-    name_store("petscBlockedSSolveBB(X)", solution);
-    name_store("petscBlockedSSystem(X)", system);
-
-    output("petscBlockedSSolveBB(X)");
-
-    input("petscBlockedSSystem(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-    err = system->solver.Solve(system->rhs, *solution);
+  $rule apply(petscBlockedSSolveBB(X)<-petscBlockedSSystem(X))[Loci::NullOp],
+  constraint(geom_cells,usePetscAssembly), option(disable_threading),
+    prelude {
+    PetscErrorCode err = $petscBlockedSSystem(X)
+      ->solver.Solve($petscBlockedSSystem(X)->rhs,
+                     *$petscBlockedSSolveBB(X)) ;
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error in PETSc blocked solve: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveApply> register_PetscBlockedSolveApply;
-
-class PetscBlockedCopy : public pointwise_rule {
-private:
-  storeVec<real> X;
-  const_blackbox<PetscBlockedVector> X_solve;
-  const_blackbox<int> block_size;
-
-public:
-  PetscBlockedCopy() {
-    name_store("petscBlockedSSolve(X)", X);
-    name_store("petscBlockedSSolveBB(X)", X_solve);
-    name_store("petscBlockSSize(X)", block_size);
-
-    output("petscBlockedSSolve(X)");
-
-    input("petscBlockedSSolveBB(X)");
-    input("petscBlockSSize(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule pointwise(petscBlockedSSolve(X)<-
+                  petscBlockedSSolveBB(X),petscBlockSSize(X)),
+  constraint(geom_cells,usePetscAssembly), option(disable_threading),
+  prelude {
     PetscInt minRowNum, maxRowNum;
-    X_solve->GetOwnershipRange(&minRowNum, &maxRowNum);
-    int const bsz = *block_size;
-    X.setVecSize(bsz);
+    $petscBlockedSSolveBB(X)->GetOwnershipRange(&minRowNum, &maxRowNum);
+    int const bsz = *$petscBlockSSize(X) ;
+    $petscBlockedSSolve(X).setVecSize(bsz);
     PetscScalar * X_Copy;
-    X_solve->GetArray(&X_Copy);
+    $petscBlockedSSolveBB(X)->GetArray(&X_Copy);
     sequence::const_iterator cellPtr = seq.begin();
     for(PetscInt row = minRowNum; row < maxRowNum; ++cellPtr) {
       for(int i = 0; i < bsz; ++i, ++row) {
-        X[*cellPtr][i] = X_Copy[row-minRowNum];
+        $petscBlockedSSolve(X)[*cellPtr][i] = X_Copy[row-minRowNum];
       }
     }
-    X_solve->RestoreArray(&X_Copy);
-  }
-};
+    $petscBlockedSSolveBB(X)->RestoreArray(&X_Copy);
+  } ;
 
-register_rule<PetscBlockedCopy> register_PetscBlockedCopy;
+  $type petscBlockedVecSCoords(X) blackbox<PetscVecCoords> ;
 
-class PetscBlockedVecCoordsUnit : public unit_rule {
-private:
-  blackbox<PetscVecCoords> vec_coords;
+  $rule unit(petscBlockedVecSCoords(X)),
+  constraint(geom_cells),option(disable_threading),
+  prelude {
+    $petscBlockedVecSCoords(X) = PetscVecCoords() ;
+  } ;
 
-public:
-  PetscBlockedVecCoordsUnit() {
-    name_store("petscBlockedVecSCoords(X)", vec_coords);
+  $rule apply(petscBlockedVecSCoords(X)<-petscCellToRow,
+              petscBlockSSize(X),petscVecEntities)[Loci::NullOp],
+  constraint(geom_cells), option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSSize(X) ;
 
-    output("petscBlockedVecSCoords(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *vec_coords = PetscVecCoords();
-  }
-};
-
-register_rule<PetscBlockedVecCoordsUnit> register_PetscBlockedVecCoordsUnit;
-
-class PetscBlockedVecCoordsApply : public apply_rule<
-  blackbox<PetscVecCoords>, NullOp<PetscVecCoords>
-> {
-private:
-  blackbox<PetscVecCoords> vec_coords;
-  const_store<int> cell2row;
-  const_blackbox<int> block_size;
-  const_blackbox<PetscVecEntities> vec_entities;
-
-public:
-  PetscBlockedVecCoordsApply() {
-    name_store("petscBlockedVecSCoords(X)", vec_coords);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("petscVecEntities", vec_entities);
-
-    output("petscBlockedVecSCoords(X)");
-
-    input("petscCellToRow");
-    input("petscBlockSSize(X)");
-    input("petscVecEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-
-    vec_coords->rowidx.resize(vec_entities->size*bsz);
-    for(size_t i = 0; i < vec_entities->size; ++i) {
+    $petscBlockedVecSCoords(X)->rowidx.resize($petscVecEntities->size*bsz);
+    for(size_t i = 0; i < $petscVecEntities->size; ++i) {
       for(int j = 0; j < bsz; ++j) {
-        vec_coords->rowidx[i*bsz+j] = cell2row[vec_entities->entity[i]]*bsz+j;
+        $petscBlockedVecSCoords(X)->rowidx[i*bsz+j] =
+          $petscCellToRow[$petscVecEntities->entity[i]]*bsz+j;
       }
     }
 
-    vec_coords->size = (PetscCount)(vec_entities->size*bsz);
-  }
-};
+    $petscBlockedVecSCoords(X)->size =
+      (PetscCount)($petscVecEntities->size*bsz);
+  } ;
 
-register_rule<PetscBlockedVecCoordsApply> register_PetscBlockedVecCoordsApply;
 
-class PetscBlockedMatCoordsUnit : public unit_rule {
-private:
-  blackbox<PetscMatCoords> mat_coords;
-
-public:
-  PetscBlockedMatCoordsUnit() {
-    name_store("petscBlockedMatSCoords(X)", mat_coords);
-
-    output("petscBlockedMatSCoords(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *mat_coords = PetscMatCoords();
-  }
-};
-
-register_rule<PetscBlockedMatCoordsUnit> register_PetscBlockedMatCoordsUnit;
-
-class PetscBlockedMatCoordsApply : public apply_rule<
-  blackbox<PetscMatCoords>, NullOp<PetscMatCoords>
-> {
-private:
-  blackbox<PetscMatCoords> mat_coords;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_blackbox<int> block_size;
-  const_store<int> cell2row;
-  const_blackbox<PetscMatEntities> mat_entities;
-
-public:
-  PetscBlockedMatCoordsApply() {
-    name_store("petscBlockedMatSCoords(X)", mat_coords);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscMatEntities", mat_entities);
-
-    output("petscBlockedMatSCoords(X)");
-
-    input("petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("petscBlockSSize(X)");
-    input("petscMatEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
+  $type petscBlockedMatSCoords(X) blackbox<PetscMatCoords> ;
+  $rule unit(petscBlockedMatSCoords(X)),
+  constraint(geom_cells),option(disable_threading),
+  prelude {
+    $petscBlockedMatSCoords(X) = PetscMatCoords() ;
+  } ;
+  $rule apply(petscBlockedMatSCoords(X)<- petscCellToRow,
+              lower->cl->petscCellToRow, upper->cr->petscCellToRow,
+              petscBlockSSize(X), petscMatEntities)[Loci::NullOp],
+  constraint(geom_cells),option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSSize(X) ;
     int const bsz2 = bsz*bsz;
 
-    mat_coords->rowidx.resize(mat_entities->size*bsz2);
-    mat_coords->colidx.resize(mat_entities->size*bsz2);
+    $petscBlockedMatSCoords(X)->rowidx.resize($petscMatEntities->size*bsz2);
+    $petscBlockedMatSCoords(X)->colidx.resize($petscMatEntities->size*bsz2);
 
-    for(size_t i = 0; i < mat_entities->size; ++i) {
-      int const br = cell2row[mat_entities->row_cell[i]];
-      int const bc = cell2row[mat_entities->col_cell[i]];
+    for(size_t i = 0; i < $petscMatEntities->size; ++i) {
+      int const br = $petscCellToRow[$petscMatEntities->row_cell[i]];
+      int const bc = $petscCellToRow[$petscMatEntities->col_cell[i]];
       for(int c = 0; c < bsz; ++c) {
         for(int r = 0; r < bsz; ++r) {
           size_t const li = i*bsz2+c*bsz+r;
-          mat_coords->rowidx[li] = br*bsz+r;
-          mat_coords->colidx[li] = bc*bsz+c;
+          $petscBlockedMatSCoords(X)->rowidx[li] = br*bsz+r;
+          $petscBlockedMatSCoords(X)->colidx[li] = bc*bsz+c;
         }
       }
     }
 
-    mat_coords->size = (PetscCount)(mat_entities->size*bsz2);
-  }
-};
+    $petscBlockedMatSCoords(X)->size =
+      (PetscCount)($petscMatEntities->size*bsz2);
+  } ;
 
-register_rule<PetscBlockedMatCoordsApply> register_PetscBlockedMatCoordsApply;
+  $type petscBlockedSSystemCOO(X) blackbox<PetscBlockedSystem> ;
+  $rule unit( petscBlockedSSystemCOO(X)<-petscBlockedVecSCoords(X),
+              petscBlockedMatSCoords(X),petscNumCell,petscBlockSSize(X),
+              petscOptions(X),petscMatrixName(X), petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
+    int const bsz = *$petscBlockSSize(X);
 
-class PetscBlockedSystemCOOUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_blackbox<PetscVecCoords> vec_coords;
-  const_blackbox<PetscMatCoords> mat_coords;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> block_size;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
-
-public:
-  PetscBlockedSystemCOOUnit() {
-    name_store("petscBlockedSSystemCOO(X)", system);
-    name_store("petscBlockedVecSCoords(X)", vec_coords);
-    name_store("petscBlockedMatSCoords(X)", mat_coords);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSSystemCOO(X)");
-
-    input("petscBlockedVecSCoords(X)");
-    input("petscBlockedMatSCoords(X)");
-    input("petscNumCell");
-    input("petscBlockSSize(X)");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    vector<PetscInt> vec_rowidx = vec_coords->rowidx;
-    vector<PetscInt> mat_rowidx = mat_coords->rowidx;
-    vector<PetscInt> mat_colidx = mat_coords->colidx;
+    vector<PetscInt> vec_rowidx = $petscBlockedVecSCoords(X)->rowidx;
+    vector<PetscInt> mat_rowidx = $petscBlockedMatSCoords(X)->rowidx;
+    vector<PetscInt> mat_colidx = $petscBlockedMatSCoords(X)->colidx;
 
-    err = system->rhs.CreateCOO(
-      bsz, n, N, vec_coords->size, &vec_rowidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err =
+      $petscBlockedSSystemCOO(X)
+      ->rhs.CreateCOO(
+                      bsz, n, N, $petscBlockedVecSCoords(X)->size,
+                      &vec_rowidx[0],
+                      $petscMatrixName(X)->c_str(),
+                      $petscOptionsPrefix(X)->c_str()
+                      );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system rhs: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->matrix.CreateCOO(
-      bsz, n, N, mat_coords->size, &mat_rowidx[0], &mat_colidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    err = $petscBlockedSSystemCOO(X)->matrix.CreateCOO(
+                                                       bsz, n, N,
+                                                       $petscBlockedMatSCoords(X)->size,
+                                                       &mat_rowidx[0], &mat_colidx[0],
+                                                       $petscMatrixName(X)->c_str(),
+                                                       $petscOptionsPrefix(X)->c_str()
+                                                       );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.Create(1e-5, 1e-18, 100, options_prefix->c_str());
+    err = $petscBlockedSSystemCOO(X)
+      ->solver.Create(1e-5, 1e-18, 100, $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc solver: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSystemCOOUnit> register_PetscBlockedSystemCOOUnit;
-
-class PetscBlockedSystemCOOApply : public apply_rule<
-  blackbox<PetscBlockedSystem>, NullOp<PetscBlockedSystem>
-> {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_blackbox<PetscVecEntities> vec_entities;
-  const_blackbox<PetscMatEntities> mat_entities;
-  const_store<int> cell2row;
-  const_blackbox<int> block_size;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_storeVec<real_fj> xB;
-  const_storeMat<real_fj> xD, xL, xU;
-
-public:
-  PetscBlockedSystemCOOApply() {
-    name_store("petscBlockedSSystemCOO(X)", system);
-    name_store("petscVecEntities", vec_entities);
-    name_store("petscMatEntities", mat_entities);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("X_B", xB);
-    name_store("X_D", xD);
-    name_store("X_L", xL);
-    name_store("X_U", xU);
-
-    output("petscBlockedSSystemCOO(X)");
-
-    input("petscVecEntities");
-    input("petscMatEntities");
-    input("petscCellToRow");
-    input("petscBlockSSize(X)");
-    input("upper->cr->petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("X_B");
-    input("X_D");
-    input("lower->X_L");
-    input("upper->X_U");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
+  $rule apply(petscBlockedSSystemCOO(X)<-petscVecEntities,petscMatEntities,
+              petscCellToRow,petscBlockSSize(X),upper->cr->petscCellToRow,
+              lower->cl->petscCellToRow,
+              X_B,X_D,lower->X_L,upper->X_U)[Loci::NullOp],
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSSize(X) ;
     int const bsz2 = bsz*bsz;
 
-    size_t const vec_size = vec_entities->size*bsz;
-    size_t const mat_size = mat_entities->size*bsz2;
+    size_t const vec_size = $petscVecEntities->size*bsz;
+    size_t const mat_size = $petscMatEntities->size*bsz2;
 
     vector<PetscScalar> vec_values(vec_size, 0.0);
     vector<PetscScalar> mat_values(mat_size, 0.0);
 
-    for(size_t i = 0; i < vec_entities->size; ++i) {
+    for(size_t i = 0; i < $petscVecEntities->size; ++i) {
       for(int b = 0; b < bsz; ++b) {
-        vec_values[i*bsz+b] = xB[vec_entities->entity[i]][b];
+        vec_values[i*bsz+b] = $X_B[$petscVecEntities->entity[i]][b];
       }
     }
 
-    for(size_t i = mat_entities->off[0]; i < mat_entities->off[1]; ++i) {
+    for(size_t i = $petscMatEntities->off[0]; i < $petscMatEntities->off[1]; ++i) {
       for(int c = 0; c < bsz; ++c) {
         for(int r = 0; r < bsz; ++r) {
-          mat_values[i*bsz2+c*bsz+r] = xD[mat_entities->value_entity[i]][r][c];
+          mat_values[i*bsz2+c*bsz+r] = $X_D[$petscMatEntities->value_entity[i]][r][c];
         }
       }
     }
 
-    for(size_t i = mat_entities->off[1]; i < mat_entities->off[2]; ++i) {
+    for(size_t i = $petscMatEntities->off[1]; i < $petscMatEntities->off[2]; ++i) {
       for(int r = 0; r < bsz; ++r) {
         for(int c = 0; c < bsz; ++c) {
-          mat_values[i*bsz2+c*bsz+r] = xL[mat_entities->value_entity[i]][r][c];
+          mat_values[i*bsz2+c*bsz+r] = $X_L[$petscMatEntities->value_entity[i]][r][c];
         }
       }
     }
 
-    for(size_t i = mat_entities->off[2]; i < mat_entities->off[3]; ++i) {
+    for(size_t i = $petscMatEntities->off[2]; i < $petscMatEntities->off[3]; ++i) {
       for(int r = 0; r < bsz; ++r) {
         for(int c = 0; c < bsz; ++c) {
-          mat_values[i*bsz2+c*bsz+r] = xU[mat_entities->value_entity[i]][r][c];
+          mat_values[i*bsz2+c*bsz+r] = $X_U[$petscMatEntities->value_entity[i]][r][c];
         }
       }
     }
 
-    PetscErrorCode err;
-    err = system->rhs.SetValuesCOO(&vec_values[0]);
+    PetscErrorCode err = $petscBlockedSSystemCOO(X)
+      ->rhs.SetValuesCOO(&vec_values[0]);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assigning values to PETSc blocked system rhs: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->matrix.SetValuesCOO(&mat_values[0]);
+    err = $petscBlockedSSystemCOO(X)->matrix.SetValuesCOO(&mat_values[0]);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assigning values to PETSc blocked system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.SetOperators(system->matrix);
+    err = $petscBlockedSSystemCOO(X)
+      ->solver.SetOperators($petscBlockedSSystemCOO(X)->matrix);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error setting PETSc blocked solver operator: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSystemCOOApply> register_PetscBlockedSystemCOOApply;
+  $type petscBlockedSSolveCOOBB(X) blackbox<PetscBlockedVector> ;
 
-class PetscBlockedSolveCOOUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<int> block_size;
-  const_store<int> cell2row;
-  const_param<vector<int> > num_cells;
-  const_blackbox<PetscVecCoords> vec_coords;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
+  $rule unit(petscBlockedSSolveCOOBB(X)<-petscBlockSSize(X),
+             petscCellToRow,petscNumCell,
+             petscBlockedVecSCoords(X), petscOptions(X),
+             petscMatrixName(X), petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
 
-public:
-  PetscBlockedSolveCOOUnit() {
-    name_store("petscBlockedSSolveCOOBB(X)", solution);
-    name_store("petscBlockSSize(X)", block_size);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockedVecSCoords(X)", vec_coords);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
+    int const bsz = *$petscBlockSSize(X);
 
-    output("petscBlockedSSolveCOOBB(X)");
-
-    input("petscBlockSSize(X)");
-    input("petscCellToRow");
-    input("petscNumCell");
-    input("petscBlockedVecSCoords(X)");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    vector<PetscInt> rowidx = vec_coords->rowidx;
+    vector<PetscInt> rowidx = $petscBlockedVecSCoords(X)->rowidx;
 
-    err = solution->CreateCOO(
-      bsz, n, N, vec_coords->size, &rowidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err =
+      $petscBlockedSSolveCOOBB(X)
+      ->CreateCOO(bsz, n, N, $petscBlockedVecSCoords(X)->size, &rowidx[0],
+                  $petscMatrixName(X)->c_str(),
+                  $petscOptionsPrefix(X)->c_str()
+                  );
 
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked solution vector" << endl;
       }
       Loci::Abort();
     }
 
-    err = solution->SetValue(0.0);
+    err = $petscBlockedSSolveCOOBB(X)->SetValue(0.0);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error initializing PETSc blocked solution vector: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveCOOUnit> register_PetscBlockedSolveCOOUnit;
-
-class PetscBlockedSolveCOOApply : public apply_rule<
-  blackbox<PetscBlockedVector>, NullOp<PetscBlockedVector>
-> {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<PetscBlockedSystem> system;
-
-public:
-  PetscBlockedSolveCOOApply() {
-    name_store("petscBlockedSSolveCOOBB(X)", solution);
-    name_store("petscBlockedSSystemCOO(X)", system);
-
-    output("petscBlockedSSolveCOOBB(X)");
-
-    input("petscBlockedSSystemCOO(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-    err = system->solver.Solve(system->rhs, *solution);
+  $rule apply(petscBlockedSSolveCOOBB(X)<-
+              petscBlockedSSystemCOO(X))[Loci::NullOp],
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+    prelude {
+    PetscErrorCode err =
+      $petscBlockedSSystemCOO(X)->
+      solver.Solve($petscBlockedSSystemCOO(X)->rhs,
+                   *$petscBlockedSSolveCOOBB(X));
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error solving PETSc blocked system: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveCOOApply> register_PetscBlockedSolveCOOApply;
+  $type petscBlockedSSolve(X) storeVec<real> ;
 
-class PetscBlockedCOOCopy : public pointwise_rule {
-private:
-  storeVec<real> X;
-  const_blackbox<PetscBlockedVector> X_solve;
-  const_blackbox<int> block_size;
-
-public:
-  PetscBlockedCOOCopy() {
-    name_store("petscBlockedSSolve(X)", X);
-    name_store("petscBlockedSSolveCOOBB(X)", X_solve);
-    name_store("petscBlockSSize(X)", block_size);
-
-    output("petscBlockedSSolve(X)");
-
-    input("petscBlockedSSolveCOOBB(X)");
-    input("petscBlockSSize(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule pointwise(petscBlockedSSolve(X)<-petscBlockedSSolveCOOBB(X),
+                  petscBlockSSize(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
     PetscInt minRowNum, maxRowNum;
-    X_solve->GetOwnershipRange(&minRowNum, &maxRowNum);
-    int const bsz = *block_size;
-    X.setVecSize(bsz);
+    $petscBlockedSSolveCOOBB(X)->GetOwnershipRange(&minRowNum, &maxRowNum);
+    int const bsz = *$petscBlockSSize(X) ;
+    $petscBlockedSSolve(X).setVecSize(bsz);
     PetscScalar * X_Copy;
-    X_solve->GetArray(&X_Copy);
+    $petscBlockedSSolveCOOBB(X)->GetArray(&X_Copy);
     sequence::const_iterator cellPtr = seq.begin();
     for(PetscInt row = minRowNum; row < maxRowNum; ++cellPtr) {
       for(int i = 0; i < bsz; ++i, ++row) {
-        X[*cellPtr][i] = X_Copy[row-minRowNum];
+        $petscBlockedSSolve(X)[*cellPtr][i] = X_Copy[row-minRowNum];
       }
     }
-    X_solve->RestoreArray(&X_Copy);
-  }
-};
+    $petscBlockedSSolveCOOBB(X)->RestoreArray(&X_Copy);
+  } ;
 
-register_rule<PetscBlockedCOOCopy> register_PetscBlockedCOOCopy;
+
+
+  $untype X_B ;
+  $untype X_L ;
+  $untype X_U ;
+  $untype X_D ;
+
+  $type X_B storeVec<real> ;
+  $type X_L storeMat<real> ;
+  $type X_U storeMat<real> ;
+  $type X_D storeMat<real> ;
+
+  $type petscBlockSize(X) blackbox<int> ;
+  $rule unit(petscBlockSize(X)),constraint(X_B), prelude {
+    *$petscBlockSize(X) = 0 ;
+  } ;
+
+  
+  $rule apply(petscBlockSize(X)<-X_B)[Loci::NullOp], prelude {
+    *$petscBlockSize(X) = max(*$petscBlockSize(X),$X_B.vecSize()) ;
+  } ;
     
-} // end: namespace blockeds
+  $type petscBlockVecCoords(X) blackbox<PetscVecCoords> ;
+  $rule unit(petscBlockVecCoords(X)),
+  constraint(geom_cells),option(disable_threading),
+  prelude {
+    $petscBlockVecCoords(X) = PetscVecCoords() ;
+  } ;
 
-namespace blocked {
+  $rule apply(petscBlockVecCoords(X)<-petscCellToRow,
+              petscBlockSize(X),petscVecEntities)[Loci::NullOp],
+  constraint(geom_cells), option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSize(X) ;
 
-class PetscGetBlockSizeUnit : public unit_rule {
-  blackbox<int> block_size;
+    $petscBlockVecCoords(X)->rowidx.resize($petscVecEntities->size*bsz);
+    for(size_t i = 0; i < $petscVecEntities->size; ++i) {
+      for(int j = 0; j < bsz; ++j) {
+        $petscBlockVecCoords(X)->rowidx[i*bsz+j] =
+          $petscCellToRow[$petscVecEntities->entity[i]]*bsz+j;
+      }
+    }
 
-public:
-  PetscGetBlockSizeUnit() {
-    name_store("petscBlockSize(X)", block_size);
-    constraint("X_B");
-    output("petscBlockSize(X)");
-  }
+    $petscBlockVecCoords(X)->size =
+      (PetscCount)($petscVecEntities->size*bsz);
+  } ;
 
-  void compute(sequence const &seq) {
-    *block_size = 0;
-  }
-};
 
-register_rule<PetscGetBlockSizeUnit> register_PetscGetBlockSizeUnit;
+  $type petscBlockMatCoords(X) blackbox<PetscMatCoords> ;
+  $rule unit(petscBlockMatCoords(X)),
+  constraint(geom_cells),option(disable_threading),
+  prelude {
+    $petscBlockMatCoords(X) = PetscMatCoords() ;
+  } ;
+  $rule apply(petscBlockMatCoords(X)<- petscCellToRow,
+              lower->cl->petscCellToRow, upper->cr->petscCellToRow,
+              petscBlockSize(X), petscMatEntities)[Loci::NullOp],
+  constraint(geom_cells),option(disable_threading),
+    prelude {
+    int const bsz = *$petscBlockSize(X) ;
+    int const bsz2 = bsz*bsz;
 
-class PetscGetBlockSizeApply : public apply_rule<
-  blackbox<int>, Loci::NullOp<int>
-> {
-private:
-  const_storeVec<real> xB;
-  blackbox<int> block_size;
+    $petscBlockMatCoords(X)->rowidx.resize($petscMatEntities->size*bsz2);
+    $petscBlockMatCoords(X)->colidx.resize($petscMatEntities->size*bsz2);
 
-public:
-  PetscGetBlockSizeApply() {
-    name_store("X_B", xB);
-    name_store("petscBlockSize(X)", block_size);
+    for(size_t i = 0; i < $petscMatEntities->size; ++i) {
+      int const br = $petscCellToRow[$petscMatEntities->row_cell[i]];
+      int const bc = $petscCellToRow[$petscMatEntities->col_cell[i]];
+      for(int c = 0; c < bsz; ++c) {
+        for(int r = 0; r < bsz; ++r) {
+          size_t const li = i*bsz2+c*bsz+r;
+          $petscBlockMatCoords(X)->rowidx[li] = br*bsz+r;
+          $petscBlockMatCoords(X)->colidx[li] = bc*bsz+c;
+        }
+      }
+    }
 
-    output("petscBlockSize(X)");
+    $petscBlockMatCoords(X)->size =
+      (PetscCount)($petscMatEntities->size*bsz2);
+  } ;
 
-    input("X_B");
-  }
-
-  void compute(sequence const & seq) {
-    *block_size = max(*block_size, xB.vecSize());
-  }
-};
-
-register_rule<PetscGetBlockSizeApply> register_PetscGetBlockSizeApply;
-
-class PetscScalarDNNZVectorUnit : public unit_rule {
-private:
-  blackbox<std::vector<int> > dnnz_vector;
-
-public:
-  PetscScalarDNNZVectorUnit() {
-    name_store("petscScalarDNNZVector(X)", dnnz_vector);
-    output("petscScalarDNNZVector(X)");
-    constraint("geom_cells");
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    (*dnnz_vector) = std::vector<int>();
-  }
-};
-
-register_rule<PetscScalarDNNZVectorUnit> register_PetscScalarDNNZVectorUnit;
-
-class PetscScalarDNNZApply : public apply_rule<
-  blackbox<std::vector<int> >,
-  Loci::NullOp<std::vector<int> >
-> {
-private:
-  blackbox<std::vector<int> > dnnz_vector;
-  const_store<int> dnnz;
-  const_param<std::vector<int> > num_cells;
-  const_blackbox<int> block_size;
-
-public:
-  PetscScalarDNNZApply() {
-    name_store("petscScalarDNNZVector(X)", dnnz_vector);
-    name_store("petscDNNZ", dnnz);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSize(X)", block_size);
-
-    output("petscScalarDNNZVector(X)");
-
-    input("petscDNNZ");
-    input("petscNumCell");
-    input("petscBlockSize(X)");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $type petscScalarDNNZVector(X) blackbox<std::vector<int> >  ;
+  $rule unit(petscScalarDNNZVector(X)),
+  constraint(geom_cells),option(disable_threading),prelude {
+    $petscScalarDNNZVector(X) = std::vector<int>() ;
+  } ;
+  $rule apply(petscScalarDNNZVector(X)<-petscDNNZ,petscNumCell,
+              petscBlockSize(X))[Loci::NullOp],
+  option(disable_threading),prelude {
+    int const bsz = *$petscBlockSize(X);
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
     int count = 0;
-    (*dnnz_vector).resize(n*bsz);
+    (*$petscScalarDNNZVector(X)).resize(n*bsz);
     sequence::const_iterator siter = seq.begin();
     while(siter != seq.end()) {
       for(int i = 0; i < bsz; ++i) {
-        (*dnnz_vector)[count*bsz+i] = dnnz[*siter]*bsz;
+        (*$petscScalarDNNZVector(X))[count*bsz+i] = $petscDNNZ[*siter]*bsz;
       }
       ++siter;
       ++count;
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarDNNZApply> register_PetscScalarDNNZApply;
+  $type petscScalarONNZVector(X) blackbox<std::vector<int> > ;
 
-class PetscScalarONNZVectorUnit : public unit_rule {
-private:
-  blackbox<std::vector<int> > onnz_vector;
+  $rule unit(petscScalarONNZVector(X)),
+  constraint(geom_cells), prelude {
+    $petscScalarONNZVector(X) = std::vector<int>() ;
+  } ;
 
-public:
-  PetscScalarONNZVectorUnit() {
-    name_store("petscScalarONNZVector(X)", onnz_vector);
-    output("petscScalarONNZVector(X)");
-    constraint("geom_cells");
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    (*onnz_vector) = std::vector<int>();
-  }
-};
-
-register_rule<PetscScalarONNZVectorUnit> register_PetscScalarONNZVectorUnit;
-
-class PetscScalarONNZVectorApply : public apply_rule<
-  blackbox<std::vector<int> >,
-  Loci::NullOp<std::vector<int> >
-> {
-private:
-  blackbox<std::vector<int> > onnz_vector;
-  const_store<int> onnz;
-  const_param<std::vector<int> > num_cells;
-  const_blackbox<int> block_size;
-
-public:
-  PetscScalarONNZVectorApply() {
-    name_store("petscScalarONNZVector(X)", onnz_vector);
-    name_store("petscONNZ", onnz);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSize(X)", block_size);
-
-    output("petscScalarONNZVector(X)");
-
-    input("petscONNZ");
-    input("petscNumCell");
-    input("petscBlockSize(X)");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule apply(petscScalarONNZVector(X)<-petscONNZ,petscNumCell,
+              petscBlockSize(X))[Loci::NullOp],
+  option(disable_threading),prelude {
+    int const bsz = *$petscBlockSize(X);
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
-
+    
     int count = 0;
-    (*onnz_vector).resize(n*bsz);
+    (*$petscScalarONNZVector(X)).resize(n*bsz);
     sequence::const_iterator siter = seq.begin();
     while(siter != seq.end()) {
       for(int i = 0; i < bsz; ++i) {
-        (*onnz_vector)[count*bsz+i] = onnz[*siter]*bsz;
+        (*$petscScalarONNZVector(X))[count*bsz+i] = $petscONNZ[*siter]*bsz;
       }
       ++siter;
       ++count;
     }
-  }
-};
+  } ;
 
-register_rule<PetscScalarONNZVectorApply> register_PetscScalarONNZVectorApply;
+  $type petscBlockedSystem(X) blackbox<PetscBlockedSystem> ;
 
-class PetscBlockedSystemUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> block_size;
-  const_blackbox<vector<int> > dnnz_vector;
-  const_blackbox<vector<int> > onnz_vector;
-  const_blackbox<vector<int> > scalar_dnnz_vector;
-  const_blackbox<vector<int> > scalar_onnz_vector;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
-
-public:
-  PetscBlockedSystemUnit() {
-    name_store("petscBlockedSystem(X)", system);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("petscDNNZVector", dnnz_vector);
-    name_store("petscONNZVector", onnz_vector);
-    name_store("petscScalarDNNZVector(X)", scalar_dnnz_vector);
-    name_store("petscScalarONNZVector(X)", scalar_onnz_vector);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSystem(X)");
-
-    input("petscNumCell");
-    input("petscBlockSize(X)");
-    input("petscDNNZVector");
-    input("petscONNZVector");
-    input("petscScalarDNNZVector(X)");
-    input("petscScalarONNZVector(X)");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+  $rule unit(petscBlockedSystem(X)<-petscNumCell,petscBlockSize(X),
+             petscDNNZVector,petscONNZVector,petscScalarDNNZVector(X),
+             petscScalarONNZVector(X),petscOptions(X),
+             petscMatrixName(X),petscOptionsPrefix(X)),
+  constraint(geom_cells),option(disable_threading), prelude {
+    int const bsz = *$petscBlockSize(X);
+    
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    err = system->rhs.Create(bsz, n, N, matrix_name->c_str(), options_prefix->c_str());
+    PetscErrorCode err =
+      $petscBlockedSystem(X)->rhs.Create(bsz, n, N,
+                                         $petscMatrixName(X)->c_str(),
+                                         $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system rhs: " << err << endl;
       }
       Loci::Abort();
     }
-
-    err = system->matrix.Create(
-      bsz, n, N, &(*dnnz_vector)[0], &(*onnz_vector)[0],
-      &(*scalar_dnnz_vector)[0], &(*scalar_onnz_vector)[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    
+    err = $petscBlockedSystem(X)->
+      matrix.Create(
+                    bsz, n, N, &(*$petscDNNZVector)[0],
+                    &(*$petscONNZVector)[0],
+                    &(*$petscScalarDNNZVector(X))[0],
+                    &(*$petscScalarONNZVector(X))[0],
+                    $petscMatrixName(X)->c_str(),
+                    $petscOptionsPrefix(X)->c_str()
+                    );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system matrix: " << err << endl;
       }
       Loci::Abort();
     }
-
-    err = system->solver.Create(1e-5, 1e-18, 100, options_prefix->c_str());
+    
+    err = $petscBlockedSystem(X)->
+      solver.Create(1e-5, 1e-18, 100, $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked solver: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSystemUnit> register_PetscBlockedSystemUnit;
+  $rule apply(petscBlockedSystem(X)<-petscCellToRow,
+              upper->cr->petscCellToRow,lower->cl->petscCellToRow,max_fpc,
+              petscBlockSize(X),X_B,X_D,lower->X_L, upper->X_U)[Loci::NullOp],
+  constraint(geom_cells),option(disable_threading),prelude {
+    int const bsz = *$petscBlockSize(X) ;
 
-class PetscBlockedSystemApply : public apply_rule<
-  blackbox<PetscBlockedSystem>, NullOp<PetscBlockedSystem>
-> {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_store<int> cell2row;
-  const_blackbox<int> block_size;
-  const_multiMap lower, upper;
-  const_Map cl, cr;
-  const_storeVec<real> xB;
-  const_storeMat<real> xD, xL, xU;
+    int mwidth = *$max_fpc+1 ;
+    vector<PetscInt> rowsidx(bsz) ;
+    vector<PetscInt> colidx(mwidth) ;
+    vector<PetscInt> colsidx(mwidth*bsz) ;
+    vector<PetscScalar> values(mwidth*bsz*bsz) ;
+    vector<PetscScalar> svalues(mwidth*bsz*bsz) ;
 
-  PetscInt * rowsidx;
-  PetscInt * colidx;
-  PetscInt * colsidx;
-  PetscScalar * values;
-  PetscScalar * svalues;
+    entitySet dom = entitySet(seq) ;
+    //    do_loop(seq, this, &PetscBlockedSystemApply::AssembleMatrix);
+    FORALL(dom,cell) {
+      PetscInt count = 0, scount = 0, cnt = 0;
+      PetscInt rowidx = $petscCellToRow[cell];
 
-public:
-  PetscBlockedSystemApply() {
-    name_store("petscBlockedSystem(X)", system);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("X_B", xB);
-    name_store("X_D", xD);
-    name_store("X_L", xL);
-    name_store("X_U", xU);
+      int const nl = $lower.num_elems(cell);
+      int const nu = $upper.num_elems(cell);
 
-    output("petscBlockedSystem(X)");
+      for(int i = 0; i < bsz; ++i) {
+        rowsidx[i] = $petscCellToRow[cell]*bsz+i;
+      }
 
-    input("petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("petscBlockSize(X)");
-    input("X_B");
-    input("X_D");
-    input("lower->X_L");
-    input("upper->X_U");
+      for(int l = 0; l < nl; ++l) {
+        Entity fc = $lower[cell][l];
+        Entity lc = $cl[fc];
+        colidx[count++] = $petscCellToRow[lc];
+        for(int i = 0; i < bsz; ++i) {
+          colsidx[scount++] = $petscCellToRow[lc]*bsz+i;
+        }
+        for(int j = 0; j < bsz; ++j) {
+          for(int i = 0; i < bsz; ++i) {
+            values[cnt++] = $X_L[fc][i][j];
+          }
+        }
+      }
+      colidx[count++] = $petscCellToRow[cell];
+      for(int i = 0; i < bsz; ++i) {
+        colsidx[scount++] = $petscCellToRow[cell]*bsz+i;
+      }
+      for(int j = 0; j < bsz; ++j) {
+        for(int i = 0; i < bsz; ++i) {
+          values[cnt++] = $X_D[cell][i][j];
+        }
+      }
+      for(int u = 0; u < nu; ++u) {
+        Entity fc = $upper[cell][u];
+        Entity rc = $cr[fc];
+        if($petscCellToRow[cell] != $petscCellToRow[rc]) {
+          colidx[count++] = $petscCellToRow[rc];
+          for(int i = 0; i < bsz; ++i) {
+            colsidx[scount++] = $petscCellToRow[rc]*bsz+i;
+          }
+          for(int j = 0; j < bsz; ++j) {
+            for(int i = 0; i < bsz; ++i) {
+              values[cnt++] = $X_U[fc][i][j];
+            }
+          }
+        }
+      }
 
-    constraint("geom_cells");
+      for(int i = 0; i < bsz; ++i) {
+        for(int k = 0; k < bsz*count; ++k) {
+          svalues[i*count*bsz+k] = values[k*bsz+i];
+        }
+      }
 
-    disable_threading();
-  }
+      $petscBlockedSystem(X)->
+        matrix.SetRowValues(
+                            bsz, rowidx, &rowsidx[0], count,
+                            &colidx[0], &colsidx[0], &svalues[0]
+                            );
+    } ENDFORALL ;
 
-  void compute(sequence const & seq) {
-    PetscErrorCode err1, err2;
-
-    int const bsz = *block_size;
-
-    rowsidx = new PetscInt[bsz];
-    colidx = new PetscInt[100];
-    colsidx = new PetscInt[100*bsz];
-    values = new PetscScalar[100*bsz*bsz];
-    svalues = new PetscScalar[100*bsz*bsz];
-
-    do_loop(seq, this, &PetscBlockedSystemApply::AssembleMatrix);
-    err1 = system->matrix.AssemblyBegin();
-    err2 = system->matrix.AssemblyEnd();
+    PetscErrorCode err1 =
+      $petscBlockedSystem(X)->matrix.AssemblyBegin();
+    PetscErrorCode  err2 =
+      $petscBlockedSystem(X)->matrix.AssemblyEnd();
     if(err1 || err2) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assembling PETSc blocked system matrix: "
-          << err1 << ", " << err2 << endl;
+             << err1 << ", " << err2 << endl;
       }
       Loci::Abort();
     }
 
-    do_loop(seq, this, &PetscBlockedSystemApply::AssembleRHS);
-    err1 = system->rhs.AssemblyBegin();
-    err2 = system->rhs.AssemblyEnd();
+    //do_loop(seq, this, &PetscBlockedSystemApply::AssembleRHS);
+    FORALL(dom,cell) {
+      PetscInt const row = $petscCellToRow[cell];
+      int cnt = 0;
+      for(int i = 0; i < bsz; ++i) {
+        values[cnt++] = $X_B[cell][i];
+      }
+      $petscBlockedSystem(X)->rhs.SetValue(row, &values[0]);
+    } ENDFORALL ;
+    err1 = $petscBlockedSystem(X)->rhs.AssemblyBegin();
+    err2 = $petscBlockedSystem(X)->rhs.AssemblyEnd();
     if(err1 || err2) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assembling PETSc blocked system rhs: "
-          << err1 << ", " << err2 << endl;
+             << err1 << ", " << err2 << endl;
       }
       Loci::Abort();
     }
 
-    delete[] rowsidx;
-    delete[] colidx;
-    delete[] colsidx;
-    delete[] values;
-    delete[] svalues;
-
-    err1 = system->solver.SetOperators(system->matrix);
+    err1 = $petscBlockedSystem(X)->
+      solver.SetOperators($petscBlockedSystem(X)->matrix);
     if(err1) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error setting PETSc blocked solver operator: " << err1 << endl;
       }
       Loci::Abort();
     }
-  }
+  } ;
+  
+  $type petscBlockedSolveBB(X) blackbox<PetscBlockedVector> ;
+  
+  $rule unit(petscBlockedSolveBB(X)<-petscBlockSize(X),petscCellToRow,
+             petscNumCell,petscOptions(X),
+             petscMatrixName(X),petscOptionsPrefix(X)),
+  option(disable_threading),prelude {
+    int const bsz = *$petscBlockSize(X);
 
-  void AssembleMatrix(Entity cell) {
-    PetscInt const bsz = *block_size;
-    PetscInt count = 0, scount = 0, cnt = 0;
-    PetscInt rowidx = cell2row[cell];
-
-    int const nl = lower.num_elems(cell);
-    int const nu = upper.num_elems(cell);
-
-    for(int i = 0; i < bsz; ++i) {
-      rowsidx[i] = cell2row[cell]*bsz+i;
-    }
-
-    for(int l = 0; l < nl; ++l) {
-      Entity fc = lower[cell][l];
-      Entity lc = cl[fc];
-      colidx[count++] = cell2row[lc];
-      for(int i = 0; i < bsz; ++i) {
-        colsidx[scount++] = cell2row[lc]*bsz+i;
-      }
-      for(int j = 0; j < bsz; ++j) {
-        for(int i = 0; i < bsz; ++i) {
-          values[cnt++] = xL[fc][i][j];
-        }
-      }
-    }
-    colidx[count++] = cell2row[cell];
-    for(int i = 0; i < bsz; ++i) {
-      colsidx[scount++] = cell2row[cell]*bsz+i;
-    }
-    for(int j = 0; j < bsz; ++j) {
-      for(int i = 0; i < bsz; ++i) {
-        values[cnt++] = xD[cell][i][j];
-      }
-    }
-    for(int u = 0; u < nu; ++u) {
-      Entity fc = upper[cell][u];
-      Entity rc = cr[fc];
-      if(cell2row[cell] != cell2row[rc]) {
-        colidx[count++] = cell2row[rc];
-        for(int i = 0; i < bsz; ++i) {
-          colsidx[scount++] = cell2row[rc]*bsz+i;
-        }
-        for(int j = 0; j < bsz; ++j) {
-          for(int i = 0; i < bsz; ++i) {
-            values[cnt++] = xU[fc][i][j];
-          }
-        }
-      }
-    }
-
-    for(int i = 0; i < bsz; ++i) {
-      for(int k = 0; k < bsz*count; ++k) {
-        svalues[i*count*bsz+k] = values[k*bsz+i];
-      }
-    }
-
-    system->matrix.SetRowValues(
-      bsz, rowidx, rowsidx, count, colidx, colsidx, svalues
-    );
-  }
-
-  void AssembleRHS(Entity cell) {
-    PetscInt const bsz = *block_size;
-    PetscInt const row = cell2row[cell];
-    int cnt = 0;
-    for(int i = 0; i < bsz; ++i) {
-      values[cnt++] = xB[cell][i];
-    }
-    system->rhs.SetValue(row, values);
-  }
-};
-
-register_rule<PetscBlockedSystemApply> register_PetscBlockedSystemApply;
-
-class PetscBlockedSolveUnit : public unit_rule {
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<int> block_size;
-  const_store<int> cell2row;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> petsc_options;
-  const_param<std::string> matrix_name;
-  const_param<std::string> options_prefix;
-
-public:
-  PetscBlockedSolveUnit() {
-    name_store("petscBlockedSolveBB(X)", solution);
-    name_store("petscBlockSize(X)",block_size);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscNumCell", num_cells);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSolveBB(X)");
-
-    input("petscBlockSize(X)");
-    input("petscCellToRow");
-    input("petscNumCell");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
-
-    err = solution->Create(
-      bsz, n, N, matrix_name->c_str(), options_prefix->c_str()
-    );
+      
+    PetscErrorCode err =
+      $petscBlockedSolveBB(X)->
+      Create(
+             bsz, n, N, $petscMatrixName(X)->c_str(),
+             $petscOptionsPrefix(X)->c_str()
+             );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc solution vector for blocked system: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = solution->SetValue(0.0);
+    err = $petscBlockedSolveBB(X)->SetValue(0.0);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error initializing PETSc solution vector for blocked system: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
 
-register_rule<PetscBlockedSolveUnit> register_PetscBlockedSolveUnit;
+  } ;
 
-class PetscBlockedSolveApply : public apply_rule<
-  blackbox<PetscBlockedVector>, Loci::NullOp<PetscBlockedVector>
-> {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<PetscBlockedSystem> system;
-
-public:
-  PetscBlockedSolveApply() {
-    name_store("petscBlockedSolveBB(X)", solution);
-    name_store("petscBlockedSystem(X)", system);
-
-    output("petscBlockedSolveBB(X)");
-
-    input("petscBlockSystem(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-    err = system->solver.Solve(system->rhs, *solution);
+  $rule apply(petscBlockedSolveBB(X)<-petscBlockedSystem(X))[Loci::NullOp],
+  constraint(geom_cells),option(disable_threading),prelude {
+    PetscErrorCode err =
+      $petscBlockedSystem(X)->solver.Solve($petscBlockedSystem(X)->rhs,
+                                           *$petscBlockedSolveBB(X));
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error in PETSc blocked solve: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveApply> register_PetscBlockedSolveApply;
-
-class PetscBlockedCopy : public pointwise_rule {
-private:
-  const_blackbox<PetscBlockedVector> X_solve;
-  storeVec<real> X;
-  const_blackbox<int> block_size;
-
-public:
-  PetscBlockedCopy() {
-    name_store("petscBlockedSolve(X)", X);
-    name_store("petscBlockedSolveBB(X)", X_solve);
-    name_store("petscBlockSize(X)", block_size);
-
-    output("petscBlockedSolve(X)");
-
-    input("petscBlockedSolveBB(X)");
-    input("petscBlockSize(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule pointwise(petscBlockedSolve(X)<-petscBlockedSolveBB(X),
+                  petscBlockSize(X)),
+  constraint(geom_cells,usePetscAssembly), option(disable_threading),
+  prelude {
     PetscInt minRowNum, maxRowNum;
-    X_solve->GetOwnershipRange(&minRowNum, &maxRowNum);
-    int const bsz = *block_size;
-    X.setVecSize(bsz);
+    $petscBlockedSolveBB(X)->GetOwnershipRange(&minRowNum, &maxRowNum);
+    int const bsz = *$petscBlockSize(X) ;
+    $petscBlockedSolve(X).setVecSize(bsz);
     PetscScalar * X_Copy;
-    X_solve->GetArray(&X_Copy);
+    $petscBlockedSolveBB(X)->GetArray(&X_Copy);
     sequence::const_iterator cellPtr = seq.begin();
     for(PetscInt row = minRowNum; row < maxRowNum; ++cellPtr) {
       for(int i = 0; i < bsz; ++i, ++row) {
-        X[*cellPtr][i] = X_Copy[row-minRowNum];
+        $petscBlockedSolve(X)[*cellPtr][i] = X_Copy[row-minRowNum];
       }
     }
-    X_solve->RestoreArray(&X_Copy);
-  }
-};
+    $petscBlockedSolveBB(X)->RestoreArray(&X_Copy);
+  } ;
+  $type petscBlockedSystemCOO(X) blackbox<PetscBlockedSystem> ;
+  $rule unit(petscBlockedSystemCOO(X)<-petscBlockVecCoords(X),
+             petscBlockMatCoords(X),petscNumCell,
+             petscBlockSize(X), petscOptions(X),
+             petscMatrixName(X), petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
+    int const bsz = *$petscBlockSize(X);
 
-register_rule<PetscBlockedCopy> register_PetscBlockedCopy;
-
-class PetscBlockedVecCoordsUnit : public unit_rule {
-private:
-  blackbox<PetscVecCoords> vec_coords;
-
-public:
-  PetscBlockedVecCoordsUnit() {
-    name_store("petscBlockedVecCoords(X)", vec_coords);
-
-    output("petscBlockedVecCoords(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *vec_coords = PetscVecCoords();
-  }
-};
-
-register_rule<PetscBlockedVecCoordsUnit> register_PetscBlockedVecCoordsUnit;
-
-class PetscBlockedVecCoordsApply : public apply_rule<
-  blackbox<PetscVecCoords>, NullOp<PetscVecCoords>
-> {
-private:
-  blackbox<PetscVecCoords> vec_coords;
-  const_store<int> cell2row;
-  const_blackbox<int> block_size;
-  const_blackbox<PetscVecEntities> vec_entities;
-
-public:
-  PetscBlockedVecCoordsApply() {
-    name_store("petscBlockedVecCoords(X)", vec_coords);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("petscVecEntities", vec_entities);
-
-    output("petscBlockedVecCoords(X)");
-
-    input("petscCellToRow");
-    input("petscBlockSize(X)");
-    input("petscVecEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-
-    vec_coords->rowidx.resize(vec_entities->size*bsz);
-    for(size_t i = 0; i < vec_entities->size; ++i) {
-      for(int j = 0; j < bsz; ++j) {
-        vec_coords->rowidx[i*bsz+j] = cell2row[vec_entities->entity[i]]*bsz+j;
-      }
-    }
-
-    vec_coords->size = (PetscCount)(vec_entities->size*bsz);
-  }
-};
-
-register_rule<PetscBlockedVecCoordsApply> register_PetscBlockedVecCoordsApply;
-
-class PetscBlockedMatCoordsUnit : public unit_rule {
-private:
-  blackbox<PetscMatCoords> mat_coords;
-
-public:
-  PetscBlockedMatCoordsUnit() {
-    name_store("petscBlockedMatCoords(X)", mat_coords);
-
-    output("petscBlockedMatCoords(X)");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    *mat_coords = PetscMatCoords();
-  }
-};
-
-register_rule<PetscBlockedMatCoordsUnit> register_PetscBlockedMatCoordsUnit;
-
-class PetscBlockedMatCoordsApply : public apply_rule<
-  blackbox<PetscMatCoords>, NullOp<PetscMatCoords>
-> {
-private:
-  blackbox<PetscMatCoords> mat_coords;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_blackbox<int> block_size;
-  const_store<int> cell2row;
-  const_blackbox<PetscMatEntities> mat_entities;
-
-public:
-  PetscBlockedMatCoordsApply() {
-    name_store("petscBlockedMatCoords(X)", mat_coords);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscMatEntities", mat_entities);
-
-    output("petscBlockedMatCoords(X)");
-
-    input("petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("upper->cr->petscCellToRow");
-    input("petscBlockSize(X)");
-    input("petscMatEntities");
-
-    constraint("geom_cells");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
-    int const bsz2 = bsz*bsz;
-
-    mat_coords->rowidx.resize(mat_entities->size*bsz2);
-    mat_coords->colidx.resize(mat_entities->size*bsz2);
-
-    for(size_t i = 0; i < mat_entities->size; ++i) {
-      int const br = cell2row[mat_entities->row_cell[i]];
-      int const bc = cell2row[mat_entities->col_cell[i]];
-      for(int c = 0; c < bsz; ++c) {
-        for(int r = 0; r < bsz; ++r) {
-          size_t const li = i*bsz2+c*bsz+r;
-          mat_coords->rowidx[li] = br*bsz+r;
-          mat_coords->colidx[li] = bc*bsz+c;
-        }
-      }
-    }
-
-    mat_coords->size = (PetscCount)(mat_entities->size*bsz2);
-  }
-};
-
-register_rule<PetscBlockedMatCoordsApply> register_PetscBlockedMatCoordsApply;
-
-class PetscBlockedSystemCOOUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_blackbox<PetscVecCoords> vec_coords;
-  const_blackbox<PetscMatCoords> mat_coords;
-  const_param<vector<int> > num_cells;
-  const_blackbox<int> block_size;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
-
-public:
-  PetscBlockedSystemCOOUnit() {
-    name_store("petscBlockedSystemCOO(X)", system);
-    name_store("petscBlockVecCoords(X)", vec_coords);
-    name_store("petscBlockMatCoords(X)", mat_coords);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSystemCOO(X)");
-
-    input("petscBlockVecCoords(X)");
-    input("petscBlockMatCoords(X)");
-    input("petscNumCell");
-    input("petscBlockSize(X)");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
     int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    vector<PetscInt> vec_rowidx = vec_coords->rowidx;
-    vector<PetscInt> mat_rowidx = mat_coords->rowidx;
-    vector<PetscInt> mat_colidx = mat_coords->colidx;
+    vector<PetscInt> vec_rowidx = $petscBlockVecCoords(X)->rowidx;
+    vector<PetscInt> mat_rowidx = $petscBlockMatCoords(X)->rowidx;
+    vector<PetscInt> mat_colidx = $petscBlockMatCoords(X)->colidx;
 
-    err = system->rhs.CreateCOO(
-      bsz, n, N, vec_coords->size, &vec_rowidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err =
+      $petscBlockedSystemCOO(X)->
+      rhs.CreateCOO(
+                    bsz, n, N, $petscBlockVecCoords(X)->size, &vec_rowidx[0],
+                    $petscMatrixName(X)->c_str(),
+                    $petscOptionsPrefix(X)->c_str()
+                    );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system rhs: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->matrix.CreateCOO(
-      bsz, n, N, mat_coords->size, &mat_rowidx[0], &mat_colidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    err = $petscBlockedSystemCOO(X)->
+      matrix.CreateCOO(
+                       bsz, n, N, $petscBlockMatCoords(X)->size,
+                       &mat_rowidx[0], &mat_colidx[0],
+                       $petscMatrixName(X)->c_str(),
+                       $petscOptionsPrefix(X)->c_str()
+                       );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.Create(1e-5, 1e-18, 100, options_prefix->c_str());
+    err = $petscBlockedSystemCOO(X)->
+      solver.Create(1e-5, 1e-18, 100, $petscOptionsPrefix(X)->c_str());
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked solver: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
+  
 
-register_rule<PetscBlockedSystemCOOUnit> register_PetscBlockedSystemCOOUnit;
-
-class PetscBlockedSystemCOOApply : public apply_rule<
-  blackbox<PetscBlockedSystem>, NullOp<PetscBlockedSystem>
-> {
-private:
-  blackbox<PetscBlockedSystem> system;
-  const_blackbox<PetscVecEntities> vec_entities;
-  const_blackbox<PetscMatEntities> mat_entities;
-  const_store<int> cell2row;
-  const_blackbox<int> block_size;
-  const_multiMap lower;
-  const_multiMap upper;
-  const_Map cl;
-  const_Map cr;
-  const_storeVec<real> xB;
-  const_storeMat<real> xD, xL, xU;
-
-public:
-  PetscBlockedSystemCOOApply() {
-    name_store("petscBlockedSystemCOO(X)", system);
-    name_store("petscVecEntities", vec_entities);
-    name_store("petscMatEntities", mat_entities);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("lower", lower);
-    name_store("upper", upper);
-    name_store("cl", cl);
-    name_store("cr", cr);
-    name_store("X_B", xB);
-    name_store("X_D", xD);
-    name_store("X_L", xL);
-    name_store("X_U", xU);
-
-    output("petscBlockedSystemCOO(X)");
-
-    input("petscVecEntities");
-    input("petscMatEntities");
-    input("petscCellToRow");
-    input("petscBlockSize(X)");
-    input("upper->cr->petscCellToRow");
-    input("lower->cl->petscCellToRow");
-    input("X_B");
-    input("X_D");
-    input("lower->X_L");
-    input("upper->X_U");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    int const bsz = *block_size;
+  $rule apply(petscBlockedSystemCOO(X)<-petscVecEntities,petscMatEntities,
+              petscCellToRow,petscBlockSize(X),
+              upper->cr->petscCellToRow,lower->cl->petscCellToRow,
+              X_B,X_D,lower->X_L,upper->X_U)[Loci::NullOp],
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
+    int const bsz = *$petscBlockSize(X) ;
     int const bsz2 = bsz*bsz;
-
-    size_t vec_size = vec_entities->size*bsz;
-    size_t mat_size = mat_entities->size*bsz2;
+    
+    size_t vec_size = $petscVecEntities->size*bsz;
+    size_t mat_size = $petscMatEntities->size*bsz2;
 
     vector<PetscScalar> vec_values(vec_size, 0.0);
     vector<PetscScalar> mat_values(mat_size, 0.0);
 
-    for(size_t i = 0; i < vec_entities->size; ++i) {
+    for(size_t i = 0; i < $petscVecEntities->size; ++i) {
       for(int b = 0; b < bsz; ++b) {
-        vec_values[i*bsz+b] = xB[vec_entities->entity[i]][b];
+        vec_values[i*bsz+b] = $X_B[$petscVecEntities->entity[i]][b];
       }
     }
 
-    for(size_t i = mat_entities->off[0]; i < mat_entities->off[1]; ++i) {
+    for(size_t i = $petscMatEntities->off[0]; i < $petscMatEntities->off[1]; ++i) {
       for(int r = 0; r < bsz; ++r) {
         for(int c = 0; c < bsz; ++c) {
-          mat_values[i*bsz2+c*bsz+r] = xD[mat_entities->value_entity[i]][r][c];
+          mat_values[i*bsz2+c*bsz+r] = $X_D[$petscMatEntities->value_entity[i]][r][c];
         }
       }
     }
 
-    for(size_t i = mat_entities->off[1]; i < mat_entities->off[2]; ++i) {
+    for(size_t i = $petscMatEntities->off[1]; i < $petscMatEntities->off[2]; ++i) {
       for(int r = 0; r < bsz; ++r) {
         for(int c = 0; c < bsz; ++c) {
-          mat_values[i*bsz2+c*bsz+r] = xL[mat_entities->value_entity[i]][r][c];
+          mat_values[i*bsz2+c*bsz+r] = $X_L[$petscMatEntities->value_entity[i]][r][c];
         }
       }
     }
 
-    for(size_t i = mat_entities->off[2]; i < mat_entities->off[3]; ++i) {
+    for(size_t i = $petscMatEntities->off[2]; i < $petscMatEntities->off[3]; ++i) {
       for(int r = 0; r < bsz; ++r) {
         for(int c = 0; c < bsz; ++c) {
-          mat_values[i*bsz2+c*bsz+r] = xU[mat_entities->value_entity[i]][r][c];
+          mat_values[i*bsz2+c*bsz+r] = $X_U[$petscMatEntities->value_entity[i]][r][c];
         }
       }
     }
 
-    PetscErrorCode err;
-    err = system->rhs.SetValuesCOO(&vec_values[0]);
+    PetscErrorCode err = $petscBlockedSystemCOO(X)->
+      rhs.SetValuesCOO(&vec_values[0]);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assigning values to PETSc blocked system rhs: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->matrix.SetValuesCOO(&mat_values[0]);
+    err = $petscBlockedSystemCOO(X)->matrix.SetValuesCOO(&mat_values[0]);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error assigning values to PETSc blocked system matrix: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = system->solver.SetOperators(system->matrix);
+    err = $petscBlockedSystemCOO(X)->
+      solver.SetOperators($petscBlockedSystemCOO(X)->matrix);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error setting PETSc blocked solver operator: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSystemCOOApply> register_PetscBlockedSystemCOOApply;
+  $type petscBlockedSolveCOOBB(X) blackbox<PetscBlockedVector> ;
 
-class PetscBlockedSolveCOOUnit : public unit_rule {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<int> block_size;
-  const_store<int> cell2row;
-  const_param<vector<int> > num_cells;
-  const_blackbox<PetscVecCoords> vec_coords;
-  const_blackbox<int> petsc_options;
-  const_param<string> matrix_name;
-  const_param<string> options_prefix;
+  $rule unit(petscBlockedSolveCOOBB(X)<-petscBlockSize(X),petscCellToRow,
+             petscNumCell,petscBlockVecCoords(X),petscOptions(X),
+             petscMatrixName(X),petscOptionsPrefix(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
+    int const bsz = *$petscBlockSize(X);
 
-public:
-  PetscBlockedSolveCOOUnit() {
-    name_store("petscBlockedSolveCOOBB(X)", solution);
-    name_store("petscBlockSize(X)", block_size);
-    name_store("petscCellToRow", cell2row);
-    name_store("petscNumCell", num_cells);
-    name_store("petscBlockVecCoords(X)", vec_coords);
-    name_store("petscOptions(X)", petsc_options);
-    name_store("petscMatrixName(X)", matrix_name);
-    name_store("petscOptionsPrefix(X)", options_prefix);
-
-    output("petscBlockedSolveCOOBB(X)");
-
-    input("petscBlockSize(X)");
-    input("petscCellToRow");
-    input("petscNumCell");
-    input("petscBlockVecCoords(X)");
-    input("petscOptions(X)");
-    input("petscMatrixName(X)");
-    input("petscOptionsPrefix(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-
-    int const bsz = *block_size;
-
-    int const n = (*num_cells)[Loci::MPI_rank];
-    int N = 0;
-    for(size_t i = 0; i < (*num_cells).size(); ++i) {
-      N += (*num_cells)[i];
+    int const n = (*$petscNumCell)[Loci::MPI_rank];
+    int N = 0 ;
+    for(size_t i = 0; i < (*$petscNumCell).size(); ++i) {
+      N += (*$petscNumCell)[i];
     }
 
-    vector<PetscInt> rowidx = vec_coords->rowidx;
+    vector<PetscInt> rowidx = $petscBlockVecCoords(X)->rowidx;
 
-    err = solution->CreateCOO(
-      bsz, n, N, vec_coords->size, &rowidx[0],
-      matrix_name->c_str(), options_prefix->c_str()
-    );
+    PetscErrorCode err =
+      $petscBlockedSolveCOOBB(X)->
+      CreateCOO(
+                bsz, n, N, $petscBlockVecCoords(X)->size, &rowidx[0],
+                $petscMatrixName(X)->c_str(), $petscOptionsPrefix(X)->c_str()
+                );
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error creating PETSc blocked solution vector: " << err << endl;
       }
       Loci::Abort();
     }
 
-    err = solution->SetValue(0.0);
+    err = $petscBlockedSolveCOOBB(X)->SetValue(0.0);
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error initializing PETSc blocked solution vector: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveCOOUnit> register_PetscBlockedSolveCOOUnit;
-
-class PetscBlockedSolveCOOApply : public apply_rule<
-  blackbox<PetscBlockedVector>, NullOp<PetscBlockedVector>
-> {
-private:
-  blackbox<PetscBlockedVector> solution;
-  const_blackbox<PetscBlockedSystem> system;
-
-public:
-  PetscBlockedSolveCOOApply() {
-    name_store("petscBlockedSolveCOOBB(X)", solution);
-    name_store("petscBlockedSystemCOO(X)", system);
-
-    output("petscBlockedSolveCOOBB(X)");
-
-    input("petscBlockedSystemCOO(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
-    PetscErrorCode err;
-    err = system->solver.Solve(system->rhs, *solution);
+  $rule apply(petscBlockedSolveCOOBB(X)<-
+              petscBlockedSystemCOO(X))[Loci::NullOp],
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+    prelude {
+    PetscErrorCode err =
+      $petscBlockedSystemCOO(X)->solver.Solve($petscBlockedSystemCOO(X)->rhs,
+                                              *$petscBlockedSolveCOOBB(X));
     if(err) {
-      if(Loci::MPI_rank == 0) {
+      $[Once] {
         cerr << "Error solving PETSc blocked system: " << err << endl;
       }
       Loci::Abort();
     }
-  }
-};
+  } ;
 
-register_rule<PetscBlockedSolveCOOApply> register_PetscBlockedSolveCOOApply;
-
-class PetscBlockedCOOCopy : public pointwise_rule {
-private:
-  storeVec<real> X;
-  const_blackbox<PetscBlockedVector> X_solve;
-  const_blackbox<int> block_size;
-
-public:
-  PetscBlockedCOOCopy() {
-    name_store("petscBlockedSolve(X)", X);
-    name_store("petscBlockedSolveCOOBB(X)", X_solve);
-    name_store("petscBlockSize(X)", block_size);
-
-    output("petscBlockedSolve(X)");
-
-    input("petscBlockedSolveCOOBB(X)");
-    input("petscBlockSize(X)");
-
-    constraint("geom_cells");
-    constraint("usePetscCOOAssembly");
-
-    disable_threading();
-  }
-
-  void compute(sequence const & seq) {
+  $rule pointwise(petscBlockedSolve(X)<-petscBlockedSolveCOOBB(X),
+                  petscBlockSize(X)),
+  constraint(geom_cells,usePetscCOOAssembly),option(disable_threading),
+  prelude {
     PetscInt minRowNum, maxRowNum;
-    X_solve->GetOwnershipRange(&minRowNum, &maxRowNum);
-    int const bsz = *block_size;
-    X.setVecSize(bsz);
+    $petscBlockedSolveCOOBB(X)->GetOwnershipRange(&minRowNum, &maxRowNum);
+    int const bsz = *$petscBlockSize(X);
+    $petscBlockedSolve(X).setVecSize(bsz);
     PetscScalar * X_Copy;
-    X_solve->GetArray(&X_Copy);
+    $petscBlockedSolveCOOBB(X)->GetArray(&X_Copy);
     sequence::const_iterator cellPtr = seq.begin();
     for(PetscInt row = minRowNum; row < maxRowNum; ++cellPtr) {
       for(int i = 0; i < bsz; ++i, ++row) {
-        X[*cellPtr][i] = X_Copy[row-minRowNum];
+        $petscBlockedSolve(X)[*cellPtr][i] = X_Copy[row-minRowNum];
       }
     }
-    X_solve->RestoreArray(&X_Copy);
-  }
-};
-
-register_rule<PetscBlockedCOOCopy> register_PetscBlockedCOOCopy;
-
-} // end: namespace blocked
+    $petscBlockedSolveCOOBB(X)->RestoreArray(&X_Copy);
+  } ;
 
 } // end: namespace Loci
 #endif


### PR DESCRIPTION
I converted the petsc module to use the lpp format as a process to go through more through review of the recent changes to support GPGPUs.  In the process I found that the double blocked matrix code had a fault, and removed some magic numbers from the implementation.  Also I changed the reporting of device information unless the user selects this option.  On my system I have found that I cannot run with more than 32 cores with this printing enabled without segfaulting.  Also, it gets stuck on this code when the number of cores is fairly large.  I think there is alot of contention on the shared gpu resources that is causing race condition problems in the PETSc interface.  It may be that we cannot oversubscribe the gpus too much.  Please review these changes and evaluate how they work for gpu execution.