### PR TITLE
Fix compile from release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ cd loci
 git submodule init
 ```
 
+Do not use the source tarballs from [tags](https://github.com/EdwardALuke/loci/tags)
+since they will not compile because they are lacking git version information.
+
 ## Dependencies
 **Required:**
 * MPI implementation, such as [Open MPI](https://www.open-mpi.org/) or [MPICH](https://www.mpich.org)

--- a/configure
+++ b/configure
@@ -414,8 +414,8 @@ if [ "$METIS_BASE" == "/notselected" ] ; then
 fi
 
 # check for git repo information
-if [ ! -d .git ]; then
-    echo "ERROR: .git directory not found, cannot determine versioning.";
+if [ ! -d .git ] && [ ! -f "src/version.conf" ]; then
+    echo "ERROR: neither .git directory or src/version.conf found, cannot determine versioning.";
     echo "If you downloaded the source tarball from https://github.com/EdwardALuke/loci/tags that is not supported; instead do the following:";
     echo "git clone https://github.com/EdwardALuke/loci.git";
     echo "cd loci";

--- a/configure
+++ b/configure
@@ -413,6 +413,18 @@ if [ "$METIS_BASE" == "/notselected" ] ; then
     fi
 fi
 
+# check for git repo information
+if [ ! -d .git ]; then
+    echo "ERROR: .git directory not found, cannot determine versioning.";
+    echo "If you downloaded the source tarball from https://github.com/EdwardALuke/loci/tags that is not supported; instead do the following:";
+    echo "git clone https://github.com/EdwardALuke/loci.git";
+    echo "cd loci";
+    echo "git submodule init";
+    echo "git checkout <tag>";
+    echo "where <tag> is the version you want to compile"
+    exit -1
+fi
+
 # if Loci is not installing METIS setup METIS_LIBS and METIS_INCLUDES
 if [ $NO_MPI == 1 ] ; then
     INSTALL_METIS=0

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,8 +60,8 @@ SPRNG :
 
 .PHONY: FORCE
 
-LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/")
-LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/")
+LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/p; t; s/.*/0/")
+LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/p; t; s/.*/0/")
 include/Config/version_info.h: FORCE
 	@echo \#ifndef CONFIG_LOCI_INFO_H > version_info.h
 	@echo \#define CONFIG_LOCI_INFO_H >> version_info.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,8 +60,8 @@ SPRNG :
 
 .PHONY: FORCE
 
-LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/p; t; s/.*/0/")
-LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/p; t; s/.*/0/")
+LOCI_MAJOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v\([0-9][0-9]*\).*/\1/")
+LOCI_MINOR_VERSION=$(shell echo $(GIT_INFO) | sed "s/v[0-9][0-9]*[.]\([0-9][0-9]*\).*/\1/")
 include/Config/version_info.h: FORCE
 	@echo \#ifndef CONFIG_LOCI_INFO_H > version_info.h
 	@echo \#define CONFIG_LOCI_INFO_H >> version_info.h


### PR DESCRIPTION
Fixes #236.

Adds a check in configure for a `.git` folder. If one is not found it directs the user to `git clone` the repository.

Updates the readme to inform users not to use the source tarballs from the tags page.