### PR TITLE
[#206] Fix gk_inst in build_loci_deps.sh

### DIFF
--- a/build_loci_deps.sh
+++ b/build_loci_deps.sh
@@ -252,7 +252,7 @@ build_metis() {
   ensure_submodule METIS
   say "==== METIS ===="
 
-  local gk_inst="$ext/GKlib_install"
+  local gk_inst="$prefix/GKlib_install"
   [[ -d "$gk_inst/include" && -d "$gk_inst/lib" ]] || die "METIS needs GKlib installed."
 
   local src="$ext/METIS"


### PR DESCRIPTION
Update the gk_inst variable to point to the installation directory for GK_lib ($prefix) rather than build directory ($ext).