### PR TITLE
Selector pattern parameterized

### DIFF
--- a/src/FVMMod/cellgradient.loci
+++ b/src/FVMMod/cellgradient.loci
@@ -24,62 +24,60 @@ $include "FVM.lh"
 namespace Loci {
 
   $type gradStencilBias param<std::string>;
-  $rule default(gradStencilBias),
-    comments("Select the biased stencil weights. Requires a cell-based stencil_bias variable. Default is 'off'. ")
-  {
+  /// Select the biased stencil weights. Requires a cell-based stencil_bias
+  /// variable. Default is 'off'. 
+  $rule default(gradStencilBias) {
     $gradStencilBias = "off" ;
   }
 
-  $type stencilBias Constraint ;
-  $type stencilDirect Constraint ;
-  $rule constraint(stencilDirect,stencilBias<-gradStencilBias) {
-    $stencilDirect = EMPTY ;
-    $stencilBias = EMPTY;
-    if($gradStencilBias == "off") {
-      $stencilDirect = $*gradStencilBias.domain() ;
-    } else if($gradStencilBias == "on") {
-      $stencilBias = $*gradStencilBias.domain() ;
-    }else {
-      cerr << "gradStencilBias " << $gradStencilBias << " of unknown type" << endl ;
-      Loci::Abort() ;
-    }
-  }
+  $rule pointwise(OUTPUT<-selector(gradStencilBias,off)) {}
+  $type gradStencilBias_select_off Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencilBias,on)) {}
+  $type gradStencilBias_select_on Constraint ;
 
   $type gradStencil param<std::string> ;
-  
-  $rule default(gradStencil),
-    comments("Select stencil used for computing gradients.  Options include 'standard', 'stable', and 'green'.  Standard includes cells that share a face, while the stable stencil includes any cell that satisfies geometric requirements of cell face reconstructions, and 'green' implements a green's theorem gradient.")
-  {
-    $gradStencil = "standard" ;
-  }
 
-  $type stencilStandard Constraint ;
-  $type useCellStencil Constraint ;
-  $type greensGradient Constraint ;
+  /// Select stencil used for computing gradients.  Options include 'standard',
+  /// 'stable', and 'green'.  Standard includes cells that share a face, while
+  /// the stable stencil includes any cell that satisfies geometric
+  /// requirements of cell face reconstructions, and 'green' implements a
+  /// green's theorem gradient.
+  $rule default(gradStencil) { $gradStencil = "standard" ;  }
 
-  $rule constraint(stencilStandard,useCellStencil,greensGradient<-gradStencil) {
-    $stencilStandard = EMPTY ;
-    $useCellStencil = EMPTY ;
-    $greensGradient = EMPTY ;
-    if($gradStencil == "standard") {
-      $stencilStandard = $*gradStencil.domain() ;
-    } else if($gradStencil == "full" || $gradStencil == "stable"||
-              $gradStencil == "symm" || $gradStencil == "symmF" ||
-              $gradStencil == "symmC") {
-      $useCellStencil = $*gradStencil.domain() ;
-    } else if($gradStencil == "green") {
-      $greensGradient = $*gradStencil.domain() ;
-    }else {
-      cerr << "gradStencil " << $gradStencil << " of unknown type" << endl ;
-      Loci::Abort() ;
-    }
-  }
+  $rule pointwise(OUTPUT<-selector(gradStencil,standard)) {} 
+  $type gradStencil_select_standard Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencil,full)) {}
+  $type gradStencil_select_full Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencil,stable)) {}
+  $type gradStencil_select_stable Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencil,symm)) {}
+  $type gradStencil_select_symm Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencil,symmF)) {}
+  $type gradStencil_select_symmF Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencil,symmC)) {}
+  $type gradStencil_select_symmC Constraint ;
+  $rule pointwise(OUTPUT<-selector(gradStencil,green)) {}
+  $type gradStencil_select_green Constraint ;
+
+  $type useCellStencil param<bool> ;
+  $rule singleton(useCellStencil),constraint(gradStencil_select_full)
+  { $useCellStencil = true ; }
+  $rule singleton(useCellStencil),constraint(gradStencil_select_stable)
+  { $useCellStencil = true ; }
+  $rule singleton(useCellStencil),constraint(gradStencil_select_symm)
+  { $useCellStencil = true ; }
+  $rule singleton(useCellStencil),constraint(gradStencil_select_symmC)
+  { $useCellStencil = true ; }
+  $rule singleton(useCellStencil),constraint(gradStencil_select_symmF)
+  { $useCellStencil = true ; }
+    
+    
 
   $type X storeVec<real_t> ;
   $type X_f storeVec<real_t> ;
   
   $rule pointwise(gradv(X)<-(lower,upper)->(cl,cr)->(X,vol),(lower,upper)->area,boundary_map->(X_f,area),vol),
-                                constraint(geom_cells,greensGradient), prelude {
+                                constraint(geom_cells,gradStencil_select_green), prelude {
     $gradv(X).setVecSize($X.vecSize()) ;
   } compute {
     const real_t rvol = 1./$vol ;
@@ -113,7 +111,7 @@ namespace Loci {
   $type X_f store<real_t> ;
 
   $rule pointwise(grads(X)<-(lower,upper)->(cl,cr)->(X,vol),(lower,upper)->area,boundary_map->(X_f,area),vol),
-    constraint(geom_cells,greensGradient) {
+    constraint(geom_cells,gradStencil_select_green) {
     const real_t rvol = 1./$vol ;
     vector3d<real_t> gradsum = vector3d<real_t>(0.0,0.0,0.0);
     for(const Entity *li = $lower.begin();li!=$lower.end();++li) {
@@ -143,7 +141,7 @@ namespace Loci {
   $type X_f store<vector3d<real_t> > ;
   
   $rule pointwise(gradv3d(X)<-(lower,upper)->(cl,cr)->(X,vol),(lower,upper)->area,boundary_map->(X_f,area),vol),
-    constraint(geom_cells,greensGradient) {
+    constraint(geom_cells,gradStencil_select_green) {
     tensor3d<real_t>  gradsum = tensor3d<real_t> (vector3d<real_t>(0,0,0),vector3d<real_t>(0,0,0),vector3d<real_t>(0,0,0)) ;
     const real_t rvol = 1./$vol ;
     
@@ -359,7 +357,7 @@ namespace Loci {
   
   $rule pointwise(grads(X)<-lower->Wf_r,upper->Wf_l,boundary_map->Wf_l,
 		  lower->cl->X,upper->cr->X,boundary_map->X_f,X),
-    constraint(geom_cells,stencilStandard) {
+    constraint(geom_cells,gradStencil_select_standard) {
 
     vector3d<real_t> Qt_b = vector3d<real_t>(0,0,0) ;
     real_t X_center = $X ;
@@ -388,7 +386,7 @@ namespace Loci {
   $type X_f store<vector3d<real_t> > ;
   $rule pointwise(gradv3d(X)<-lower->Wf_r,upper->Wf_l,boundary_map->Wf_l,
 		  lower->cl->X,upper->cr->X,boundary_map->X_f,X),
-    constraint(geom_cells,stencilStandard) {
+    constraint(geom_cells,gradStencil_select_standard) {
 
     tensor3d<real_t>  Qt_b = tensor3d<real_t> (vector3d<real_t>(0,0,0),
 					       vector3d<real_t>(0,0,0),
@@ -430,7 +428,7 @@ namespace Loci {
   
   $rule pointwise(gradv(X)<-lower->Wf_r,upper->Wf_l,boundary_map->Wf_l,
 		  lower->cl->X,upper->cr->X,boundary_map->X_f,X),
-    constraint(geom_cells,stencilStandard),prelude {
+    constraint(geom_cells,gradStencil_select_standard),prelude {
     $gradv(X).setVecSize($X.vecSize()) ;
   } compute {
     int vs = $*X.vecSize()  ;
@@ -610,7 +608,7 @@ namespace Loci {
 		  cellcenter,cellStencil->cellcenter,
 		  boundary_map->facecenter),
             option(disable_threading),
-            constraint(cellcenter,stencilDirect),
+            constraint(cellcenter,gradStencilBias_select_off),
   prelude {
     $LSWeights.setSizes($cellStencil) ;
     $LSBWeights.setSizes($boundary_map) ;
@@ -751,7 +749,7 @@ namespace Loci {
 		  boundary_map->facecenter,
                   lower->cl,upper->cr,stencil_bias),
             option(disable_threading),
-      constraint(cellcenter,stencilBias),
+      constraint(cellcenter,gradStencilBias_select_on),
   prelude {
     $LSWeights.setSizes($cellStencil) ;
     $LSBWeights.setSizes($boundary_map) ;

--- a/src/FVMMod/facegradient.loci
+++ b/src/FVMMod/facegradient.loci
@@ -26,40 +26,23 @@ $include "FVM.lh"
 namespace Loci {
 
   $type faceGradStencil param<std::string> ;
-  
-  $rule default(faceGradStencil),
-    comments("Determines how face gradients will be computed.  May be 'positive' or 'limited'") {
-    //$faceGradStencil = "positive" ;
+
+  /// Determinse ow face gradients will be computed.  May be set to 'positive',
+  /// 'limited', 'centered', or 'nishikawa'.g
+  $rule default(faceGradStencil) {
     $faceGradStencil = "limited" ;
     //$faceGradStencil = "centered" ;
   }
 
-  $type positiveFaceStencil Constraint ;
-  $type limitedFaceStencil Constraint ;
-  $type centeredFaceStencil Constraint ;
-  $type nishikawaFaceStencil Constraint ;
+  $rule pointwise(OUTPUT<-selector(faceGradStencil,positive)) {} 
+  $type faceGradStencil_select_positive Constraint ;
+  $rule pointwise(OUTPUT<-selector(faceGradStencil,limited)) {}
+  $type faceGradStencil_select_limited Constraint ;
+  $rule pointwise(OUTPUT<-selector(faceGradStencil,centered)) {}
+  $type faceGradStencil_select_centered Constraint ;
+  $rule pointwise(OUTPUT<-selector(faceGradStencil,nishikawa)) {}
+  $type faceGradStencil_select_nishikawa Constraint ;
   
-  $rule constraint(positiveFaceStencil,limitedFaceStencil,centeredFaceStencil,
-		   nishikawaFaceStencil <-faceGradStencil) {
-    $positiveFaceStencil = EMPTY ;
-    $limitedFaceStencil = EMPTY ;
-    $centeredFaceStencil = EMPTY ;
-    $nishikawaFaceStencil = EMPTY ;
-    if($faceGradStencil == "positive") {
-      $positiveFaceStencil = $*faceGradStencil.domain() ;
-    } else if($faceGradStencil == "limited") {
-      $limitedFaceStencil = $*faceGradStencil.domain() ;
-    } else if($faceGradStencil == "centered") {
-      $centeredFaceStencil = $*faceGradStencil.domain() ;
-    } else if($faceGradStencil == "nishikawa") {
-      $nishikawaFaceStencil = $*faceGradStencil.domain() ;
-    } else {
-      cerr << "stencil " << $faceGradStencil << " is unknown, defaulting to limited" << endl ;
-      $limitedFaceStencil = $*faceGradStencil.domain() ;
-    }      
-      
-  }
-    
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
@@ -68,7 +51,7 @@ namespace Loci {
   $type X_f storeVec<real> ;
   
   $rule pointwise(gradv_f(X)<-(cr,cl)->(X,cellcenter,gradv(X),vol),area),
-    constraint(positiveFaceStencil,(cl,cr)->X), prelude {
+    constraint(faceGradStencil_select_positive,(cl,cr)->X), prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const vect3d delta = $cr->$cellcenter-$cl->$cellcenter ;
@@ -87,7 +70,7 @@ namespace Loci {
   }
   
   $rule pointwise(gradv_f(X)<-cl->(X,cellcenter,gradv(X)),X_f,facecenter,area),
-      constraint(positiveFaceStencil,ci->X),prelude {
+      constraint(faceGradStencil_select_positive,ci->X),prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const vect3d delta = $facecenter-$cl->$cellcenter ;
@@ -108,7 +91,7 @@ namespace Loci {
   $type X_f store<real> ;
 
   $rule pointwise(grads_f(X)<-(cr,cl)->(X,cellcenter,grads(X),vol),area),
-    constraint(positiveFaceStencil,(cl,cr)->X) {
+    constraint(faceGradStencil_select_positive,(cl,cr)->X) {
     const vect3d delta = $cr->$cellcenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -123,7 +106,7 @@ namespace Loci {
   }
 
   $rule pointwise(grads_f(X)<-cl->(X,cellcenter,grads(X)),X_f,facecenter,area),
-    constraint(positiveFaceStencil,ci->X) {
+    constraint(faceGradStencil_select_positive,ci->X) {
     const vect3d delta = $facecenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -140,7 +123,7 @@ namespace Loci {
   $type X_f store<vect3d> ;
 
   $rule pointwise(gradv3d_f(X)<-(cr,cl)->(X,cellcenter,gradv3d(X),vol),area),
-    constraint(positiveFaceStencil,(cl,cr)->X) {
+    constraint(faceGradStencil_select_positive,(cl,cr)->X) {
     const vect3d delta = $cr->$cellcenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -165,7 +148,7 @@ namespace Loci {
   }
 
   $rule pointwise(gradv3d_f(X)<-cl->(X,cellcenter,gradv3d(X)),X_f,facecenter,area),
-    constraint(positiveFaceStencil,ci->X) {
+    constraint(faceGradStencil_select_positive,ci->X) {
     const vect3d delta = $facecenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -196,7 +179,7 @@ namespace Loci {
   
   $rule pointwise(gradv_f(X)<-(cr,cl)->(X,cellcenter,gradv(X),vol),area,
                   (cl,cr)->limiterv(X)),
-    constraint(limitedFaceStencil,(cl,cr)->X), prelude {
+    constraint(faceGradStencil_select_limited,(cl,cr)->X), prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const vect3d delta = $cr->$cellcenter-$cl->$cellcenter ;
@@ -220,7 +203,7 @@ namespace Loci {
   
   $rule pointwise(gradv_f(X)<-cl->(X,cellcenter,gradv(X)),X_f,facecenter,
                   cl->limiterv(X),area),
-      constraint(limitedFaceStencil,ci->X),prelude {
+      constraint(faceGradStencil_select_limited,ci->X),prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const vect3d delta = $facecenter-$cl->$cellcenter ;
@@ -244,7 +227,7 @@ namespace Loci {
 
   $rule pointwise(grads_f(X)<-(cr,cl)->(X,cellcenter,grads(X),vol),area,
                   (cl,cr)->limiters(X)),
-    constraint(limitedFaceStencil,(cl,cr)->X) {
+    constraint(faceGradStencil_select_limited,(cl,cr)->X) {
     const vect3d delta = $cr->$cellcenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -266,7 +249,7 @@ namespace Loci {
 
   $rule pointwise(grads_f(X)<-cl->(X,cellcenter,grads(X)),X_f,facecenter,
                   cl->limiters(X),area),
-    constraint(limitedFaceStencil,ci->X) {
+    constraint(faceGradStencil_select_limited,ci->X) {
     const vect3d delta = $facecenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -284,7 +267,7 @@ namespace Loci {
 
   $rule pointwise(gradv3d_f(X)<-(cr,cl)->(X,cellcenter,gradv3d(X),vol),area,
                   (cl,cr)->limiterv3d(X)),
-    constraint(limitedFaceStencil,(cl,cr)->X) {
+    constraint(faceGradStencil_select_limited,(cl,cr)->X) {
     const vect3d delta = $cr->$cellcenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -319,7 +302,7 @@ namespace Loci {
 
   $rule pointwise(gradv3d_f(X)<-cl->(X,cellcenter,gradv3d(X)),X_f,facecenter,
                   cl->limiterv3d(X),area),
-    constraint(limitedFaceStencil,ci->X) {
+    constraint(faceGradStencil_select_limited,ci->X) {
     const vect3d delta = $facecenter-$cl->$cellcenter ;
     const vect3d n = $area.n ;
     const real rdist = 1./dot(delta,n) ;
@@ -351,7 +334,7 @@ namespace Loci {
 
   $rule pointwise(grads_f(X)<-(cl,cr)->(X,cellcenter,limiters(X),grads(X)),
                   face2node->pos,facecenter,area),
-    constraint(centeredFaceStencil,(cl,cr)->cellcenter) {
+    constraint(faceGradStencil_select_centered,(cl,cr)->cellcenter) {
     const int sz = $face2node.size() ;
     // compute projected distance between cells
     real_t len = dot($cr->$cellcenter-$cl->$cellcenter,$area.n) ;
@@ -399,7 +382,7 @@ namespace Loci {
 
   $rule pointwise(grads_f(X)<-area,ci->(X,cellcenter,grads(X),limiters(X)),
                   X_f,facecenter, face2node->pos),
-    constraint(centeredFaceStencil,ci->cellcenter) {
+    constraint(faceGradStencil_select_centered,ci->cellcenter) {
 
     const vector3d<real_t> n = $area.n ;
     real_t len = dot($facecenter-$ci->$cellcenter,n) ;
@@ -422,7 +405,7 @@ namespace Loci {
 
   $rule pointwise(gradv_f(X)<-(cl,cr)->(X,cellcenter,limiterv(X),gradv(X)),
                   face2node->pos,facecenter,area),
-    constraint(centeredFaceStencil,(cl,cr)->cellcenter), prelude {
+    constraint(faceGradStencil_select_centered,(cl,cr)->cellcenter), prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const int sz = $face2node.size() ;
@@ -476,7 +459,7 @@ namespace Loci {
 
   $rule pointwise(gradv_f(X)<-area,ci->(X,cellcenter,gradv(X),limiterv(X)),
                   X_f,facecenter, face2node->pos),
-      constraint(centeredFaceStencil,ci->cellcenter), prelude {
+      constraint(faceGradStencil_select_centered,ci->cellcenter), prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
 
@@ -505,7 +488,7 @@ namespace Loci {
 
   $rule pointwise(gradv3d_f(X)<-(cl,cr)->(X,cellcenter,limiterv3d(X),gradv3d(X)),
                   face2node->pos,facecenter,area),
-    constraint(centeredFaceStencil,(cl,cr)->cellcenter) {
+    constraint(faceGradStencil_select_centered,(cl,cr)->cellcenter) {
     const int sz = $face2node.size() ;
     // compute projected distance between cells
     real_t len = dot($cr->$cellcenter-$cl->$cellcenter,$area.n) ;
@@ -627,7 +610,7 @@ namespace Loci {
 
   $rule pointwise(gradv3d_f(X)<-area,ci->(X,cellcenter,gradv3d(X),limiterv3d(X)),
                   X_f,facecenter, face2node->pos),
-    constraint(centeredFaceStencil,ci->cellcenter) {
+    constraint(faceGradStencil_select_centered,ci->cellcenter) {
 
     const vector3d<real_t> n = $area.n ;
     const real_t len = dot($facecenter-$ci->$cellcenter,n) ;
@@ -672,7 +655,7 @@ namespace Loci {
 
   $rule pointwise(grads_f(X)<-(cl,cr)->(X,cellcenter,grads(X)),
                   facecenter,area),
-    constraint(nishikawaFaceStencil,(cl,cr)->cellcenter) {
+    constraint(faceGradStencil_select_nishikawa,(cl,cr)->cellcenter) {
 
     // Use gradients to compute upwind extrapolated values for left and right
     // sides of face
@@ -699,7 +682,7 @@ namespace Loci {
 
   $rule pointwise(grads_f(X)<-area,ci->(X,cellcenter,grads(X)),
                   X_f,facecenter),
-    constraint(nishikawaFaceStencil,ci->cellcenter) {
+    constraint(faceGradStencil_select_nishikawa,ci->cellcenter) {
 
     // Use gradients to compute upwind extrapolated values for left and right
     // sides of face
@@ -728,7 +711,7 @@ namespace Loci {
 
   $rule pointwise(gradv3d_f(X)<-(cl,cr)->(X,cellcenter,gradv3d(X)),
                   facecenter,area),
-    constraint(nishikawaFaceStencil,(cl,cr)->cellcenter) {
+    constraint(faceGradStencil_select_nishikawa,(cl,cr)->cellcenter) {
 
     // Use gradients to compute upwind extrapolated values for left and right
     // sides of face
@@ -761,7 +744,7 @@ namespace Loci {
 
   $rule pointwise(gradv3d_f(X)<-area,ci->(X,cellcenter,gradv3d(X)),
                   X_f,facecenter),
-    constraint(nishikawaFaceStencil,ci->cellcenter) {
+    constraint(faceGradStencil_select_nishikawa,ci->cellcenter) {
 
     // Use gradients to compute upwind extrapolated values for left and right
     // sides of face
@@ -794,7 +777,7 @@ namespace Loci {
   $type X_f storeVec<real> ;
   
   $rule pointwise(gradv_f(X)<-(cr,cl)->(X,cellcenter,gradv(X)),facecenter,area),
-    constraint(nishikawaFaceStencil,(cl,cr)->X), prelude {
+    constraint(faceGradStencil_select_nishikawa,(cl,cr)->X), prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const vect3d dvl = $facecenter-$cl->$cellcenter ;
@@ -817,7 +800,7 @@ namespace Loci {
   }
   
   $rule pointwise(gradv_f(X)<-cl->(X,cellcenter,gradv(X)),X_f,facecenter,area),
-      constraint(nishikawaFaceStencil,ci->X),prelude {
+      constraint(faceGradStencil_select_nishikawa,ci->X),prelude {
     $gradv_f(X).setVecSize($X.vecSize()) ;
   } compute {
     const vect3d dvl = $facecenter-$cl->$cellcenter ;

--- a/src/FVMMod/limiter.loci
+++ b/src/FVMMod/limiter.loci
@@ -105,41 +105,6 @@ namespace Loci {
   {
     $nisPow = 3;
   }
-  
-  $rule constraint(Vk_limiter,B_limiter,N_limiter,Z_limiter,NB_limiter,V2_limiter,NISf_limiter,NISc_limiter<-limiter) {
-    $Vk_limiter = EMPTY ;
-    $V2_limiter = EMPTY ;
-    $B_limiter = EMPTY ;
-    $NB_limiter = EMPTY ;
-    $NISf_limiter = EMPTY;
-    $NISc_limiter = EMPTY;
-    $N_limiter = EMPTY ;
-    $Z_limiter = EMPTY ;
-      
-    if($limiter == "venkatakrishnan" || $limiter == "V") {
-      $Vk_limiter = ~EMPTY ;
-    } else if($limiter == "V2") {
-      $V2_limiter = ~EMPTY ;
-    } else if($limiter == "barth" || $limiter == "B") {
-      $B_limiter = ~EMPTY ;
-    } else if($limiter == "nodalbarth" || $limiter == "NB") {
-      $NB_limiter = ~EMPTY ;
-    } else if($limiter == "nishikawaf" || $limiter == "NISf") {
-      $NISf_limiter = ~EMPTY;
-    } else if($limiter == "nishikawac" || $limiter == "NISc"){
-      $NISc_limiter = ~EMPTY;
-    } else if($limiter == "none") {
-      $N_limiter = ~EMPTY ;
-    } else if($limiter == "zero") {
-      $Z_limiter = ~EMPTY ;
-    } else {
-      cerr << "limiter " << $limiter
-	   << " not supported for generalized grids" << endl ;
-      cerr << "defaulting to venkatakrishnan limiter" << endl ;
-      $Vk_limiter = ~EMPTY ;
-    }
-  }
-
 
   $rule constraint(standardvecLimit,minvecLimit<-vecminLimiter)
   {

--- a/src/FVMMod/limiters/barth.loci
+++ b/src/FVMMod/limiters/barth.loci
@@ -26,6 +26,10 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+  $rule pointwise(OUTPUT<-selector(limiter,barth,B)) {}
+  /// Select barth's limiter
+  $type limiter_select_barth Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
@@ -36,7 +40,7 @@ namespace Loci {
 		  upper->cr->S,upper->facecenter,
 		  lower->cl->S,lower->facecenter,
 		  boundary_map->S_f,boundary_map->facecenter),
-      constraint(geom_cells,B_limiter) {
+      constraint(geom_cells,limiter_select_barth) {
     const real Xcc = $S ;
     real qmax = Xcc ;
     real qmin = qmax ;
@@ -93,7 +97,7 @@ namespace Loci {
                                 upper->cr->V,upper->facecenter,
                                 lower->cl->V,lower->facecenter,
                                 boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,B_limiter,standardv3dLimit) 
+        constraint(geom_cells,limiter_select_barth,standardv3dLimit) 
   {
     const vect3d Xcc = $V ;
     vect3d qmax = Xcc ;
@@ -186,7 +190,7 @@ namespace Loci {
                                 upper->cr->V,upper->facecenter,
                                 lower->cl->V,lower->facecenter,
                                 boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,B_limiter,minv3dLimit) 
+        constraint(geom_cells,limiter_select_barth,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     vect3d qmax = Xcc ;
@@ -281,7 +285,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,B_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_barth,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -341,7 +345,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,B_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_barth,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {

--- a/src/FVMMod/limiters/nishikawa.loci
+++ b/src/FVMMod/limiters/nishikawa.loci
@@ -26,6 +26,10 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+  $rule pointwise(OUTPUT<-selector(limiter,nishikawaf,NISf)) {}
+  /// Select Nishikawa's limiter which improves convergence characteristics.
+  $type limiter_select_nishikawaf Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
@@ -77,7 +81,7 @@ namespace Loci {
                                 upper->cr->S,upper->facecenter,
                                 lower->cl->S,lower->facecenter,
                                 boundary_map->S_f,boundary_map->facecenter),
-        constraint(geom_cells,NISf_limiter) 
+        constraint(geom_cells,limiter_select_nishikawaf) 
   {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
@@ -142,7 +146,7 @@ namespace Loci {
                                   upper->cr->V,upper->facecenter,
                                   lower->cl->V,lower->facecenter,
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,NISf_limiter,standardv3dLimit) 
+        constraint(geom_cells,limiter_select_nishikawaf,standardv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -223,7 +227,7 @@ namespace Loci {
                                   upper->cr->V,upper->facecenter,
                                   lower->cl->V,lower->facecenter,
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,NISf_limiter,minv3dLimit) 
+        constraint(geom_cells,limiter_select_nishikawaf,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -306,7 +310,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NISf_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nishikawaf,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -367,7 +371,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NISf_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nishikawaf,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {

--- a/src/FVMMod/limiters/nishikawa2.loci
+++ b/src/FVMMod/limiters/nishikawa2.loci
@@ -26,6 +26,11 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+  $rule pointwise(OUTPUT<-selector(limiter,nishikawac,NISc)) {}
+  /// Implements Nishikawa's limiter except applied to stencil instead of
+  /// extrapolated faces.
+  $type limiter_select_nishikawac Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
@@ -77,7 +82,7 @@ namespace Loci {
                                 upper->cr->(cellcenter,S),
                                 lower->cl->(cellcenter,S),
                                 boundary_map->S_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter) 
+        constraint(geom_cells,limiter_select_nishikawac) 
   {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
@@ -144,7 +149,7 @@ namespace Loci {
                                   upper->cr->(V,cellcenter),
                                   lower->cl->(V,cellcenter),
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,standardv3dLimit) 
+        constraint(geom_cells,limiter_select_nishikawac,standardv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -225,7 +230,7 @@ namespace Loci {
                                   upper->cr->(V,cellcenter),
                                   lower->cl->(V,cellcenter),
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,minv3dLimit) 
+        constraint(geom_cells,limiter_select_nishikawac,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -308,7 +313,7 @@ namespace Loci {
                                 upper->cr->(M,cellcenter),
                                 lower->cl->(M,cellcenter),
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nishikawac,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -369,7 +374,7 @@ $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                                 upper->cr->(M,cellcenter),
                                 lower->cl->(M,cellcenter),
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nishikawac,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -438,7 +443,7 @@ $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                                         Kl,nisPow,vol,grid_vol,
                                         cellStencil->(cellcenter,S),
                                         boundary_map->S_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter) 
+        constraint(geom_cells,limiter_select_nishikawac) 
   {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
@@ -487,7 +492,7 @@ $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                                           Kl,nisPow,vol,grid_vol,
                                           cellStencil->(V,cellcenter),
                                           boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,standardv3dLimit) 
+        constraint(geom_cells,limiter_select_nishikawac,standardv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -545,7 +550,7 @@ $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                                         Kl,nisPow,vol,grid_vol,
                                         cellStencil->(V,cellcenter),
                                         boundary_map->V_f,boundary_map->facecenter),
-      constraint(geom_cells,NISc_limiter,minv3dLimit) 
+      constraint(geom_cells,limiter_select_nishikawac,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -603,7 +608,7 @@ $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                                         Kl,nisPow,vol,grid_vol,
                                         cellStencil->(M,cellcenter),
                                         boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nishikawac,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -651,7 +656,7 @@ $rule pointwise(limiterv(M)<-cellcenter,M,gradv(M),firstOrderCells,
                                         Kl,nisPow,vol,grid_vol,
                                         cellStencil->(M,cellcenter),
                                         boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NISc_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nishikawac,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {

--- a/src/FVMMod/limiters/nodal_barth.loci
+++ b/src/FVMMod/limiters/nodal_barth.loci
@@ -26,6 +26,10 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+  $rule pointwise(OUTPUT<-selector(limiter,nodalbarth,NB)) {}
+  /// Select barth limiter applied to the cell nodes instead of faces.
+  $type limiter_select_nodalbarth Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
@@ -193,7 +197,7 @@ namespace Loci {
 		  upper->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S)),
 		  lower->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S)),
 		  boundary_map->face2node->(pos,NGTNodalMax(S),NGTNodalMin(S))),
-  constraint(geom_cells,NB_limiter) {
+  constraint(geom_cells,limiter_select_nodalbarth) {
     const real Xcc = $S ;
     const vect3d Xgr = $grads(S) ;
     const vect3d cent = $cellcenter ;
@@ -234,7 +238,7 @@ namespace Loci {
                                 upper->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 lower->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 boundary_map->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V))),
-  constraint(geom_cells,NB_limiter,standardv3dLimit) {
+  constraint(geom_cells,limiter_select_nodalbarth,standardv3dLimit) {
     const vect3d Xcc = $V ;
     const tens3d Xgr = $gradv3d(V) ;
     const vect3d cent = $cellcenter ;
@@ -303,7 +307,7 @@ namespace Loci {
                                 upper->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 lower->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V)),
                                 boundary_map->face2node->(pos,NGTNodalv3dMax(V),NGTNodalv3dMin(V))),
-  constraint(geom_cells,NB_limiter,minv3dLimit) 
+  constraint(geom_cells,limiter_select_nodalbarth,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     const tens3d Xgr = $gradv3d(V) ;
@@ -371,7 +375,7 @@ namespace Loci {
                               upper->cr->M,upper->facecenter,
                               lower->cl->M,lower->facecenter,
                               boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NB_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nodalbarth,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -432,7 +436,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,NB_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_nodalbarth,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {

--- a/src/FVMMod/limiters/none.loci
+++ b/src/FVMMod/limiters/none.loci
@@ -26,7 +26,7 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
-  $rule pointwise(OUTPUT<-selector(limiter,none,L1)) {}
+  $rule pointwise(OUTPUT<-selector(limiter,none)) {}
   /// No limiter is selected (the limiter is always one, effectively disabling
   /// this limiter
   $type limiter_select_none Constraint ;

--- a/src/FVMMod/limiters/none.loci
+++ b/src/FVMMod/limiters/none.loci
@@ -26,24 +26,29 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+  $rule pointwise(OUTPUT<-selector(limiter,none,L1)) {}
+  /// No limiter is selected (the limiter is always one, effectively disabling
+  /// this limiter
+  $type limiter_select_none Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
 
   $type S store<real> ;
 
-  $rule pointwise(limiters(S)<-S),constraint(geom_cells,N_limiter) {
+  $rule pointwise(limiters(S)<-S),constraint(geom_cells,limiter_select_none) {
     $limiters(S) = 1.0 ;
   }
 
   $type V store<vect3d> ;
   
-  $rule pointwise(limiterv3d(V)<-V),constraint(geom_cells,N_limiter) {
+  $rule pointwise(limiterv3d(V)<-V),constraint(geom_cells,limiter_select_none) {
     $limiterv3d(V) = vect3d(1.0,1.0,1.0) ;
   }
 
   $type M storeVec<real> ;
-  $rule pointwise(limiterv(M)<-M),constraint(geom_cells,N_limiter),prelude {
+  $rule pointwise(limiterv(M)<-M),constraint(geom_cells,limiter_select_none),prelude {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
     $limiterv(M) = mk_Scalar(1.) ;

--- a/src/FVMMod/limiters/venkatakrishnan.loci
+++ b/src/FVMMod/limiters/venkatakrishnan.loci
@@ -26,6 +26,13 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+
+  $rule pointwise(OUTPUT<-selector(limiter,venkatakrishnan,V)) {}
+
+  /// Enables the Venkatakrishnan style limiter that admits small overshoots
+  /// but enhances convergence characteristics by reducing limiter chatter.
+  $type limiter_select_venkatakrishnan Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
@@ -56,7 +63,7 @@ namespace Loci {
 		  upper->cr->S,upper->facecenter,
 		  lower->cl->S,lower->facecenter,
 		  boundary_map->S_f,boundary_map->facecenter),
-      constraint(geom_cells,Vk_limiter) {
+      constraint(geom_cells,limiter_select_venkatakrishnan) {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
@@ -121,7 +128,7 @@ namespace Loci {
                                   upper->cr->V,upper->facecenter,
                                   lower->cl->V,lower->facecenter,
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,Vk_limiter,standardv3dLimit) 
+        constraint(geom_cells,limiter_select_venkatakrishnan,standardv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -201,7 +208,7 @@ namespace Loci {
                                   upper->cr->V,upper->facecenter,
                                   lower->cl->V,lower->facecenter,
                                   boundary_map->V_f,boundary_map->facecenter),
-      constraint(geom_cells,Vk_limiter,minv3dLimit)
+      constraint(geom_cells,limiter_select_venkatakrishnan,minv3dLimit)
  {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -283,7 +290,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,Vk_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_venkatakrishnan,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -343,7 +350,7 @@ namespace Loci {
                                 upper->cr->M,upper->facecenter,
                                 lower->cl->M,lower->facecenter,
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,Vk_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_venkatakrishnan,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {

--- a/src/FVMMod/limiters/venkatakrishnan2.loci
+++ b/src/FVMMod/limiters/venkatakrishnan2.loci
@@ -30,7 +30,13 @@ namespace Loci {
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
 
-
+  $rule pointwise(OUTPUT<-selector(limiter,venkatakrishnan2,V2)) {}
+  /// Select a more conservative style of venkatakrishnan limiter that uses the
+  /// originating stencil instead of the extrapolating faces.  This will
+  /// cause much more aggresive limiting which can be helpful for difficult
+  /// cases.
+  $type limiter_select_venkatakrishnan2 Constraint ;
+  
   //==========================================================================
   //
   // Venkatakrishnan Limiter2 (Limit to cell centers)
@@ -62,7 +68,7 @@ namespace Loci {
 		  upper->cr->(cellcenter,S),
 		  lower->cl->(cellcenter,S),
 		  boundary_map->S_f,boundary_map->facecenter),
-      constraint(geom_cells,V2_limiter) {
+      constraint(geom_cells,limiter_select_venkatakrishnan2) {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
@@ -127,7 +133,7 @@ namespace Loci {
                                   upper->cr->(V,cellcenter),
                                   lower->cl->(V,cellcenter),
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,V2_limiter,standardv3dLimit) 
+        constraint(geom_cells,limiter_select_venkatakrishnan2,standardv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -207,7 +213,7 @@ namespace Loci {
                                   upper->cr->(V,cellcenter),
                                   lower->cl->(V,cellcenter),
                                   boundary_map->V_f,boundary_map->facecenter),
-        constraint(geom_cells,V2_limiter,minv3dLimit) 
+        constraint(geom_cells,limiter_select_venkatakrishnan2,minv3dLimit) 
   {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
@@ -289,7 +295,7 @@ namespace Loci {
                                 upper->cr->(M,cellcenter),
                                 lower->cl->(M,cellcenter),
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,V2_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_venkatakrishnan2,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -349,7 +355,7 @@ namespace Loci {
                                 upper->cr->(M,cellcenter),
                                 lower->cl->(M,cellcenter),
                                 boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,V2_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_venkatakrishnan2,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -417,7 +423,7 @@ namespace Loci {
 		  Kl,vol,grid_vol,
 		  cellStencil->(cellcenter,S),
 		  boundary_map->S_f,boundary_map->facecenter),
-      constraint(geom_cells,V2_limiter) {
+      constraint(geom_cells,limiter_select_venkatakrishnan2) {
     const real Xcc = $S ;
     const vect3d cctr = $cellcenter ;
 
@@ -464,7 +470,7 @@ namespace Loci {
 		  Kl,vol,grid_vol,
 		  cellStencil->(V,cellcenter),
 		  boundary_map->V_f,boundary_map->facecenter),
-      constraint(geom_cells,V2_limiter) {
+      constraint(geom_cells,limiter_select_venkatakrishnan2) {
     const vect3d Xcc = $V ;
     real refsq = dot(Xcc,Xcc) ;
     int numrefs = 1 ;
@@ -520,7 +526,7 @@ namespace Loci {
                                         Kl,vol,grid_vol,
                                         cellStencil->(M,cellcenter),
                                         boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,V2_limiter,standardvecLimit),prelude 
+        constraint(geom_cells,limiter_select_venkatakrishnan2,standardvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
@@ -567,7 +573,7 @@ namespace Loci {
                                         Kl,vol,grid_vol,
                                         cellStencil->(M,cellcenter),
                                         boundary_map->M_f,boundary_map->facecenter),
-        constraint(geom_cells,V2_limiter,minvecLimit),prelude 
+        constraint(geom_cells,limiter_select_venkatakrishnan2,minvecLimit),prelude 
   {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {

--- a/src/FVMMod/limiters/zero.loci
+++ b/src/FVMMod/limiters/zero.loci
@@ -26,24 +26,28 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
+  $rule pointwise(OUTPUT<-selector(limiter,zero,L0)) {}
+  /// Always limit the extrapolations reducing MUSCL extrapolations first order
+  $type limiter_select_zero Constraint ;
+  
   typedef vector3d<real_t> vect3d ;
   typedef tensor3d<real_t> tens3d ;
   typedef real_t real ;
 
   $type S store<real> ;
 
-  $rule pointwise(limiters(S)<-S),constraint(geom_cells,Z_limiter) {
+  $rule pointwise(limiters(S)<-S),constraint(geom_cells,limiter_select_zero) {
     $limiters(S) = 0.0 ;
   }
 
   $type V store<vect3d> ;
   
-  $rule pointwise(limiterv3d(V)<-V),constraint(geom_cells,Z_limiter) {
+  $rule pointwise(limiterv3d(V)<-V),constraint(geom_cells,limiter_select_zero) {
     $limiterv3d(V) = vect3d(0.0,0.0,0.0) ;
   }
     
   $type M storeVec<real> ;
-  $rule pointwise(limiterv(M)<-M),constraint(geom_cells,Z_limiter),prelude {
+  $rule pointwise(limiterv(M)<-M),constraint(geom_cells,limiter_select_zero),prelude {
     $limiterv(M).setVecSize($M.vecSize()) ;
   } compute {
     $limiterv(M) = mk_Scalar(0.) ;

--- a/src/FVMMod/limiters/zero.loci
+++ b/src/FVMMod/limiters/zero.loci
@@ -26,7 +26,7 @@ using std::cerr ;
 using std::endl ;
 
 namespace Loci {
-  $rule pointwise(OUTPUT<-selector(limiter,zero,L0)) {}
+  $rule pointwise(OUTPUT<-selector(limiter,zero)) {}
   /// Always limit the extrapolations reducing MUSCL extrapolations first order
   $type limiter_select_zero Constraint ;
   

--- a/src/FVMMod/metrics.loci
+++ b/src/FVMMod/metrics.loci
@@ -49,13 +49,11 @@ namespace Loci {
     }      
   }
 
-  /// compute exact centroid constraint for selecting exact centroid metrics  
-  $rule constraint(exactCentroid<-centroid) {
-    $exactCentroid = EMPTY ;
-    if($centroid == "exact") 
-      $exactCentroid = $*centroid.domain() ;
-  } 
-
+  $rule pointwise(OUTPUT<-selector(centroid,exact)) {}
+  $type centroid_select_exact Constraint ; 
+  $rule pointwise(OUTPUT<-selector(centroid,wireframe)) {}
+  $type centroid_select_wireframe Constraint ;
+  
   /// unit rule used to compute cell z coordinate thickness for processing
   /// 2-D grids
   $rule unit(cell_thickness),constraint(geom_cells) {
@@ -457,7 +455,8 @@ namespace Loci {
   /// centroid is defined as the edge length average of the edge centroids.
   /// This amounts to an centroid computation assuming that the mass is
   /// on the edges of the face.
-  $rule pointwise(facecenter<-face2node->pos) {
+  $rule pointwise(facecenter<-face2node->pos),
+  constraint(face2node->pos,centroid_select_wireframe) {
     vector3d<real_t> nodesum(0.0,0.0,0.0) ;
     real_t lensum = 0 ;
     warn($face2node.begin() == $face2node.end() ||
@@ -484,8 +483,8 @@ namespace Loci {
   /// Compute the cell centroid as the area weighted average of the face
   /// centroids that amounts to the centroid assuming that the mass is
   /// only present on the surface of the cell.
-  $rule pointwise(cellcenter<-(upper,lower,boundary_map)->(facecenter,area)
-                  ), constraint(geom_cells,cartesianCoordinateModel) {
+  $rule pointwise(cellcenter<-(upper,lower,boundary_map)->(facecenter,area)),
+  constraint(geom_cells,cartesianCoordinateModel,centroid_select_wireframe) {
     vector3d<real_t> nodesum(0.0,0.0,0.0) ;
     real_t areasum = 0 ;
     for(const Entity *id=$upper.begin();id!=$upper.end();++id) {
@@ -509,8 +508,8 @@ namespace Loci {
   /// the nodal average approximation and then iterate with the exact centroid
   /// computation four iterations to arrive at a close approximation to a face
   /// where the centroid also defines the triangulation of the face. 
-  $rule pointwise(truecentroid::facecenter<-face2node->pos
-                  ),constraint(exactCentroid,face2node->pos) {
+  $rule pointwise(facecenter<-face2node->pos),
+  constraint(centroid_select_exact,face2node->pos) {
     
     // Compute approximate centroid
     const int fsz = $face2node.size() ;
@@ -546,11 +545,11 @@ namespace Loci {
   /// Exact centroid override for the cell center computation.  This computes
   /// The exact centroid by dividing the cell into tetrahedra and computing
   /// an exact integration of the positions over the cell.
-  $rule pointwise(truecentroid::cellcenter<-
+  $rule pointwise(cellcenter<-
                   (upper,lower,boundary_map)->(facecenter,area),
                   (upper,lower,boundary_map)->face2node->pos
-                  ),constraint(geom_cells,exactCentroid,
-                               cartesianCoordinateModel) {
+                  ),
+  constraint(geom_cells,centroid_select_exact,cartesianCoordinateModel) {
     vector3d<real_t> nodesum(0.0,0.0,0.0) ;
     real_t areasum = 0 ;
     for(const Entity *id=$upper.begin();id!=$upper.end();++id) {
@@ -658,7 +657,8 @@ namespace Loci {
   $rule pointwise(cellcenter<-
                   (upper,lower,boundary_map)->(facecenter,area),
                   (upper,lower,boundary_map)->face2node->pos
-                  ),constraint(geom_cells,axisymmetricCoordinateModel) {
+                  ),
+  constraint(geom_cells,axisymmetricCoordinateModel,centroid_select_wireframe) {
     vector3d<real_t> nodesum(0.0,0.0,0.0) ;
 
     // cellcenter is just average of two symmetry plane face centers

--- a/src/FVMMod/misc.loci
+++ b/src/FVMMod/misc.loci
@@ -130,12 +130,33 @@ namespace Loci {
                               *$parametricName(ABBREV)) ;
     (*$selectorOptions(SELECTOR)).push_back(entry) ;
   } ;
+  $rule apply(selectorOptions(SELECTOR)<-
+              parametricName(SELECTION))[Loci::NullOp],
+  parametric(selector(SELECTOR,SELECTION)), prelude {
+    pair<string,string> entry(*$parametricName(SELECTION),
+                              string("")) ;
+    (*$selectorOptions(SELECTOR)).push_back(entry) ;
+  } ;
     
   
   /// Control flow path to report errors in selection
   $type reportSelectorError(SELECTOR) param<int> ;
 
-
+  /// @brief Shortcut for summarizing valid options for selector
+  void printSelectorMessage(const string &selector,
+                            vector<pair<string,string> > info) {
+    sort(info.begin(),info.end()) ;
+    cerr << "Possible valid settings for '" << selector
+         << "' is:" << endl ;
+    for(size_t i=0;i<info.size();++i) {
+      cerr << "    setting of '" << info[i].first
+           << "'" ;
+      if(info[i].second.size() > 0)
+        cerr << " abbreviated as '" << info[i].second << "'" ;
+      cerr << endl ;
+    }
+  }
+    
   /// Check verification of selector and print informative message
   /// if verification fails
   $rule singleton(reportSelectorError(SELECTOR)<-parametricName(SELECTOR),
@@ -146,25 +167,15 @@ namespace Loci {
       if($verifySelector(SELECTOR) == 0) {
         cerr << "Error in setting of '" << $parametricName(SELECTOR)
              << ": " << $SELECTOR << "'!" << endl ;
-        cerr << "Possible valid settings for '" << $parametricName(SELECTOR)
-             << "' is:" << endl ;
-        for(size_t i=0;i<$selectorOptions(SELECTOR).size();++i) {
-          cerr << "    setting of '" << $selectorOptions(SELECTOR)[i].first
-               << "' abbreviated as '" << $selectorOptions(SELECTOR)[i].second
-               << "'" << endl ;
-        }
+        printSelectorMessage($parametricName(SELECTOR),
+                             $selectorOptions(SELECTOR)) ;
         Loci::Abort() ;
       }
       if($verifySelector(SELECTOR) != 1) {
         cerr << "Unexpected internal error in verification of '"
              << $parametricName(SELECTOR) << ": " << $SELECTOR << "'" << endl ;
-        cerr << "Possible valid settings for '" << $parametricName(SELECTOR)
-             << "' is:" << endl ;
-        for(size_t i=0;i<$selectorOptions(SELECTOR).size();++i) {
-          cerr << "    setting of '" << $selectorOptions(SELECTOR)[i].first
-               << "' abbreviated as '" << $selectorOptions(SELECTOR)[i].second
-               << "'" << endl ;
-        }
+        printSelectorMessage($parametricName(SELECTOR),
+                             $selectorOptions(SELECTOR)) ;
         Loci::Abort() ;
       }
     }
@@ -191,6 +202,18 @@ namespace Loci {
       $SELECTOR_select_SELECTION = ~EMPTY ;
   }
 
+  /// Constraint generator for when SELECTOR selects SELECTION (no ABBREV)
+  $rule constraint(SELECTOR_select_SELECTION<-SELECTOR,
+                   parametricName(SELECTION),
+                   verifySelector(SELECTOR,SELECTION)),
+  parametric(selector(SELECTOR,SELECTION)) {
+    $SELECTOR_select_SELECTION = EMPTY ;
+    if($SELECTOR == $parametricName(SELECTION))
+      $SELECTOR_select_SELECTION = ~EMPTY ;
+  }
+
+  /// dryrun option for making a query to just validate inputs
+  /// this veriable will contain the number of detected errors.
   $type dryrun param<int> ;
 
   $rule unit(dryrun), constraint(UNIVERSE) {
@@ -205,24 +228,14 @@ namespace Loci {
       if(*$verifySelector(SELECTOR) == 0) {
         cerr << "Error in setting of '" << *$parametricName(SELECTOR)
              << ": " << *$SELECTOR << "'!" << endl ;
-        cerr << "Possible valid settings for '" << *$parametricName(SELECTOR)
-             << "' is:" << endl ;
-        for(size_t i=0;i<(*$selectorOptions(SELECTOR)).size();++i) {
-          cerr << "    setting of '" << (*$selectorOptions(SELECTOR))[i].first
-               << "' abbreviated as '" << (*$selectorOptions(SELECTOR))[i].second
-               << "'" << endl ;
-        }
+        printSelectorMessage(*$parametricName(SELECTOR),
+                             *$selectorOptions(SELECTOR)) ;
         join(*$dryrun,1) ;
       } else   if(*$verifySelector(SELECTOR) != 1) {
         cerr << "Unexpected internal error in verification of '"
              << *$parametricName(SELECTOR) << ": " << *$SELECTOR << "'" << endl ;
-        cerr << "Possible valid settings for '" << *$parametricName(SELECTOR)
-             << "' is:" << endl ;
-        for(size_t i=0;i<(*$selectorOptions(SELECTOR)).size();++i) {
-          cerr << "    setting of '" << (*$selectorOptions(SELECTOR))[i].first
-               << "' abbreviated as '" << (*$selectorOptions(SELECTOR))[i].second
-               << "'" << endl ;
-        }
+        printSelectorMessage(*$parametricName(SELECTOR),
+                             *$selectorOptions(SELECTOR)) ;
         join(*$dryrun,1) ;
       }
     }

--- a/src/FVMMod/misc.loci
+++ b/src/FVMMod/misc.loci
@@ -76,4 +76,159 @@ namespace Loci {
     }
   } ;
 
+
+  /// Convert a parametric substitution to a string
+  $rule singleton(parametricName(X)), constraint(UNIVERSE),
+  option(disable_threading) {
+    Loci::rule_impl::info const & info = get_info();
+    Loci::variableSet outset = info.output_vars();
+    Loci::variable out = *outset.begin();
+    std::string name = "X";
+    if(out.get_arg_list().size() != 1) {
+      $[Once] {
+        std::cerr << "Unexpected fault: " << "variable " << out
+                  << " should be parametricName(X)!" << std::endl;
+      }
+      Loci::Abort();
+    }
+    Loci::variable varg = Loci::variable(out.get_arg_list()[0]);
+    Loci::variable::info const & vinfo = varg.get_info();
+    name = vinfo.name;
+    $parametricName(X) = name;
+  }
+
+
+  /// Variable used for creating selection constraints
+  $type SELECTOR param<string> ;
+  /// Verify that the selection is satisfied by one rule
+  $type verifySelector(SELECTOR) param<int> ;
+  /// Unit rule to count valid selections
+  $rule unit(verifySelector(SELECTOR)),constraint(UNIVERSE) {
+    $verifySelector(SELECTOR) = 0 ;
+  }
+  /// Check that SELECTOR input selects SELECTION
+  $rule apply(verifySelector(SELECTOR)<-SELECTOR,
+              parametricName(SELECTION))[Loci::Summation],
+  parametric(verifySelector(SELECTOR,SELECTION)) ,prelude {
+    $[Once] {
+      if(*$SELECTOR == *$parametricName(SELECTION))
+        join(*$verifySelector(SELECTOR),1) ;
+    }
+  };
+
+  $type selectorOptions(SELECTOR) blackbox<vector<pair<string,string> > > ;
+
+  $rule unit(selectorOptions(SELECTOR)),constraint(UNIVERSE),prelude {
+    *$selectorOptions(SELECTOR) = vector<pair<string,string> >() ;
+  } ;
+
+  $rule apply(selectorOptions(SELECTOR)<-
+              parametricName(SELECTION),
+              parametricName(ABBREV))[Loci::NullOp],
+  parametric(selector(SELECTOR,SELECTION,ABBREV)), prelude {
+    pair<string,string> entry(*$parametricName(SELECTION),
+                              *$parametricName(ABBREV)) ;
+    (*$selectorOptions(SELECTOR)).push_back(entry) ;
+  } ;
+    
+  
+  /// Control flow path to report errors in selection
+  $type reportSelectorError(SELECTOR) param<int> ;
+
+
+  /// Check verification of selector and print informative message
+  /// if verification fails
+  $rule singleton(reportSelectorError(SELECTOR)<-parametricName(SELECTOR),
+                  verifySelector(SELECTOR),SELECTOR,
+                  selectorOptions(SELECTOR)) {
+    $reportSelectorError(SELECTOR)=$verifySelector(SELECTOR) ;
+    $[Once] {
+      if($verifySelector(SELECTOR) == 0) {
+        cerr << "Error in setting of '" << $parametricName(SELECTOR)
+             << ": " << $SELECTOR << "'!" << endl ;
+        cerr << "Possible valid settings for '" << $parametricName(SELECTOR)
+             << "' is:" << endl ;
+        for(size_t i=0;i<$selectorOptions(SELECTOR).size();++i) {
+          cerr << "    setting of '" << $selectorOptions(SELECTOR)[i].first
+               << "' abbreviated as '" << $selectorOptions(SELECTOR)[i].second
+               << "'" << endl ;
+        }
+        Loci::Abort() ;
+      }
+      if($verifySelector(SELECTOR) != 1) {
+        cerr << "Unexpected internal error in verification of '"
+             << $parametricName(SELECTOR) << ": " << $SELECTOR << "'" << endl ;
+        cerr << "Possible valid settings for '" << $parametricName(SELECTOR)
+             << "' is:" << endl ;
+        for(size_t i=0;i<$selectorOptions(SELECTOR).size();++i) {
+          cerr << "    setting of '" << $selectorOptions(SELECTOR)[i].first
+               << "' abbreviated as '" << $selectorOptions(SELECTOR)[i].second
+               << "'" << endl ;
+        }
+        Loci::Abort() ;
+      }
+    }
+  }
+  /// Routes check requests from a specific SELECTION of SELECTOR
+  $type verifySelector(SELECTOR,SELECTION) param<int> ;
+  $rule singleton(verifySelector(SELECTOR,SELECTION)<-
+                  reportSelectorError(SELECTOR)) {
+    $verifySelector(SELECTOR,SELECTION) = $reportSelectorError(SELECTOR) ;
+  }
+
+  /// Constraint that is generate by selector
+  $type SELECTOR_select_SELECTION Constraint ;
+
+  /// Constraint generator for when SELECTOR selects SELECTION or ABBREV
+  $rule constraint(SELECTOR_select_SELECTION<-SELECTOR,
+                   parametricName(SELECTION),parametricName(ABBREV),
+                   verifySelector(SELECTOR,SELECTION),
+                   verifySelector(SELECTOR,ABBREV)),
+  parametric(selector(SELECTOR,SELECTION,ABBREV)) {
+    $SELECTOR_select_SELECTION = EMPTY ;
+    if($SELECTOR == $parametricName(SELECTION) ||
+       $SELECTOR == $parametricName(ABBREV))
+      $SELECTOR_select_SELECTION = ~EMPTY ;
+  }
+
+  $type dryrun param<int> ;
+
+  $rule unit(dryrun), constraint(UNIVERSE) {
+    $dryrun = 0 ;
+  }
+
+  $rule apply(dryrun<-verifySelector(SELECTOR),
+              parametricName(SELECTOR),
+              SELECTOR, selectorOptions(SELECTOR))[Loci::Summation],
+  parametric(verifySelector(SELECTOR)), prelude {
+    $[Once] {
+      if(*$verifySelector(SELECTOR) == 0) {
+        cerr << "Error in setting of '" << *$parametricName(SELECTOR)
+             << ": " << *$SELECTOR << "'!" << endl ;
+        cerr << "Possible valid settings for '" << *$parametricName(SELECTOR)
+             << "' is:" << endl ;
+        for(size_t i=0;i<(*$selectorOptions(SELECTOR)).size();++i) {
+          cerr << "    setting of '" << (*$selectorOptions(SELECTOR))[i].first
+               << "' abbreviated as '" << (*$selectorOptions(SELECTOR))[i].second
+               << "'" << endl ;
+        }
+        join(*$dryrun,1) ;
+      } else   if(*$verifySelector(SELECTOR) != 1) {
+        cerr << "Unexpected internal error in verification of '"
+             << *$parametricName(SELECTOR) << ": " << *$SELECTOR << "'" << endl ;
+        cerr << "Possible valid settings for '" << *$parametricName(SELECTOR)
+             << "' is:" << endl ;
+        for(size_t i=0;i<(*$selectorOptions(SELECTOR)).size();++i) {
+          cerr << "    setting of '" << (*$selectorOptions(SELECTOR))[i].first
+               << "' abbreviated as '" << (*$selectorOptions(SELECTOR))[i].second
+               << "'" << endl ;
+        }
+        join(*$dryrun,1) ;
+      }
+    }
+
+  };
+    
+    
+
 }

--- a/src/include/FVM.lh
+++ b/src/include/FVM.lh
@@ -196,6 +196,8 @@ $type parametricName(X) param<std::string>;
 
 /// Dummy type to facilitate adding selector generators using parametric rules
 $type selector(SELECT,SELECTION,ABBREV) param<bool> ;
+/// Dummy type to facilitate adding selector generators using parametric rules
+$type selector(SELECT,SELECTION) param<bool> ;
 
 /// get vector size of storeVec<real_t>
 $type vecSize(M) param<int> ;

--- a/src/include/FVM.lh
+++ b/src/include/FVM.lh
@@ -54,9 +54,6 @@ $type gridCoordinates param<std::string> ;
 /** Vars file selector for type of centroid calculation */
 $type centroid param<std::string> ;
 
-/** Constraint used to turn on exact centroid calculation */
-$type exactCentroid Constraint ;
-
 /** Compute thickness of extrusion (for axisymmetric case) */
 $type cell_thickness store<real_t> ;
 /** Maximum Grid Thickness (used to check validity of 2-D axisymmetric mesh */

--- a/src/include/FVM.lh
+++ b/src/include/FVM.lh
@@ -190,6 +190,13 @@ $type LinfNorm(X) param<Loci::real_t> ;
 /** Get file number of entity */
 $type fileNumber(X) store<int> ;
 
+/// Convert argument into a string that is the name of the substitution used
+/// in parametricName(X)
+$type parametricName(X) param<std::string>;
+
+/// Dummy type to facilitate adding selector generators using parametric rules
+$type selector(SELECT,SELECTION,ABBREV) param<bool> ;
+
 /// get vector size of storeVec<real_t>
 $type vecSize(M) param<int> ;
 

--- a/src/include/FVMMod/limiters.lh
+++ b/src/include/FVMMod/limiters.lh
@@ -30,22 +30,6 @@ $type Kl param<real> ;
  * 'venkatakrishnan', 'barth', 'none' for second order solutions, and 'zero' 
  * for first order solutions" */
 $type limiter param<std::string> ;
-/** Venkatakrishnan limiter */
-$type Vk_limiter Constraint ;
-/** Barth limiter */
-$type B_limiter Constraint ;
-/** No limiter (limiter = 1) */
-$type N_limiter Constraint ;
-/** Zero limiter (limiter = 0) */
-$type Z_limiter Constraint ;
-/** Nodal Barth limiter  */
-$type NB_limiter Constraint ;
-/** Venkatakrishnan 2 (cell center) limiter */
-$type V2_limiter Constraint ;
-/** Nisikawa limiter to face centers */
-$type NISf_limiter Constraint;
-/** Niskiawak limiter to cell centers */
-$type NISc_limiter Constraint;
 /** Scalar cell to node max */
 $type NGTNodalMax(S) store<real_t> ;
 /** Scalar cell to node min */


### PR DESCRIPTION
This update adds a parametric version of the selector pattern.  This pattern uses parametric rules to automate the process of generating constraints and validating inputs used to select different methods using constraints.  As an example of how this is used the limiter infrastructure is updated to use the new selector pattern.  This only changes the behavior of the limiter in that it will error out if the limiter is set to an invalid selection instead of defaulting to venkatakrishnan, which is probably a more desirable outcome.

One advantage of the new patterns is that it is now possible to create third party add on modules that can add new limiters without needing to change the FVMMod.  

The way that this pattern is you need to create a default rule to define the default setting of the selector (which must be of type param<string>)  Then for each selected algorithm you add a rule such as

 $rule pointwise(OUTPUT<-selector(limiter,venkatakrishnan,V)) {}

Note, this rule is not actually executed, but it causes rules to be instantiated to manage the creation of code that will check and create a constraint for the selector and also create validators that will check that one and only one of the constraints are set to ~EMPTY.  The first argument of the selector parametric variable is the input variable for the selector, the second is the selection name, and the third is an abbreviation of the selected name.  In this case when limiter is set to either "venkatakrishnan" or "V" then the constraint limiter_select_venkatakrishnan will be set to UNIVERSE (~EMPTY).  All other selector generated constraints will be empty.
