### PR TITLE
Tarball from releases/tags page does not compile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -60,8 +60,8 @@ SPRNG :
 
 .PHONY: FORCE
 
-LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/")
-LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/")
+LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/p; t; s/.*/0/")
+LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/p; t; s/.*/0/")
 include/Config/version_info.h: FORCE
 	@echo \#ifndef CONFIG_LOCI_INFO_H > version_info.h
 	@echo \#define CONFIG_LOCI_INFO_H >> version_info.h


### PR DESCRIPTION
Fixes #236 

In the event that there is no git info this defaults `LOCI_VERSION_MAJOR` and `LOCI_VERSION_MINOR` to 0. Another option would be to template `intToString` or create a version that accepts strings so something like "unknown" could be used instead of 0.