### PR TITLE
Added __host__ and __device__ attributes to functions, methods, and

### DIFF
--- a/src/include/Tools/autodiff.h
+++ b/src/include/Tools/autodiff.h
@@ -27,7 +27,6 @@
 #include <array>
 #include <math.h>
 #include <Tools/vtypes.h>
-#include <Tools/gpu_attr.h>
 
 namespace Loci {
 
@@ -43,82 +42,82 @@ namespace Loci {
 #ifdef TO_BE_DEPRECATED
     /* MPGCOMMENT [05-12-2017 13:49] ---> constructor */
     template< class T1>
-    GPU_DECL FAD2d(T1 a0): value(a0), grad(0.0),grad2(0.0) { }
+    FAD2d(T1 a0): value(a0), grad(0.0),grad2(0.0) { }
 #endif
-    GPU_DECL FAD2d(double a0, double b0, double c0): value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(const FAD2d &u) : value(u.value), grad(u.grad), grad2(u.grad2) { }
+    FAD2d(double a0, double b0, double c0): value(a0), grad(b0), grad2(c0) { }
+    FAD2d(const FAD2d &u) : value(u.value), grad(u.grad), grad2(u.grad2) { }
 
     FAD2d() = default ;
     // --------------------------------------------------------------------
     // REH ADDED BELOW - 20220202 - Missing code from initial 2017 dev mods
     // --------------------------------------------------------------------
-    GPU_DECL FAD2d(int a0         ,int b0)        : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(int a0         ,float b0)        : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(int a0         ,double b0)        : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(int a0         ,long double b0)        : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(float a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(float a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(float a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(float a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(long double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(long double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(long double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    GPU_DECL FAD2d(long double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(int a0         ,int b0)        : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(int a0         ,float b0)        : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(int a0         ,double b0)        : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(int a0         ,long double b0)        : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(float a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(float a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(float a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(float a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(long double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(long double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(long double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    FAD2d(long double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
 
-    GPU_DECL FAD2d(double a0      ,int b0        , int c0)       : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,int b0        , float c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,int b0        , double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,int b0        , long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,float b0      , int c0)       : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,float b0      , float c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,float b0      , double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,float b0      , long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,double b0     , int c0)       : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,double b0     , float c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,int b0        , int c0)       : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,int b0        , float c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,int b0        , double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,int b0        , long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,float b0      , int c0)       : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,float b0      , float c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,float b0      , double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,float b0      , long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,double b0     , int c0)       : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,double b0     , float c0)     : value(a0), grad(b0), grad2(c0) { }
     //FAD2d(double a0      ,double b0     , double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,double b0     , long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,long double b0, int c0)       : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,long double b0, float c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,long double b0, double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(double a0      ,long double b0, long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    GPU_DECL FAD2d(bool &u)        : value((u)?1.0:0.0), grad(0.0), grad2(0.0) { }
+    FAD2d(double a0      ,double b0     , long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,long double b0, int c0)       : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,long double b0, float c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,long double b0, double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(double a0      ,long double b0, long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    FAD2d(bool &u)        : value((u)?1.0:0.0), grad(0.0), grad2(0.0) { }
     //FAD2d(const FAD2d &u) : value(u.value), grad(u.grad), grad2(u.grad2) { }
-    GPU_DECL FAD2d(int a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    GPU_DECL FAD2d(size_t a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    GPU_DECL FAD2d(float a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    GPU_DECL FAD2d(double a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    GPU_DECL FAD2d(long double a0)        : value(a0), grad(0.0), grad2(0.0) {  }
+    FAD2d(int a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    FAD2d(size_t a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    FAD2d(float a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    FAD2d(double a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    FAD2d(long double a0)        : value(a0), grad(0.0), grad2(0.0) {  }
     // --------------------------------------------------------------------
-    GPU_DECL void setValue(double val) { value = val ; }
-    GPU_DECL FAD2d& operator =(const FAD2d &u) {
+    void setValue(double val) { value = val ; }
+    FAD2d& operator =(const FAD2d &u) {
       value = u.value;
       grad = u.grad;
       grad2 = u.grad2 ;
       return *this;
     }
-    GPU_DECL FAD2d& operator =(const int &u) {
+    FAD2d& operator =(const int &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0 ;
       return *this;
     }
-    GPU_DECL FAD2d& operator =(const float &u) {
+    FAD2d& operator =(const float &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0;
       return *this;
     }
-    GPU_DECL FAD2d& operator =(const double &u) {
+    FAD2d& operator =(const double &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0;
       return *this;
     }
-    GPU_DECL FAD2d& operator =(const long double &u) {
+    FAD2d& operator =(const long double &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0;
@@ -126,142 +125,142 @@ namespace Loci {
     }
 
 
-    GPU_DECL FAD2d operator +(const FAD2d &v) const{
+    FAD2d operator +(const FAD2d &v) const{
       return FAD2d(value+v.value, grad+v.grad, grad2+v.grad2);
     }
-    GPU_DECL FAD2d operator +() const{
+    FAD2d operator +() const{
       return FAD2d(value, grad, grad2);
     }
-    GPU_DECL FAD2d operator +(const int &v) const{
+    FAD2d operator +(const int &v) const{
       return FAD2d(value+(double)v, grad, grad2);
     }
-    GPU_DECL FAD2d operator +(const float &v) const{
+    FAD2d operator +(const float &v) const{
       return FAD2d(value+(double)v, grad, grad2);
     }
-    GPU_DECL FAD2d operator +(const double &v) const{
+    FAD2d operator +(const double &v) const{
       return FAD2d(value+(double)v, grad, grad2);
     }
-    GPU_DECL FAD2d operator +(const long double &v) const{
+    FAD2d operator +(const long double &v) const{
       return FAD2d(double(value+v), grad, grad2);
     }
 
-    GPU_DECL FAD2d& operator +=(const FAD2d &u) {
+    FAD2d& operator +=(const FAD2d &u) {
       value+=u.value;
       grad+=u.grad;
       grad2+=u.grad2 ;
       return *this;
     }
-    GPU_DECL FAD2d& operator +=(const int &u) {
+    FAD2d& operator +=(const int &u) {
       value+=u;
       return *this;
     }
-    GPU_DECL FAD2d& operator +=(const float &u) {
+    FAD2d& operator +=(const float &u) {
       value+=u;
       return *this;
     }
-    GPU_DECL FAD2d& operator +=(const double &u) {
+    FAD2d& operator +=(const double &u) {
       value+=u;
       return *this;
     }
-    GPU_DECL FAD2d& operator +=(const long double &u) {
+    FAD2d& operator +=(const long double &u) {
       value+=u;
       return *this;
     }
 
-    GPU_DECL FAD2d operator -(const FAD2d &v) const{
+    FAD2d operator -(const FAD2d &v) const{
       return FAD2d(value-v.value, grad-v.grad,grad2-v.grad2);
     }
-    GPU_DECL FAD2d operator -() const {
+    FAD2d operator -() const {
       return FAD2d(-value, -grad, -grad2);
     }
-    GPU_DECL FAD2d operator -(const int &v) const{
+    FAD2d operator -(const int &v) const{
       return FAD2d(value-(double)v, grad, grad2);
     }
-    GPU_DECL FAD2d operator -(const float &v) const{
+    FAD2d operator -(const float &v) const{
       return FAD2d(value-(double)v, grad, grad2);
     }
-    GPU_DECL FAD2d operator -(const double &v) const{
+    FAD2d operator -(const double &v) const{
       return FAD2d(value-(double)v, grad, grad2);
     }
-    GPU_DECL FAD2d operator -(const long double &v) const{
+    FAD2d operator -(const long double &v) const{
       return FAD2d(double(value-v), grad, grad2);
     }
 
-    GPU_DECL FAD2d& operator -=(const FAD2d &u) {
+    FAD2d& operator -=(const FAD2d &u) {
       value-=u.value;
       grad-=u.grad;
       grad2 -= u.grad2 ;
       return *this;
     }
-    GPU_DECL FAD2d& operator -=(const int &u) {
+    FAD2d& operator -=(const int &u) {
       value-=u;
       return *this;
     }
-    GPU_DECL FAD2d& operator -=(const float &u) {
+    FAD2d& operator -=(const float &u) {
       value-=u;
       return *this;
     }
-    GPU_DECL FAD2d& operator -=(const double &u) {
+    FAD2d& operator -=(const double &u) {
       value-=u;
       return *this;
     }
-    GPU_DECL FAD2d& operator -=(const long double &u) {
+    FAD2d& operator -=(const long double &u) {
       value-=u;
       return *this;
     }
 
-    GPU_DECL FAD2d operator *(const FAD2d &v) const {
+    FAD2d operator *(const FAD2d &v) const {
       return FAD2d(value*v.value,  grad*v.value + v.grad*value,
                    grad2*v.value + value*v.grad2 + 2.*grad*v.grad);
     }
-    GPU_DECL FAD2d operator *(const int &v) const{
+    FAD2d operator *(const int &v) const{
       return FAD2d(value*(double)v,  grad*(double)v, grad2*(double) v);
     }
-    GPU_DECL FAD2d operator *(const float &v) const{
+    FAD2d operator *(const float &v) const{
       return FAD2d(value*(double)v,  grad*(double)v, grad2*(double) v);
     }
-    GPU_DECL FAD2d operator *(const double &v) const{
+    FAD2d operator *(const double &v) const{
       return FAD2d(value*(double)v,  grad*(double)v, grad2*(double) v);
     }
-    GPU_DECL FAD2d operator *(const long double &v) const{
+    FAD2d operator *(const long double &v) const{
       return FAD2d(double(value*v),  double(grad*v), double(grad2*v));
     }
     //    template<class T> FAD2d& operator *=(const T &u) {
     //      value*=(double)u;
     //      return *this;
     //    }
-    GPU_DECL FAD2d& operator *=(const FAD2d &u) {
+    FAD2d& operator *=(const FAD2d &u) {
       grad2 = grad2*u.value + value*u.grad2 + 2.*grad*u.grad ;
       grad = grad*u.value + u.grad * value;
       value*=u.value;
       return *this;
     }
-    GPU_DECL FAD2d& operator *=(const int &u) {
+    FAD2d& operator *=(const int &u) {
       value*=u;
       grad *=u;
       grad2 *= u ;
       return *this;
     }
-    GPU_DECL FAD2d& operator *=(const float &u) {
+    FAD2d& operator *=(const float &u) {
       value*=u;
       grad *=u;
       grad2 *= u;
       return *this;
     }
-    GPU_DECL FAD2d& operator *=(const double &u) {
+    FAD2d& operator *=(const double &u) {
       value*=u;
       grad *=u;
       grad2 *= u ;
       return *this;
     }
-    GPU_DECL FAD2d& operator *=(const long double &u) {
+    FAD2d& operator *=(const long double &u) {
       value*=u;
       grad *=u;
       grad2 *= u;
       return *this;
     }
 
-    GPU_DECL FAD2d operator /(const FAD2d &v) const{
+    FAD2d operator /(const FAD2d &v) const{
       double d = v.value ;
       double d2 = d*d ;
       double d3 = d*d2 ;
@@ -271,20 +270,20 @@ namespace Loci {
                    2.*v.grad*v.grad*value/d3 -
                    (v.grad*grad+v.grad2*value)/d2) ;
     }
-    GPU_DECL FAD2d operator /(const int &v) const{
+    FAD2d operator /(const int &v) const{
       return FAD2d(value/v, (grad/(double)v), (grad2/double(v)));
     }
-    GPU_DECL FAD2d operator /(const float &v) const{
+    FAD2d operator /(const float &v) const{
       return FAD2d(value/v, (grad/(double)v), (grad2/double(v)));
     }
-    GPU_DECL FAD2d operator /(const double &v) const{
+    FAD2d operator /(const double &v) const{
       return FAD2d(value/v, (grad/(double)v), (grad2/double(v)));
     }
-    GPU_DECL FAD2d operator /(const long double &v) const{
+    FAD2d operator /(const long double &v) const{
       return FAD2d(double(value/v), double(grad/v), double(grad2/v));
     }
 
-    GPU_DECL FAD2d& operator /=(const FAD2d &u) {
+    FAD2d& operator /=(const FAD2d &u) {
       double d = u.value ;
       double d2 = d*d ;
       double d3 = d*d2 ;
@@ -294,25 +293,25 @@ namespace Loci {
       value/=u.value;
       return *this;
     }
-    GPU_DECL FAD2d& operator /=(const int &u) {
+    FAD2d& operator /=(const int &u) {
       value/=u;
       grad /=u;
       grad2 /= u ;
       return *this;
     }
-    GPU_DECL FAD2d& operator /=(const float &u) {
+    FAD2d& operator /=(const float &u) {
       value/=u;
       grad /=u;
       grad2 /=u ;
       return *this;
     }
-    GPU_DECL FAD2d& operator /=(const double &u) {
+    FAD2d& operator /=(const double &u) {
       value/=u;
       grad /=u;
       grad2 /= u ;
       return *this;
     }
-    GPU_DECL FAD2d& operator /=(const long double &u) {
+    FAD2d& operator /=(const long double &u) {
       value/=u;
       grad /=u;
       grad2 /= u ;
@@ -320,94 +319,94 @@ namespace Loci {
     }
 
 
-    GPU_DECL bool operator ==(const FAD2d &u)const  {
+    bool operator ==(const FAD2d &u)const  {
       return ((value==u.value)?true:false);
     }
-    GPU_DECL bool operator !=(const FAD2d &u) const {
+    bool operator !=(const FAD2d &u) const {
       return ((value!=u.value)?true:false);
     }
-    GPU_DECL bool operator >(const FAD2d &u) const {
+    bool operator >(const FAD2d &u) const {
       return ((value>u.value)?true:false);
     }
-    GPU_DECL bool operator <(const FAD2d &u) const {
+    bool operator <(const FAD2d &u) const {
       return ((value<u.value)?true:false);
     }
-    GPU_DECL bool operator >=(const FAD2d &u) const {
+    bool operator >=(const FAD2d &u) const {
       return ((value>=u.value)?true:false);
     }
-    GPU_DECL bool operator <=(const FAD2d &u) const {
+    bool operator <=(const FAD2d &u) const {
       return ((value<=u.value)?true:false);
     }
-    GPU_DECL bool operator ==(const int &u) const {
+    bool operator ==(const int &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const int &u) const {
+    bool operator !=(const int &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const int &u) const {
+    bool operator >(const int &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const int &u) const {
+    bool operator <(const int &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const int &u) const {
+    bool operator >=(const int &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const int &u) const {
+    bool operator <=(const int &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const float &u) const {
+    bool operator ==(const float &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const float &u) const {
+    bool operator !=(const float &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const float &u) const {
+    bool operator >(const float &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const float &u) const {
+    bool operator <(const float &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const float &u) const {
+    bool operator >=(const float &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const float &u) const {
+    bool operator <=(const float &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const double &u) const {
+    bool operator ==(const double &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const double &u) const {
+    bool operator !=(const double &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const double &u) const {
+    bool operator  >(const double &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const double &u) const {
+    bool operator <(const double &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const double &u) const {
+    bool operator >=(const double &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const double &u) const {
+    bool operator <=(const double &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const long double &u) const {
+    bool operator ==(const long double &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const long double &u) const {
+    bool operator !=(const long double &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const long double &u) const {
+    bool operator  >(const long double &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const long double &u) const {
+    bool operator <(const long double &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const long double &u) const {
+    bool operator >=(const long double &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const long double &u) const {
+    bool operator <=(const long double &u) const {
       return ((value<=u)?true:false);
     }
 
@@ -438,30 +437,30 @@ namespace Loci {
     return stream;
   }
 
-  inline GPU_DECL double ceil(const FAD2d u) {
+  inline double ceil(const FAD2d u) {
     return std::ceil(u.value) ;
   }
-  inline GPU_DECL double floor(const FAD2d u) {
+  inline double floor(const FAD2d u) {
     return std::floor(u.value) ;
   }
 
-  inline GPU_DECL FAD2d erf(const FAD2d u) {
+  inline FAD2d erf(const FAD2d u) {
     double ef = ::erf(u.value) ;
     double efp = (2./sqrt(M_PI))*std::exp(-u.value*u.value) ;
     double efpp = -2.*u.value*efp ;
     return FAD2d(ef,u.grad*efp,u.grad*u.grad*efpp+efp*u.grad2) ;
   }
-  inline GPU_DECL FAD2d sin(const FAD2d u) {
+  inline FAD2d sin(const FAD2d u) {
     double su = std::sin(u.value) ;
     double cu = std::cos(u.value) ;
     return FAD2d(su, u.grad*cu, cu*u.grad2 - u.grad*u.grad*su);
   }
-  inline GPU_DECL FAD2d cos(const FAD2d u) {
+  inline FAD2d cos(const FAD2d u) {
     double su = std::sin(u.value) ;
     double cu = std::cos(u.value) ;
     return FAD2d(cu, -u.grad*su, -su*u.grad2 - u.grad*u.grad*cu);
   }
-  inline GPU_DECL FAD2d tan(const FAD2d u) {
+  inline FAD2d tan(const FAD2d u) {
     double tanu = std::tan(u.value) ;
     double secu = 1./std::cos(u.value) ;
     double secu2 = secu*secu ;
@@ -469,58 +468,58 @@ namespace Loci {
                  u.grad2*secu2+2.*u.grad*u.grad*secu2*tanu) ;
   }
 
-  inline GPU_DECL FAD2d exp(const FAD2d u) {
+  inline FAD2d exp(const FAD2d u) {
     double eu = std::exp(u.value) ;
     return FAD2d(eu, u.grad*eu, eu*u.grad2+u.grad*u.grad*eu);
   }
-  inline GPU_DECL FAD2d log(const FAD2d u) {
+  inline FAD2d log(const FAD2d u) {
     return FAD2d(std::log(u.value), u.grad/u.value,
                  u.grad2/u.value - u.grad*u.grad/(u.value*u.value));
   }
-  inline GPU_DECL FAD2d log10(const FAD2d u) {
+  inline FAD2d log10(const FAD2d u) {
     return FAD2d(std::log(u.value), u.grad/u.value,
                  u.grad2/u.value - u.grad*u.grad/(u.value*u.value))/std::log(10.0);
   }
 
-  inline GPU_DECL FAD2d fabs(FAD2d u) {
+  inline FAD2d fabs(FAD2d u) {
     return FAD2d(std::fabs(u.value),
                  u.grad*( (u.value<0.0)?-1.0:1.0 ),
                  u.grad2*( (u.value<0.0)?-1.0:1.0 )) ;
   }
-  inline GPU_DECL FAD2d abs(FAD2d u) {
+  inline FAD2d abs(FAD2d u) {
     return FAD2d(std::fabs(u.value),
                  u.grad*( (u.value<0.0)?-1.0:1.0 ),
                  u.grad2*( (u.value<0.0)?-1.0:1.0 )) ;
   }
   /* MPGCOMMENT [05-12-2017 15:04] ---> POW */
-  inline GPU_DECL FAD2d pow(const FAD2d u, const int k) {
+  inline FAD2d pow(const FAD2d u, const int k) {
     return FAD2d(std::pow(u.value, k),
                  (double)k * std::pow(u.value, k-1)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k - 2)*std::pow(u.grad, 2)) + std::pow(u.value, k - 1)*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d pow(const FAD2d u, const float k) {
+  inline FAD2d pow(const FAD2d u, const float k) {
     return FAD2d(std::pow(u.value, double(k)),
                  (double)k * std::pow(u.value, k-1.0)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k-2.0)*std::pow(u.grad, 2)) + std::pow(u.value, k-1.0)*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d pow(const FAD2d u, const double k) {
+  inline FAD2d pow(const FAD2d u, const double k) {
     return FAD2d(std::pow(u.value, k),
                  (double)k * std::pow(u.value, k-1.0)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k-2.0)*std::pow(u.grad, 2)) + std::pow(u.value, k - 1)*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d pow(const FAD2d u, const long double ki) {
+  inline FAD2d pow(const FAD2d u, const long double ki) {
     double k = double(ki) ;
     return FAD2d(std::pow(u.value, k),
                  (double)k * std::pow(u.value, k-1.0)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k - 2)*std::pow(u.grad, 2)) + std::pow(u.value, k - 1)*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d sqrt(const FAD2d u) {
+  inline FAD2d sqrt(const FAD2d u) {
 
     double su = std::sqrt(u.value) ;
     return FAD2d(su,0.5*u.grad/std::max(su,1e-30),
                  0.5*u.grad2/(std::max(su,1e-30)) - 0.25*u.grad*u.grad/(std::max(su*su*su,1e-30))) ;
   }
-  inline GPU_DECL FAD2d pow(const FAD2d k, const FAD2d u) {
+  inline FAD2d pow(const FAD2d k, const FAD2d u) {
     double kpu = std::pow(k.value,u.value) ;
     double kpu1 = std::pow(k.value,u.value-1.) ;
     double kpu2 = std::pow(k.value,u.value-2.) ;
@@ -533,25 +532,25 @@ namespace Loci {
                               kpu*(lxu*u.grad)) + kpu*u.grad2)) ;
 
   }
-  inline GPU_DECL FAD2d pow(const int k, const FAD2d u) {
+  inline FAD2d pow(const int k, const FAD2d u) {
     double kpu = std::pow(k,u.value) ;
     double lnk = std::log(double(k)) ;
     return FAD2d(kpu,kpu*lnk*u.grad,
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d pow(const float k, const FAD2d u) {
+  inline FAD2d pow(const float k, const FAD2d u) {
     double kpu = std::pow(double(k),u.value) ;
     double lnk = std::log(double(k)) ;
     return FAD2d(kpu,kpu*lnk*u.grad,
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d pow(const double k, const FAD2d u) {
+  inline FAD2d pow(const double k, const FAD2d u) {
     double kpu = std::pow(k,u.value) ;
     double lnk = std::log(double(k)) ;
     return FAD2d(kpu,kpu*lnk*u.grad,
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
-  inline GPU_DECL FAD2d pow(const long double ki, const FAD2d u) {
+  inline FAD2d pow(const long double ki, const FAD2d u) {
     double k = double(ki) ;
     double kpu = std::pow(k,u.value) ;
     double lnk = std::log(double(k)) ;
@@ -559,14 +558,14 @@ namespace Loci {
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
 
-  inline GPU_DECL FAD2d sinh(const FAD2d u) {
+  inline FAD2d sinh(const FAD2d u) {
     double expu = std::exp(u.value) ;
     double expmu = std::exp(-u.value) ;
     return FAD2d(std::sinh(u.value),
                  0.5*u.grad*(expu + expmu),
                  0.5*(expmu*(u.grad2-u.grad*u.grad)+expu*(u.grad2+u.grad*u.grad))) ;
   }
-  inline GPU_DECL FAD2d cosh(const FAD2d u) {
+  inline FAD2d cosh(const FAD2d u) {
     double expu = std::exp(u.value) ;
     double expmu = std::exp(-u.value) ;
     return FAD2d(std::cosh(u.value),
@@ -575,7 +574,7 @@ namespace Loci {
                       expu*(u.grad2+u.grad*u.grad))) ;
   }
 
-  inline GPU_DECL FAD2d tanh(const FAD2d u) {
+  inline FAD2d tanh(const FAD2d u) {
     double ex = std::exp(std::min(u.value,350.0)) ;
     double exm = std::exp(std::min(-u.value,350.0)) ;
     double dex = ex-exm ;
@@ -586,17 +585,17 @@ namespace Loci {
                  u.grad*u.grad*2.*(rex2-1.)*rex+
                  u.grad2*(1.-rex2)) ;
   }
-  inline GPU_DECL FAD2d asin(const FAD2d u) {
+  inline FAD2d asin(const FAD2d u) {
     double rsrt = 1./std::sqrt(1.-u.value*u.value) ;
     return FAD2d(std::asin(u.value), u.grad*rsrt,
                  u.grad2*rsrt + u.grad*u.grad*u.value*rsrt*rsrt*rsrt);
   }
-  inline GPU_DECL FAD2d acos(const FAD2d u) {
+  inline FAD2d acos(const FAD2d u) {
     double rsrt = 1./std::sqrt(1.-u.value*u.value) ;
     return FAD2d(std::acos(u.value), -u.grad*rsrt,
                  -u.grad2*rsrt - u.grad*u.grad*u.value*rsrt*rsrt*rsrt);
   }
-  inline GPU_DECL FAD2d atan(const FAD2d u) {
+  inline FAD2d atan(const FAD2d u) {
     double rval = 1./(1.+u.value*u.value) ;
     return FAD2d(std::atan(u.value), u.grad*rval,
                  u.grad2*rval-2.*u.grad*u.grad*u.value*rval*rval);
@@ -604,11 +603,11 @@ namespace Loci {
   //-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // This will not work in general
   //-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  inline GPU_DECL FAD2d atan2(const FAD2d u, const FAD2d v) {
+  inline FAD2d atan2(const FAD2d u, const FAD2d v) {
     return atan(u/v);
   }
 
-  inline GPU_DECL FAD2d asinh(const FAD2d u) {
+  inline FAD2d asinh(const FAD2d u) {
     const double uv = u.value ;
     const double uv2 = uv*uv ;
     const double strm = std::sqrt(uv2+1.) ;
@@ -619,7 +618,7 @@ namespace Loci {
                   - std::pow(uv / strm + 1., 2) / uvstrm2)*u.grad*u.grad
                  + u.grad2*(uv / strm + 1.) / uvstrm) ;
   }
-  inline GPU_DECL FAD2d acosh(const FAD2d u) {
+  inline FAD2d acosh(const FAD2d u) {
     const double uv = u.value ;
     const double uv2 = uv*uv ;
     const double strm = std::sqrt(uv*uv-1.) ;
@@ -630,7 +629,7 @@ namespace Loci {
                   - std::pow(uv / strm + 1., 2) / uvstrm2)*u.grad*u.grad
                  + u.grad2*(uv / strm + 1.) / uvstrm) ;
   }
-  inline GPU_DECL FAD2d atanh(const FAD2d u) {
+  inline FAD2d atanh(const FAD2d u) {
     const double uv = u.value ;
     const double uv2 = uv*uv ;
     const double factor = .5*(1./(1.+uv)+1./(1.-uv)) ;
@@ -640,13 +639,13 @@ namespace Loci {
   }
 
 
-  inline GPU_DECL FAD2d operator +(const double u,const FAD2d v)
+  inline FAD2d operator +(const double u,const FAD2d v)
   { return FAD2d(u+v.value, v.grad, v.grad2); }
-  inline GPU_DECL FAD2d operator -(const double u,const FAD2d v)
+  inline FAD2d operator -(const double u,const FAD2d v)
   { return FAD2d(u-v.value, -v.grad, -v.grad2); }
-  inline GPU_DECL FAD2d operator *(const double u,const FAD2d v)
+  inline FAD2d operator *(const double u,const FAD2d v)
   { return FAD2d(u*v.value,  v.grad*u, v.grad2*u ); }
-  inline GPU_DECL FAD2d operator /(const double &u,const FAD2d &v)
+  inline FAD2d operator /(const double &u,const FAD2d &v)
   { return FAD2d(u/v.value, -u*v.grad/v.value/v.value,
                  2.*u*v.grad*v.grad/(v.value*v.value*v.value) -
                  u*v.grad2/(v.value*v.value)); }
@@ -659,56 +658,56 @@ namespace Loci {
     /* MPGCOMMENT [05-12-2017 13:49] ---> constructor */
 #ifdef TO_BE_DEPRECATED
     template< class T1>
-    GPU_DECL FADd(T1 a0): value(a0), grad(0.0) { }
+    FADd(T1 a0): value(a0), grad(0.0) { }
 #endif
-    GPU_DECL FADd(int a0         ,int b0)        : value(a0), grad(b0) { }
-    GPU_DECL FADd(int a0         ,float b0)        : value(a0), grad(b0) { }
-    GPU_DECL FADd(int a0         ,double b0)        : value(a0), grad(b0) { }
-    GPU_DECL FADd(int a0         ,long double b0)        : value(a0), grad(b0) { }
-    GPU_DECL FADd(float a0      ,int b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(float a0      ,float b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(float a0      ,double b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(float a0      ,long double b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(double a0      ,int b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(double a0      ,float b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(double a0      ,double b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(double a0      ,long double b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(long double a0      ,int b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(long double a0      ,float b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(long double a0      ,double b0)       : value(a0), grad(b0) { }
-    GPU_DECL FADd(long double a0      ,long double b0)       : value(a0), grad(b0) { }
+    FADd(int a0         ,int b0)        : value(a0), grad(b0) { }
+    FADd(int a0         ,float b0)        : value(a0), grad(b0) { }
+    FADd(int a0         ,double b0)        : value(a0), grad(b0) { }
+    FADd(int a0         ,long double b0)        : value(a0), grad(b0) { }
+    FADd(float a0      ,int b0)       : value(a0), grad(b0) { }
+    FADd(float a0      ,float b0)       : value(a0), grad(b0) { }
+    FADd(float a0      ,double b0)       : value(a0), grad(b0) { }
+    FADd(float a0      ,long double b0)       : value(a0), grad(b0) { }
+    FADd(double a0      ,int b0)       : value(a0), grad(b0) { }
+    FADd(double a0      ,float b0)       : value(a0), grad(b0) { }
+    FADd(double a0      ,double b0)       : value(a0), grad(b0) { }
+    FADd(double a0      ,long double b0)       : value(a0), grad(b0) { }
+    FADd(long double a0      ,int b0)       : value(a0), grad(b0) { }
+    FADd(long double a0      ,float b0)       : value(a0), grad(b0) { }
+    FADd(long double a0      ,double b0)       : value(a0), grad(b0) { }
+    FADd(long double a0      ,long double b0)       : value(a0), grad(b0) { }
 
-    GPU_DECL FADd(const double u): value(u),grad(0.0) { }
-    GPU_DECL FADd(const float u): value(u),grad(0.0) { }
-    GPU_DECL FADd(const int u): value(u),grad(0.0) { }
-    GPU_DECL FADd(const size_t u): value(u),grad(0.0) { }
+    FADd(const double u): value(u),grad(0.0) { }
+    FADd(const float u): value(u),grad(0.0) { }
+    FADd(const int u): value(u),grad(0.0) { }
+    FADd(const size_t u): value(u),grad(0.0) { }
     //    FADd(const FADd &u) : value(u.value), grad(u.grad) { }
     FADd(const FADd &u) = default ;
 
     FADd() = default ;
 
-    GPU_DECL void setValue(double val) { value = val ; }
-    GPU_DECL FADd& operator =(const FADd &u) {
+    void setValue(double val) { value = val ; }
+    FADd& operator =(const FADd &u) {
       value = u.value;
       grad = u.grad;
       return *this;
     }
-    GPU_DECL FADd& operator =(const int &u) {
+    FADd& operator =(const int &u) {
       value = u;
       grad = 0.0;
       return *this;
     }
-    GPU_DECL FADd& operator =(const float &u) {
+    FADd& operator =(const float &u) {
       value = u;
       grad = 0.0;
       return *this;
     }
-    GPU_DECL FADd& operator =(const double &u) {
+    FADd& operator =(const double &u) {
       value = u;
       grad = 0.0;
       return *this;
     }
-    GPU_DECL FADd& operator =(const long double &u) {
+    FADd& operator =(const long double &u) {
       value = u;
       grad = 0.0;
       return *this;
@@ -719,46 +718,46 @@ namespace Loci {
     //    template<class T> FADd operator +(const T &v) const{
     //      return FADd(value+(double)v, grad);
     //    }
-    GPU_DECL FADd operator +(const FADd &v) const{
+    FADd operator +(const FADd &v) const{
       return FADd(value+v.value, grad+v.grad);
     }
-    GPU_DECL FADd operator +() const{
+    FADd operator +() const{
       return FADd(value, grad);
     }
-    GPU_DECL FADd operator +(const int &v) const{
+    FADd operator +(const int &v) const{
       return FADd(value+(double)v, grad);
     }
-    GPU_DECL FADd operator +(const float &v) const{
+    FADd operator +(const float &v) const{
       return FADd(value+(double)v, grad);
     }
-    GPU_DECL FADd operator +(const double &v) const{
+    FADd operator +(const double &v) const{
       return FADd(value+(double)v, grad);
     }
-    GPU_DECL FADd operator +(const long double &v) const{
+    FADd operator +(const long double &v) const{
       return FADd(value+(long double)v, grad);
     }
     //    template<class T> FADd& operator +=(const T &u) {
     //      value+=(double)u;
     //      return *this;
     //    }
-    GPU_DECL FADd& operator +=(const FADd &u) {
+    FADd& operator +=(const FADd &u) {
       value+=u.value;
       grad+=u.grad;
       return *this;
     }
-    GPU_DECL FADd& operator +=(const int &u) {
+    FADd& operator +=(const int &u) {
       value+=u;
       return *this;
     }
-    GPU_DECL FADd& operator +=(const float &u) {
+    FADd& operator +=(const float &u) {
       value+=u;
       return *this;
     }
-    GPU_DECL FADd& operator +=(const double &u) {
+    FADd& operator +=(const double &u) {
       value+=u;
       return *this;
     }
-    GPU_DECL FADd& operator +=(const long double &u) {
+    FADd& operator +=(const long double &u) {
       value+=u;
       return *this;
     }
@@ -768,46 +767,46 @@ namespace Loci {
     //    template<class T> FADd operator -(const T &v) const{
     //      return FADd(value-(double)v, grad);
     //    }
-    GPU_DECL FADd operator -(const FADd &v) const{
+    FADd operator -(const FADd &v) const{
       return FADd(value-v.value, grad-v.grad);
     }
-    GPU_DECL FADd operator -() const {
+    FADd operator -() const {
       return FADd(-value, -grad);
     }
-    GPU_DECL FADd operator -(const int &v) const{
+    FADd operator -(const int &v) const{
       return FADd(value-(double)v, grad);
     }
-    GPU_DECL FADd operator -(const float &v) const{
+    FADd operator -(const float &v) const{
       return FADd(value-(double)v, grad);
     }
-    GPU_DECL FADd operator -(const double &v) const{
+    FADd operator -(const double &v) const{
       return FADd(value-(double)v, grad);
     }
-    GPU_DECL FADd operator -(const long double &v) const{
+    FADd operator -(const long double &v) const{
       return FADd(value-(long double)v, grad);
     }
     //    template<class T> FADd& operator -=(const T &u) {
     //      value-=(double)u;
     //      return *this;
     //    }
-    GPU_DECL FADd& operator -=(const FADd &u) {
+    FADd& operator -=(const FADd &u) {
       value-=u.value;
       grad-=u.grad;
       return *this;
     }
-    GPU_DECL FADd& operator -=(const int &u) {
+    FADd& operator -=(const int &u) {
       value-=u;
       return *this;
     }
-    GPU_DECL FADd& operator -=(const float &u) {
+    FADd& operator -=(const float &u) {
       value-=u;
       return *this;
     }
-    GPU_DECL FADd& operator -=(const double &u) {
+    FADd& operator -=(const double &u) {
       value-=u;
       return *this;
     }
-    GPU_DECL FADd& operator -=(const long double &u) {
+    FADd& operator -=(const long double &u) {
       value-=u;
       return *this;
     }
@@ -816,46 +815,46 @@ namespace Loci {
     //    template<class T> FADd operator *(const T &v) const{
     //      return FADd(value*(double)v, grad);
     //    }
-    GPU_DECL FADd operator *(const FADd &v) const {
+    FADd operator *(const FADd &v) const {
       return FADd(value*v.value,  grad*v.value + v.grad*value);
     }
-    GPU_DECL FADd operator *(const int &v) const{
+    FADd operator *(const int &v) const{
       return FADd(value*(double)v,  grad*(double)v);
     }
-    GPU_DECL FADd operator *(const float &v) const{
+    FADd operator *(const float &v) const{
       return FADd(value*(double)v,  grad*(double)v);
     }
-    GPU_DECL FADd operator *(const double &v) const{
+    FADd operator *(const double &v) const{
       return FADd(value*(double)v,  grad*(double)v);
     }
-    GPU_DECL FADd operator *(const long double &v) const{
+    FADd operator *(const long double &v) const{
       return FADd(value*(long double)v,  grad*(long double)v);
     }
     //    template<class T> FADd& operator *=(const T &u) {
     //      value*=(double)u;
     //      return *this;
     //    }
-    GPU_DECL FADd& operator *=(const FADd &u) {
+    FADd& operator *=(const FADd &u) {
       grad = grad*u.value + u.grad * value;
       value*=u.value;
       return *this;
     }
-    GPU_DECL FADd& operator *=(const int &u) {
+    FADd& operator *=(const int &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
     }
-    GPU_DECL FADd& operator *=(const float &u) {
+    FADd& operator *=(const float &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
     }
-    GPU_DECL FADd& operator *=(const double &u) {
+    FADd& operator *=(const double &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
     }
-    GPU_DECL FADd& operator *=(const long double &u) {
+    FADd& operator *=(const long double &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
@@ -865,46 +864,46 @@ namespace Loci {
     //    template<class T> FADd operator /(const T &v) const{
     //      return FADd(value/(double)v, grad);
     //    }
-    GPU_DECL FADd operator /(const FADd &v) const{
+    FADd operator /(const FADd &v) const{
       return FADd(value/v.value, (grad*v.value - value*v.grad)/v.value/v.value);
     }
-    GPU_DECL FADd operator /(const int &v) const{
+    FADd operator /(const int &v) const{
       return FADd(value/v, (grad/(double)v));
     }
-    GPU_DECL FADd operator /(const float &v) const{
+    FADd operator /(const float &v) const{
       return FADd(value/v, (grad/(double)v));
     }
-    GPU_DECL FADd operator /(const double &v) const{
+    FADd operator /(const double &v) const{
       return FADd(value/v, (grad/(double)v));
     }
-    GPU_DECL FADd operator /(const long double &v) const{
+    FADd operator /(const long double &v) const{
       return FADd(value/v, (grad/(long double)v));
     }
     //    template<class T> FADd& operator /=(const T &u) {
     //      value/=(double)u;
     //      return *this;
     //    }
-    GPU_DECL FADd& operator /=(const FADd &u) {
+    FADd& operator /=(const FADd &u) {
       grad = (grad*u.value - value * u.grad) / u.value / u.value;
       value/=u.value;
       return *this;
     }
-    GPU_DECL FADd& operator /=(const int &u) {
+    FADd& operator /=(const int &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
     }
-    GPU_DECL FADd& operator /=(const float &u) {
+    FADd& operator /=(const float &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
     }
-    GPU_DECL FADd& operator /=(const double &u) {
+    FADd& operator /=(const double &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
     }
-    GPU_DECL FADd& operator /=(const long double &u) {
+    FADd& operator /=(const long double &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
@@ -930,94 +929,94 @@ namespace Loci {
     //    template<class T> bool operator <=(const T &u) const {
     //      return ((value<=(double)u)?true:false);
     //    }
-    GPU_DECL bool operator ==(const FADd &u)const  {
+    bool operator ==(const FADd &u)const  {
       return ((value==u.value)?true:false);
     }
-    GPU_DECL bool operator !=(const FADd &u) const {
+    bool operator !=(const FADd &u) const {
       return ((value!=u.value)?true:false);
     }
-    GPU_DECL bool operator >(const FADd &u) const {
+    bool operator >(const FADd &u) const {
       return ((value>u.value)?true:false);
     }
-    GPU_DECL bool operator <(const FADd &u) const {
+    bool operator <(const FADd &u) const {
       return ((value<u.value)?true:false);
     }
-    GPU_DECL bool operator >=(const FADd &u) const {
+    bool operator >=(const FADd &u) const {
       return ((value>=u.value)?true:false);
     }
-    GPU_DECL bool operator <=(const FADd &u) const {
+    bool operator <=(const FADd &u) const {
       return ((value<=u.value)?true:false);
     }
-    GPU_DECL bool operator ==(const int &u) const {
+    bool operator ==(const int &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const int &u) const {
+    bool operator !=(const int &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const int &u) const {
+    bool operator >(const int &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const int &u) const {
+    bool operator <(const int &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const int &u) const {
+    bool operator >=(const int &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const int &u) const {
+    bool operator <=(const int &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const float &u) const {
+    bool operator ==(const float &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const float &u) const {
+    bool operator !=(const float &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const float &u) const {
+    bool operator >(const float &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const float &u) const {
+    bool operator <(const float &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const float &u) const {
+    bool operator >=(const float &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const float &u) const {
+    bool operator <=(const float &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const double &u) const {
+    bool operator ==(const double &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const double &u) const {
+    bool operator !=(const double &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const double &u) const {
+    bool operator  >(const double &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const double &u) const {
+    bool operator <(const double &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const double &u) const {
+    bool operator >=(const double &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const double &u) const {
+    bool operator <=(const double &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const long double &u) const {
+    bool operator ==(const long double &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const long double &u) const {
+    bool operator !=(const long double &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const long double &u) const {
+    bool operator  >(const long double &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const long double &u) const {
+    bool operator <(const long double &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const long double &u) const {
+    bool operator >=(const long double &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const long double &u) const {
+    bool operator <=(const long double &u) const {
       return ((value<=u)?true:false);
     }
 
@@ -1053,98 +1052,98 @@ namespace Loci {
     return stream;
   }
 
-  inline GPU_DECL double ceil(const FADd u) {
+  inline double ceil(const FADd u) {
     return std::ceil(u.value) ;
   }
-  inline GPU_DECL double floor(const FADd u) {
+  inline double floor(const FADd u) {
     return std::floor(u.value) ;
   }
 
-  inline GPU_DECL FADd erf(const FADd u) {
+  inline FADd erf(const FADd u) {
     double ef = ::erf(u.value) ;
     double efp = (2./sqrt(M_PI))*std::exp(-u.value*u.value) ;
     return FADd(ef,u.grad*efp) ;
   }
-  inline GPU_DECL FADd sin(const FADd u) {
+  inline FADd sin(const FADd u) {
     return FADd(std::sin(u.value), u.grad*std::cos(u.value));
   }
-  inline GPU_DECL FADd cos(const FADd u) {
+  inline FADd cos(const FADd u) {
     return FADd(std::cos(u.value), -u.grad*std::sin(u.value));
   }
-  inline GPU_DECL FADd tan(const FADd u) {
+  inline FADd tan(const FADd u) {
     return FADd(std::tan(u.value), u.grad/pow(std::cos(u.value),2)) ;
   }
 
-  inline GPU_DECL FADd exp(const FADd u) {
+  inline FADd exp(const FADd u) {
     return FADd(std::exp(u.value), u.grad*std::exp(u.value));
   }
-  inline GPU_DECL FADd log(const FADd u) {
+  inline FADd log(const FADd u) {
     return FADd(std::log(u.value), u.grad/u.value);
   }
-  inline GPU_DECL FADd log10(const FADd u) {
+  inline FADd log10(const FADd u) {
     return FADd(std::log(u.value), u.grad/u.value)/std::log(10.0);
   }
-  inline GPU_DECL FADd abs(const FADd u) {
+  inline FADd abs(const FADd u) {
     return FADd(std::fabs(u.value),
                 u.grad*( (u.value<0.0)?-1.0:1.0 ) );
   }
-  inline GPU_DECL FADd fabs(const FADd u) {
+  inline FADd fabs(const FADd u) {
     return FADd(std::fabs(u.value),
                 u.grad*( (u.value<0.0)?-1.0:1.0 ) );
   }
   /* MPGCOMMENT [05-12-2017 15:04] ---> POW */
-  inline GPU_DECL FADd pow(const FADd u, const int k) {
+  inline FADd pow(const FADd u, const int k) {
     return FADd(std::pow(u.value, k),
                 (double)k * std::pow(u.value, (double)k-1.0)*u.grad );
   }
-  inline GPU_DECL FADd pow(const FADd u, const float k) {
+  inline FADd pow(const FADd u, const float k) {
     return FADd(std::pow(u.value, double(k)),
                 (double)k * std::pow(u.value, (double)k-1.0)*u.grad );
   }
-  inline GPU_DECL FADd pow(const FADd u, const double k) {
+  inline FADd pow(const FADd u, const double k) {
     return FADd(std::pow(u.value, k),
                 k * std::pow(u.value, k-1.0)*u.grad );
   }
-  inline GPU_DECL FADd pow(const FADd u, const long double k) {
+  inline FADd pow(const FADd u, const long double k) {
     return FADd(std::pow(u.value,  double(k)),
                 (double)k * std::pow(u.value,  (double)k-1.0)*u.grad );
   }
-  inline GPU_DECL FADd sqrt(const FADd u) {
+  inline FADd sqrt(const FADd u) {
     double su = std::sqrt(u.value) ;
     return FADd(su,0.5*u.grad/std::max(su,1e-30)) ;
   }
-  inline GPU_DECL FADd pow(const FADd k, const FADd u) {
+  inline FADd pow(const FADd k, const FADd u) {
     double kpu = std::pow(k.value,u.value) ;
     return FADd(kpu,std::pow(k.value,u.value-1.)*k.grad*u.value +
                 kpu*std::log(k.value)*u.grad) ;
   }
-  inline GPU_DECL FADd pow(const int k, const FADd u) {
+  inline FADd pow(const int k, const FADd u) {
     double kpu = std::pow(k,u.value) ;
     return FADd(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline GPU_DECL FADd pow(const float k, const FADd u) {
+  inline FADd pow(const float k, const FADd u) {
     double kpu = std::pow(double(k),u.value) ;
     return FADd(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline GPU_DECL FADd pow(const double k, const FADd u) {
+  inline FADd pow(const double k, const FADd u) {
     double kpu = std::pow(k,u.value) ;
     return FADd(kpu,kpu*std::log(k)*u.grad) ;
   }
-  inline GPU_DECL FADd pow(const long double k, const FADd u) {
+  inline FADd pow(const long double k, const FADd u) {
     double kpu = std::pow(double(k),u.value) ;
     return FADd(kpu,kpu*std::log(k)*u.grad) ;
   }
 
 
-  inline GPU_DECL FADd sinh(const FADd u) {
+  inline FADd sinh(const FADd u) {
     return FADd(std::sinh(u.value),
                 0.5*u.grad*(std::exp(u.value) + std::exp(-u.value))) ;
   }
-  inline GPU_DECL FADd cosh(const FADd u) {
+  inline FADd cosh(const FADd u) {
     return FADd(std::cosh(u.value),
                 0.5*u.grad*(std::exp(u.value) - std::exp(-u.value))) ;
   }
-  inline GPU_DECL FADd tanh(const FADd u) {
+  inline FADd tanh(const FADd u) {
     double ex = std::exp(std::min(u.value,350.0)) ;
     double exm = std::exp(std::min(-u.value,350.0)) ;
     double dex = ex-exm ;
@@ -1153,42 +1152,42 @@ namespace Loci {
                 u.grad*(1.-dex*dex/(sex*sex))) ;
   }
 
-  inline GPU_DECL FADd asin(const FADd u) {
+  inline FADd asin(const FADd u) {
     return FADd(std::asin(u.value), u.grad/std::sqrt(1.0-u.value*u.value) );
   }
-  inline GPU_DECL FADd acos(const FADd u) {
+  inline FADd acos(const FADd u) {
     return FADd(std::acos(u.value), -u.grad/std::sqrt(1.0-u.value*u.value) );
   }
-  inline GPU_DECL FADd atan(const FADd u) {
+  inline FADd atan(const FADd u) {
     return FADd(std::atan(u.value), u.grad/(1.0+u.value*u.value) );
   }
   // This will not work in general
-  inline GPU_DECL FADd atan2(const FADd u, const FADd v) {
+  inline FADd atan2(const FADd u, const FADd v) {
     return atan(u/v);
   }
 
-  inline GPU_DECL FADd asinh(const FADd u) {
+  inline FADd asinh(const FADd u) {
     double strm = std::sqrt(u.value*u.value+1.) ;
     double uvstrm = u.value+strm ;
     return FADd(::asinh(u.value), u.grad*(u.value/strm+1.)/uvstrm) ;
   }
-  inline GPU_DECL FADd acosh(const FADd u) {
+  inline FADd acosh(const FADd u) {
     double strm = std::sqrt(u.value*u.value-1.) ;
     double uvstrm = u.value+strm ;
     return FADd(::acosh(u.value), u.grad*(u.value/strm +1.)/uvstrm) ;
   }
-  inline GPU_DECL FADd atanh(const FADd u) {
+  inline FADd atanh(const FADd u) {
     const double uv = u.value ;
     return FADd(::atanh(uv), .5*u.grad*(1./(1.+uv)+1./(1.-uv))) ;
   }
 
-  inline GPU_DECL FADd operator +(const double u,const FADd v)
+  inline FADd operator +(const double u,const FADd v)
   { return FADd(u+v.value, v.grad); }
-  inline GPU_DECL FADd operator -(const double u,const FADd v)
+  inline FADd operator -(const double u,const FADd v)
   { return FADd(u-v.value, -v.grad); }
-  inline GPU_DECL FADd operator *(const double u,const FADd v)
+  inline FADd operator *(const double u,const FADd v)
   { return FADd(u*v.value,  v.grad*u); }
-  inline GPU_DECL FADd operator /(const double &u,const FADd &v)
+  inline FADd operator /(const double &u,const FADd &v)
   { return FADd(u/v.value, -u*v.grad/v.value/v.value); }
 
 
@@ -1209,263 +1208,263 @@ namespace Loci {
     //      this->maxN = s;
     //    }
     template< class T1>
-    GPU_DECL MFADd(T1 a0) : value(a0), grad()
+    MFADd(T1 a0) : value(a0), grad()
     { for(int i=0;i<MFAD_SIZE;++i) grad[i] =0 ; }
-    GPU_DECL MFADd() : value(0.0), grad()
+    MFADd() : value(0.0), grad()
     { for(int i=0;i<MFAD_SIZE;++i) grad[i] =0 ; }
     //explicit MFADd(int u) : value(u), grad(){ }
     //explicit MFADd(float u) : value(u), grad() { }
     //explicit MFADd(double u) : value(u), grad() { }
     //explicit MFADd(long double u) : value(u), grad() { }
-    GPU_DECL MFADd(double u, size_t n) : value(u), grad()
+    MFADd(double u, size_t n) : value(u), grad()
     { for(int i=0;i<MFAD_SIZE;++i) grad[i] =0 ; }
     //explicit MFADd(bool &u)  : value((u)?1.0:0.0), grad() { }
-    GPU_DECL MFADd(const double u, const double * g, const int n): value(u), grad() {
+    MFADd(const double u, const double * g, const int n): value(u), grad() {
       for (size_t i=0; i<maxN; i++) this->grad[i]=g[i];
     }
-    GPU_DECL MFADd(const MFADd &u, size_t n): value(u.value), grad() {
+    MFADd(const MFADd &u, size_t n): value(u.value), grad() {
       for (size_t i=0; i<maxN; i++) this->grad[i]=u.grad[i];
     }
-    GPU_DECL MFADd(const MFADd &u): value(u.value), grad() {
+    MFADd(const MFADd &u): value(u.value), grad() {
       for (size_t i=0; i<maxN; i++) this->grad[i]=u.grad[i];
     }
 
-    GPU_DECL void setValue(double val) { value = val ; }
-    GPU_DECL MFADd& operator =(const MFADd &u) {
+    void setValue(double val) { value = val ; }
+    MFADd& operator =(const MFADd &u) {
       this->value = u.value;
       for (size_t i=0; i<maxN; i++) this->grad[i]=u.grad[i];
       return *this;
     }
-    GPU_DECL MFADd& operator =(const int &u) {
+    MFADd& operator =(const int &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
-    GPU_DECL MFADd& operator =(const float &u) {
+    MFADd& operator =(const float &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
-    GPU_DECL MFADd& operator =(const double &u) {
+    MFADd& operator =(const double &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
-    GPU_DECL MFADd& operator =(const long double &u) {
+    MFADd& operator =(const long double &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
 
-    GPU_DECL MFADd operator +(const MFADd &v) const{
+    MFADd operator +(const MFADd &v) const{
       size_t s = maxN;
       MFADd out(this->value+v.value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]+v.grad[i];
       return out;
     }
-    GPU_DECL MFADd operator +() const {
+    MFADd operator +() const {
       size_t s = maxN;
       MFADd out(this->value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator +(const int &v) const{
+    MFADd operator +(const int &v) const{
       size_t s = maxN;
       MFADd out(this->value+(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator +(const float &v) const{
+    MFADd operator +(const float &v) const{
       size_t s = maxN;
       MFADd out(this->value+(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator +(const double &v) const{
+    MFADd operator +(const double &v) const{
       size_t s = maxN;
       MFADd out(this->value+(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator +(const long double &v) const{
+    MFADd operator +(const long double &v) const{
       size_t s = maxN;
       MFADd out(this->value+(long double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
 
-    GPU_DECL MFADd& operator +=(const MFADd &u) {
+    MFADd& operator +=(const MFADd &u) {
       this->value+=u.value;
       for (size_t i=0; i<maxN; i++) this->grad[i]+=u.grad[i];
       return *this;
     }
-    GPU_DECL MFADd& operator +=(const int &u) {
+    MFADd& operator +=(const int &u) {
       this->value+=u;
       return *this;
     }
-    GPU_DECL MFADd& operator +=(const float &u) {
+    MFADd& operator +=(const float &u) {
       this->value+=u;
       return *this;
     }
-    GPU_DECL MFADd& operator +=(const double &u) {
+    MFADd& operator +=(const double &u) {
       this->value+=u;
       return *this;
     }
-    GPU_DECL MFADd& operator +=(const long double &u) {
+    MFADd& operator +=(const long double &u) {
       this->value+=u;
       return *this;
     }
 
-    GPU_DECL MFADd operator -(const MFADd &v) const{
+    MFADd operator -(const MFADd &v) const{
       size_t s = maxN ;
       MFADd out(this->value-v.value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]-v.grad[i];
       return out;
     }
-    GPU_DECL MFADd operator -() const {
+    MFADd operator -() const {
       size_t s = maxN;
       MFADd out(-this->value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = -this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator -(const int &v) const{
+    MFADd operator -(const int &v) const{
       size_t s = maxN;
       MFADd out(this->value-(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator -(const float &v) const{
+    MFADd operator -(const float &v) const{
       size_t s = maxN;
       MFADd out(this->value-(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator -(const double &v) const{
+    MFADd operator -(const double &v) const{
       size_t s = maxN;
       MFADd out(this->value-(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    GPU_DECL MFADd operator -(const long double &v) const{
+    MFADd operator -(const long double &v) const{
       size_t s = maxN;
       MFADd out(this->value-(long double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
 
-    GPU_DECL MFADd& operator -=(const MFADd &u) {
+    MFADd& operator -=(const MFADd &u) {
       this->value -= u.value;
       for (size_t i=0; i<maxN; i++) this->grad[i]-=u.grad[i];
       return *this;
     }
-    GPU_DECL MFADd& operator -=(const int &u) {
+    MFADd& operator -=(const int &u) {
       this->value -= u;
       return *this;
     }
-    GPU_DECL MFADd& operator -=(const float &u) {
+    MFADd& operator -=(const float &u) {
       this->value -= u;
       return *this;
     }
-    GPU_DECL MFADd& operator -=(const double &u) {
+    MFADd& operator -=(const double &u) {
       this->value -= u;
       return *this;
     }
-    GPU_DECL MFADd& operator -=(const long double &u) {
+    MFADd& operator -=(const long double &u) {
       this->value -= u;
       return *this;
     }
 
-    GPU_DECL MFADd operator *(const MFADd &v) const {
+    MFADd operator *(const MFADd &v) const {
       size_t s = maxN ;
       MFADd out(this->value*v.value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]*v.value + v.grad[i]*this->value;
       return out;
     }
-    GPU_DECL MFADd operator *(const int &v) const {
+    MFADd operator *(const int &v) const {
       size_t s = maxN;
       MFADd out(this->value*(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (double)v;
       return out;
     }
-    GPU_DECL MFADd operator *(const float &v) const {
+    MFADd operator *(const float &v) const {
       size_t s = maxN;
       MFADd out(this->value*(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (double)v;
       return out;
     }
-    GPU_DECL MFADd operator *(const double &v) const {
+    MFADd operator *(const double &v) const {
       size_t s = maxN;
       MFADd out(this->value*(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (double)v;
       return out;
     }
-    GPU_DECL MFADd operator *(const long double &v) const {
+    MFADd operator *(const long double &v) const {
       size_t s = maxN;
       MFADd out(this->value*(long double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (long double)v;
       return out;
     }
 
-    GPU_DECL MFADd& operator *=(const MFADd &u) {
+    MFADd& operator *=(const MFADd &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] = this->grad[i]*u.value + u.grad[i] * this->value;
       this->value*=u.value;
       return *this;
     }
-    GPU_DECL MFADd& operator *=(const int &u) {
+    MFADd& operator *=(const int &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
-    GPU_DECL MFADd& operator *=(const float &u) {
+    MFADd& operator *=(const float &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
-    GPU_DECL MFADd& operator *=(const double &u) {
+    MFADd& operator *=(const double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
-    GPU_DECL MFADd& operator *=(const long double &u) {
+    MFADd& operator *=(const long double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
 
-    GPU_DECL MFADd operator /(const MFADd &v) const{
+    MFADd operator /(const MFADd &v) const{
       size_t s = maxN ;
       double div = this->value/v.value;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = (this->grad[i] - div*v.grad[i])/v.value;
       return out;
     }
-    GPU_DECL MFADd operator /(const int &v) const{
+    MFADd operator /(const int &v) const{
       size_t s = maxN;
       double div = this->value/(double)v;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]/(double)v;
       return out;
     }
-    GPU_DECL MFADd operator /(const float &v) const{
+    MFADd operator /(const float &v) const{
       size_t s = maxN;
       double div = this->value/(double)v;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]/(double)v;
       return out;
     }
-    GPU_DECL MFADd operator /(const double &v) const{
+    MFADd operator /(const double &v) const{
       size_t s = maxN;
       double div = this->value/(double)v;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]/(double)v;
       return out;
     }
-    GPU_DECL MFADd operator /(const long double &v) const{
+    MFADd operator /(const long double &v) const{
       size_t s = maxN;
       double div = this->value/(long double)v;
       MFADd out(div,s);
@@ -1473,126 +1472,126 @@ namespace Loci {
       return out;
     }
 
-    GPU_DECL MFADd& operator /=(const MFADd &u) {
+    MFADd& operator /=(const MFADd &u) {
       size_t s = maxN;
       double div = this->value/u.value;
       for (size_t i=0; i<s; i++) this->grad[i] = (this->grad[i] - div*u.grad[i])/u.value;
       this->value = div ;
       return *this;
     }
-    GPU_DECL MFADd& operator /=(const int &u) {
+    MFADd& operator /=(const int &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
-    GPU_DECL MFADd& operator /=(const float &u) {
+    MFADd& operator /=(const float &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
-    GPU_DECL MFADd& operator /=(const double &u) {
+    MFADd& operator /=(const double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
-    GPU_DECL MFADd& operator /=(const long double &u) {
+    MFADd& operator /=(const long double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
 
-    GPU_DECL bool operator ==(const MFADd &u)const  {
+    bool operator ==(const MFADd &u)const  {
       return ((this->value==u.value)?true:false);
     }
-    GPU_DECL bool operator !=(const MFADd &u) const {
+    bool operator !=(const MFADd &u) const {
       return ((this->value!=u.value)?true:false);
     }
-    GPU_DECL bool operator >(const MFADd &u) const {
+    bool operator >(const MFADd &u) const {
       return ((this->value>u.value)?true:false);
     }
-    GPU_DECL bool operator <(const MFADd &u) const {
+    bool operator <(const MFADd &u) const {
       return ((this->value<u.value)?true:false);
     }
-    GPU_DECL bool operator >=(const MFADd &u) const {
+    bool operator >=(const MFADd &u) const {
       return ((this->value>=u.value)?true:false);
     }
-    GPU_DECL bool operator <=(const MFADd &u) const {
+    bool operator <=(const MFADd &u) const {
       return ((this->value<=u.value)?true:false);
     }
-    GPU_DECL bool operator ==(const int &u) const {
+    bool operator ==(const int &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const int &u) const {
+    bool operator !=(const int &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const int &u) const {
+    bool operator >(const int &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const int &u) const {
+    bool operator <(const int &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const int &u) const {
+    bool operator >=(const int &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const int &u) const {
+    bool operator <=(const int &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const float &u) const {
+    bool operator ==(const float &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const float &u) const {
+    bool operator !=(const float &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const float &u) const {
+    bool operator >(const float &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const float &u) const {
+    bool operator <(const float &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const float &u) const {
+    bool operator >=(const float &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const float &u) const {
+    bool operator <=(const float &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const double &u) const {
+    bool operator ==(const double &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const double &u) const {
+    bool operator !=(const double &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const double &u) const {
+    bool operator  >(const double &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const double &u) const {
+    bool operator <(const double &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const double &u) const {
+    bool operator >=(const double &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const double &u) const {
+    bool operator <=(const double &u) const {
       return ((value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const long double &u) const {
+    bool operator ==(const long double &u) const {
       return ((value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const long double &u) const {
+    bool operator !=(const long double &u) const {
       return ((value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const long double &u) const {
+    bool operator  >(const long double &u) const {
       return ((value>u)?true:false);
     }
-    GPU_DECL bool operator <(const long double &u) const {
+    bool operator <(const long double &u) const {
       return ((value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const long double &u) const {
+    bool operator >=(const long double &u) const {
       return ((value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const long double &u) const {
+    bool operator <=(const long double &u) const {
       return ((value<=u)?true:false);
     }
   } ;
@@ -1643,13 +1642,13 @@ namespace Loci {
   using std::max;
   using std::min;
 
-  inline GPU_DECL double ceil(const MFADd u) {
+  inline double ceil(const MFADd u) {
     return std::ceil(u.value) ;
   }
-  inline GPU_DECL double floor(const MFADd u) {
+  inline double floor(const MFADd u) {
     return std::floor(u.value) ;
   }
-  inline GPU_DECL MFADd erf(const MFADd u) {
+  inline MFADd erf(const MFADd u) {
     double ef = ::erf(u.value) ;
     size_t s = MFADd::maxN ;
     MFADd out(ef,s) ;
@@ -1658,116 +1657,116 @@ namespace Loci {
       out.grad[i] = u.grad[i]*efp ;
     return out ;
   }
-  inline GPU_DECL MFADd sin(const MFADd u) {
+  inline MFADd sin(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::sin(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*std::cos(u.value);
     return out;
   }
-  inline GPU_DECL MFADd cos(const MFADd u) {
+  inline MFADd cos(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::cos(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = -u.grad[i]*std::sin(u.value);
     return out;
   }
-  inline GPU_DECL MFADd tan(const MFADd u) {
+  inline MFADd tan(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::tan(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/pow(std::cos(u.value),2) ;
     return out;
   }
 
-  inline GPU_DECL MFADd exp(const MFADd u) {
+  inline MFADd exp(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::exp(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*std::exp(u.value);
     return out;
   }
-  inline GPU_DECL MFADd log(const MFADd u) {
+  inline MFADd log(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::log(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/u.value ;
     return out;
   }
-  inline GPU_DECL MFADd log10(const MFADd u) {
+  inline MFADd log10(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::log(u.value)/std::log(10.0),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/u.value/std::log(10.0);
     return out;
   }
-  inline GPU_DECL MFADd abs(const MFADd u) {
+  inline MFADd abs(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::fabs(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*( (u.value<0.0)?-1.0:1.0 );
     return out;
   }
-  inline GPU_DECL MFADd fabs(const MFADd u) {
+  inline MFADd fabs(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::fabs(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*( (u.value<0.0)?-1.0:1.0 );
     return out;
   }
 
-  inline GPU_DECL MFADd pow(const MFADd u, const int k) {
+  inline MFADd pow(const MFADd u, const int k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, k),s);
     for (size_t i=0; i<s; i++) out.grad[i] = (double)k * std::pow(u.value, (double)k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const MFADd u, const float k) {
+  inline MFADd pow(const MFADd u, const float k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, double(k)),s);
     for (size_t i=0; i<s; i++) out.grad[i] = (double)k * std::pow(u.value, (double)k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const MFADd u, const double k) {
+  inline MFADd pow(const MFADd u, const double k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, k),s);
     for (size_t i=0; i<s; i++) out.grad[i] = k * std::pow(u.value, k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const MFADd u, const long double k) {
+  inline MFADd pow(const MFADd u, const long double k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, double(k)),s);
     for (size_t i=0; i<s; i++) out.grad[i] = (double)k * std::pow(u.value, (double)k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd sqrt(const MFADd u) {
+  inline MFADd sqrt(const MFADd u) {
     size_t s = MFADd::maxN;
     double sq = std::sqrt(u.value);
     MFADd out(sq,s) ;
     for (size_t i=0; i<s; i++) out.grad[i] = 0.5*u.grad[i]/::max(sq,1e-30) ;
     return out;
   }
-  inline GPU_DECL MFADd pow(const MFADd k, const MFADd u) {
+  inline MFADd pow(const MFADd k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k.value,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = std::pow(k.value,u.value-1.)*k.grad[i]*u.value + kpu*std::log(k.value)*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const int k, const MFADd u) {
+  inline MFADd pow(const int k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = kpu*std::log(double(k))*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const float k, const MFADd u) {
+  inline MFADd pow(const float k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = kpu*std::log(double(k))*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const double k, const MFADd u) {
+  inline MFADd pow(const double k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = kpu*std::log(k)*u.grad[i] ;
     return out ;
   }
-  inline GPU_DECL MFADd pow(const long double k, const MFADd u) {
+  inline MFADd pow(const long double k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(double(k),u.value) ;
     MFADd out(kpu,s);
@@ -1775,56 +1774,56 @@ namespace Loci {
     return out ;
   }
 
-  inline GPU_DECL MFADd max (const MFADd &a, const MFADd& b) {
+  inline MFADd max (const MFADd &a, const MFADd& b) {
     size_t s = MFADd::maxN;
     MFADd out((a.value<b.value)?b.value:a.value);
     for (size_t i=0; i<s; i++) out.grad[i] = (a.value<b.value)?b.grad[i]:a.grad[i];
     return out;
   }
-  inline GPU_DECL MFADd max (const MFADd &a, const int& b) {
+  inline MFADd max (const MFADd &a, const int& b) {
     return max(a,MFADd((double)b));
   }
-  inline GPU_DECL MFADd max (const MFADd &a, const float& b) {
+  inline MFADd max (const MFADd &a, const float& b) {
     return max(a,MFADd((double)b));
   }
-  inline GPU_DECL MFADd max (const MFADd &a, const double & b) {
+  inline MFADd max (const MFADd &a, const double & b) {
     return max(a,MFADd((double)b));
   }
-  inline GPU_DECL MFADd max (const MFADd &a, const long double & b) {
+  inline MFADd max (const MFADd &a, const long double & b) {
     return max(a,MFADd((double)b));
   }
-  inline GPU_DECL MFADd min (const MFADd &a, const MFADd& b) {
+  inline MFADd min (const MFADd &a, const MFADd& b) {
     size_t s = MFADd::maxN;
     MFADd out((a.value<b.value)?a.value:b.value);
     for (size_t i=0; i<s; i++) out.grad[i] = (a.value<b.value)?a.grad[i]:b.grad[i];
     return out;
   }
-  inline GPU_DECL MFADd min (const MFADd &a, const int& b) {
+  inline MFADd min (const MFADd &a, const int& b) {
     return min(a, MFADd((double)b));
   }
-  inline GPU_DECL MFADd min (const MFADd &a, const float& b) {
+  inline MFADd min (const MFADd &a, const float& b) {
     return min(a, MFADd((double)b));
   }
-  inline GPU_DECL MFADd min (const MFADd &a, const double& b) {
+  inline MFADd min (const MFADd &a, const double& b) {
     return min(a, MFADd((double)b));
   }
-  inline GPU_DECL MFADd min (const MFADd &a, const long double& b) {
+  inline MFADd min (const MFADd &a, const long double& b) {
     return min(a, MFADd((double)b));
   }
 
-  inline GPU_DECL MFADd sinh(const MFADd u) {
+  inline MFADd sinh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::sinh(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = 0.5*u.grad[i]*(std::exp(u.value) + std::exp(-(u.value))) ;
     return out;
   }
-  inline GPU_DECL MFADd cosh(const MFADd u) {
+  inline MFADd cosh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::cosh(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = 0.5*u.grad[i]*(std::exp(u.value) - std::exp(-(u.value))) ;
     return out;
   }
-  inline GPU_DECL MFADd tanh(const MFADd u) {
+  inline MFADd tanh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::tanh(u.value),s);
     double ex = std::exp(::min(u.value,350.0)) ;
@@ -1835,29 +1834,29 @@ namespace Loci {
     return out;
   }
 
-  inline GPU_DECL MFADd asin(const MFADd u) {
+  inline MFADd asin(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::asin(u.value),s);
     double val = std::sqrt(1.0-u.value*u.value);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/val;
     return out;
   }
-  inline GPU_DECL MFADd acos(const MFADd u) {
+  inline MFADd acos(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::acos(u.value),s);
     double val = std::sqrt(1.0-u.value*u.value);
     for (size_t i=0; i<s; i++) out.grad[i] = -u.grad[i]/val;
     return out;
   }
-  inline GPU_DECL MFADd atan(const MFADd u) {
+  inline MFADd atan(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::atan(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/(u.value*u.value + 1.0);
     return out;
   }
-  inline GPU_DECL MFADd atan2(const MFADd u, const MFADd v) { return atan(u/v); }
+  inline MFADd atan2(const MFADd u, const MFADd v) { return atan(u/v); }
 
-  inline GPU_DECL MFADd asinh(const MFADd u) {
+  inline MFADd asinh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(::asinh(u.value),s);
     double strm = std::sqrt(u.value*u.value+1.) ;
@@ -1865,7 +1864,7 @@ namespace Loci {
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*(u.value/strm+1.)/uvstrm ;
     return out;
   }
-  inline GPU_DECL MFADd acosh(const MFADd u) {
+  inline MFADd acosh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(::acosh(u.value),s);
     double strm = std::sqrt(u.value*u.value-1.) ;
@@ -1873,7 +1872,7 @@ namespace Loci {
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*(u.value/strm +1.)/uvstrm ;
     return out;
   }
-  inline GPU_DECL MFADd atanh(const MFADd u) {
+  inline MFADd atanh(const MFADd u) {
     size_t s = MFADd::maxN;
     const double uv = u.value ;
     MFADd out(::atanh(uv),s);
@@ -1881,25 +1880,25 @@ namespace Loci {
     return out;
   }
 
-  inline GPU_DECL MFADd operator +(const double u,const MFADd v) {
+  inline MFADd operator +(const double u,const MFADd v) {
     size_t s = MFADd::maxN;
     MFADd out(u+v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = v.grad[i];
     return out;
   }
-  inline GPU_DECL MFADd operator -(const double u,const MFADd v) {
+  inline MFADd operator -(const double u,const MFADd v) {
     size_t s = MFADd::maxN;
     MFADd out(u-v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = v.grad[i];
     return out;
   }
-  inline GPU_DECL MFADd operator *(const double u,const MFADd v) {
+  inline MFADd operator *(const double u,const MFADd v) {
     size_t s = MFADd::maxN;
     MFADd out(u*v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = u * v.grad[i];
     return out;
   }
-  inline GPU_DECL MFADd operator /(const double &u,const MFADd &v) {
+  inline MFADd operator /(const double &u,const MFADd &v) {
     size_t s = MFADd::maxN;
     MFADd out(u/v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = -u*v.grad[i]/v.value/v.value;
@@ -1942,22 +1941,22 @@ namespace Loci {
 
 #endif
 
-    GPU_DECL VFAD(const double u) {
+    VFAD(const double u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
     }
-    GPU_DECL VFAD(const int u) {
+    VFAD(const int u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
     }
-    GPU_DECL VFAD(const size_t u) {
+    VFAD(const size_t u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
     }
-    GPU_DECL VFAD(const float u) {
+    VFAD(const float u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
@@ -1967,31 +1966,31 @@ namespace Loci {
 
     VFAD() = default ;
 
-    GPU_DECL void setValue(double val) { data.value = val ; }
-    GPU_DECL VFAD& operator =(const VFAD &u) {
+    void setValue(double val) { data.value = val ; }
+    VFAD& operator =(const VFAD &u) {
       data.value = u.data.value;
       data.grad = u.data.grad;
       return *this;
     }
-    GPU_DECL VFAD& operator =(const int &u) {
+    VFAD& operator =(const int &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
       return *this;
     }
-    GPU_DECL VFAD& operator =(const float &u) {
+    VFAD& operator =(const float &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
       return *this;
     }
-    GPU_DECL VFAD& operator =(const double &u) {
+    VFAD& operator =(const double &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
       return *this;
     }
-    GPU_DECL VFAD& operator =(const long double &u) {
+    VFAD& operator =(const long double &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
@@ -1999,7 +1998,7 @@ namespace Loci {
     }
 
 
-    GPU_DECL VFAD operator +(const VFAD &v) const{
+    VFAD operator +(const VFAD &v) const{
       VFAD tmp(*this) ;
       tmp.data.value += v.data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
@@ -2007,139 +2006,139 @@ namespace Loci {
       
       return tmp ;
     }
-    GPU_DECL VFAD operator +() const{
+    VFAD operator +() const{
       return VFAD(*this);
     }
-    GPU_DECL VFAD operator +(const int &v) const{
+    VFAD operator +(const int &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator +(const float &v) const{
+    VFAD operator +(const float &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator +(const double &v) const{
+    VFAD operator +(const double &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator +(const long double &v) const{
+    VFAD operator +(const long double &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
 
-    GPU_DECL VFAD& operator +=(const VFAD &u) {
+    VFAD& operator +=(const VFAD &u) {
       data.value+=u.data.value;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] += u.data.grad[i];
       return *this;
     }
-    GPU_DECL VFAD& operator +=(const int &u) {
+    VFAD& operator +=(const int &u) {
       data.value+=u;
       return *this;
     }
-    GPU_DECL VFAD& operator +=(const float &u) {
+    VFAD& operator +=(const float &u) {
       data.value+=u;
       return *this;
     }
-    GPU_DECL VFAD& operator +=(const double &u) {
+    VFAD& operator +=(const double &u) {
       data.value+=u;
       return *this;
     }
-    GPU_DECL VFAD& operator +=(const long double &u) {
+    VFAD& operator +=(const long double &u) {
       data.value+=u;
       return *this;
     }
 
-    GPU_DECL VFAD operator -(const VFAD &v) const{
+    VFAD operator -(const VFAD &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v.data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] -= v.data.grad[i] ;
       return tmp ;
     }
-    GPU_DECL VFAD operator -() const {
+    VFAD operator -() const {
       VFAD tmp ;
       tmp.data.value = -data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] = -data.grad[i] ;
       return tmp ;
     }
-    GPU_DECL VFAD operator -(const int &v) const{
+    VFAD operator -(const int &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator -(const float &v) const{
+    VFAD operator -(const float &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator -(const double &v) const{
+    VFAD operator -(const double &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator -(const long double &v) const{
+    VFAD operator -(const long double &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    GPU_DECL VFAD& operator -=(const VFAD &u) {
+    VFAD& operator -=(const VFAD &u) {
       data.value-=u.data.value;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i]-=u.data.grad[i];
       return *this;
     }
-    GPU_DECL VFAD& operator -=(const int &u) {
+    VFAD& operator -=(const int &u) {
       data.value-=u;
       return *this;
     }
-    GPU_DECL VFAD& operator -=(const float &u) {
+    VFAD& operator -=(const float &u) {
       data.value-=u;
       return *this;
     }
-    GPU_DECL VFAD& operator -=(const double &u) {
+    VFAD& operator -=(const double &u) {
       data.value-=u;
       return *this;
     }
-    GPU_DECL VFAD& operator -=(const long double &u) {
+    VFAD& operator -=(const long double &u) {
       data.value-=u;
       return *this;
     }
 
-    GPU_DECL VFAD operator *(const VFAD &v) const {
+    VFAD operator *(const VFAD &v) const {
       VFAD tmp ;
       tmp.data.value = data.value*v.data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] = data.grad[i]*v.data.value+data.value*v.data.grad[i] ;
       return tmp ;
     }
-    GPU_DECL VFAD operator *(const int &v) const{
+    VFAD operator *(const int &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] *= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator *(const float &v) const{
+    VFAD operator *(const float &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] *= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator *(const double &v) const{
+    VFAD operator *(const double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] *= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator *(const long double &v) const{
+    VFAD operator *(const long double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
@@ -2147,38 +2146,38 @@ namespace Loci {
       return tmp ;
     }
 
-    GPU_DECL VFAD& operator *=(const VFAD &u) {
+    VFAD& operator *=(const VFAD &u) {
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = data.grad[i]*u.data.value + u.data.grad[i]*data.value;
       data.value*=u.data.value;
       return *this;
     }
-    GPU_DECL VFAD& operator *=(const int &u) {
+    VFAD& operator *=(const int &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
-    GPU_DECL VFAD& operator *=(const float &u) {
+    VFAD& operator *=(const float &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
-    GPU_DECL VFAD& operator *=(const double &u) {
+    VFAD& operator *=(const double &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i) 
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
-    GPU_DECL VFAD& operator *=(const long double &u) {
+    VFAD& operator *=(const long double &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i) 
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
 
-    GPU_DECL VFAD operator /(const VFAD &v) const{
+    VFAD operator /(const VFAD &v) const{
       VFAD tmp ;
       tmp.data.value = data.value/v.data.value ;
       float value2 = 1./max(v.data.value*v.data.value,1e-30) ;
@@ -2187,28 +2186,28 @@ namespace Loci {
                            data.value*v.data.grad[i])*value2 ;
       return tmp ;
     }
-    GPU_DECL VFAD operator /(const int &v) const{
+    VFAD operator /(const int &v) const{
       VFAD tmp(*this) ;
       tmp.data.value /= double(v) ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] /= float(v) ;
       return tmp ;
     }
-    GPU_DECL VFAD operator /(const float &v) const{ 
+    VFAD operator /(const float &v) const{ 
       VFAD tmp(*this) ;
       tmp.data.value /= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] /= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator /(const double &v) const{
+    VFAD operator /(const double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value /= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] /= v ;
       return tmp ;
     }
-    GPU_DECL VFAD operator /(const long double &v) const{
+    VFAD operator /(const long double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value /= v ;
       for(int i=0;i<VFAD_SIZE;++i)
@@ -2216,7 +2215,7 @@ namespace Loci {
       return tmp ;
     }
 
-    GPU_DECL VFAD& operator /=(const VFAD &u) {
+    VFAD& operator /=(const VFAD &u) {
       float value2 = 1./max(u.data.value*u.data.value,1e-30) ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = (data.grad[i]*u.data.value -
@@ -2224,119 +2223,119 @@ namespace Loci {
       data.value /= u.data.value;
       return *this;
     }
-    GPU_DECL VFAD& operator /=(const int &u) {
+    VFAD& operator /=(const int &u) {
       data.value/=double(u);
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=float(u);
       return *this;
     }
-    GPU_DECL VFAD& operator /=(const float &u) {
+    VFAD& operator /=(const float &u) {
       data.value/=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=u;
       return *this;
     }
-    GPU_DECL VFAD& operator /=(const double &u) {
+    VFAD& operator /=(const double &u) {
       data.value/=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=u;
       return *this;
     }
-    GPU_DECL VFAD& operator /=(const long double &u) {
+    VFAD& operator /=(const long double &u) {
       data.value/=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=u;
       return *this;
     }
 
-    GPU_DECL bool operator ==(const VFAD &u)const  {
+    bool operator ==(const VFAD &u)const  {
       return ((data.value==u.data.value)?true:false);
     }
-    GPU_DECL bool operator !=(const VFAD &u) const {
+    bool operator !=(const VFAD &u) const {
       return ((data.value!=u.data.value)?true:false);
     }
-    GPU_DECL bool operator >(const VFAD &u) const {
+    bool operator >(const VFAD &u) const {
       return ((data.value>u.data.value)?true:false);
     }
-    GPU_DECL bool operator <(const VFAD &u) const {
+    bool operator <(const VFAD &u) const {
       return ((data.value<u.data.value)?true:false);
     }
-    GPU_DECL bool operator >=(const VFAD &u) const {
+    bool operator >=(const VFAD &u) const {
       return ((data.value>=u.data.value)?true:false);
     }
-    GPU_DECL bool operator <=(const VFAD &u) const {
+    bool operator <=(const VFAD &u) const {
       return ((data.value<=u.data.value)?true:false);
     }
-    GPU_DECL bool operator ==(const int &u) const {
+    bool operator ==(const int &u) const {
       return ((data.value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const int &u) const {
+    bool operator !=(const int &u) const {
       return ((data.value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const int &u) const {
+    bool operator >(const int &u) const {
       return ((data.value>u)?true:false);
     }
-    GPU_DECL bool operator <(const int &u) const {
+    bool operator <(const int &u) const {
       return ((data.value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const int &u) const {
+    bool operator >=(const int &u) const {
       return ((data.value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const int &u) const {
+    bool operator <=(const int &u) const {
       return ((data.value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const float &u) const {
+    bool operator ==(const float &u) const {
       return ((data.value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const float &u) const {
+    bool operator !=(const float &u) const {
       return ((data.value!=u)?true:false);
     }
-    GPU_DECL bool operator >(const float &u) const {
+    bool operator >(const float &u) const {
       return ((data.value>u)?true:false);
     }
-    GPU_DECL bool operator <(const float &u) const {
+    bool operator <(const float &u) const {
       return ((data.value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const float &u) const {
+    bool operator >=(const float &u) const {
       return ((data.value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const float &u) const {
+    bool operator <=(const float &u) const {
       return ((data.value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const double &u) const {
+    bool operator ==(const double &u) const {
       return ((data.value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const double &u) const {
+    bool operator !=(const double &u) const {
       return ((data.value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const double &u) const {
+    bool operator  >(const double &u) const {
       return ((data.value>u)?true:false);
     }
-    GPU_DECL bool operator <(const double &u) const {
+    bool operator <(const double &u) const {
       return ((data.value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const double &u) const {
+    bool operator >=(const double &u) const {
       return ((data.value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const double &u) const {
+    bool operator <=(const double &u) const {
       return ((data.value<=u)?true:false);
     }
-    GPU_DECL bool operator ==(const long double &u) const {
+    bool operator ==(const long double &u) const {
       return ((data.value==u)?true:false);
     }
-    GPU_DECL bool operator !=(const long double &u) const {
+    bool operator !=(const long double &u) const {
       return ((data.value!=u)?true:false);
     }
-    GPU_DECL bool operator  >(const long double &u) const {
+    bool operator  >(const long double &u) const {
       return ((data.value>u)?true:false);
     }
-    GPU_DECL bool operator <(const long double &u) const {
+    bool operator <(const long double &u) const {
       return ((data.value<u)?true:false);
     }
-    GPU_DECL bool operator >=(const long double &u) const {
+    bool operator >=(const long double &u) const {
       return ((data.value>=u)?true:false);
     }
-    GPU_DECL bool operator <=(const long double &u) const {
+    bool operator <=(const long double &u) const {
       return ((data.value<=u)?true:false);
     }
 
@@ -2391,14 +2390,14 @@ namespace Loci {
     return stream;
   }
 
-  inline GPU_DECL double ceil(const VFAD u) {
+  inline double ceil(const VFAD u) {
     return std::ceil(u.data.value) ;
   }
-  inline GPU_DECL double floor(const VFAD u) {
+  inline double floor(const VFAD u) {
     return std::floor(u.data.value) ;
   }
 
-  inline GPU_DECL VFAD erf(const VFAD u) {
+  inline VFAD erf(const VFAD u) {
     double ef = ::erf(u.data.value) ;
     double efp = (2./sqrt(M_PI))*std::exp(-u.data.value*u.data.value) ;
     VFAD tmp ;
@@ -2407,7 +2406,7 @@ namespace Loci {
       tmp.data.grad[i] = u.data.grad[i]*efp ;
     return tmp ;
   }
-  inline GPU_DECL VFAD sin(const VFAD u) {
+  inline VFAD sin(const VFAD u) {
     double su = std::sin(u.data.value) ;
     double cu = std::cos(u.data.value) ;
     VFAD tmp ;
@@ -2416,7 +2415,7 @@ namespace Loci {
       tmp.data.grad[i] = u.data.grad[i]*cu ;
     return tmp ;
   }
-  inline GPU_DECL VFAD cos(const VFAD u) {
+  inline VFAD cos(const VFAD u) {
     double su = std::sin(u.data.value) ;
     double cu = std::cos(u.data.value) ;
     VFAD tmp ;
@@ -2425,7 +2424,7 @@ namespace Loci {
       tmp.data.grad[i] = -u.data.grad[i]*su ;
     return tmp ;
   }
-  inline GPU_DECL VFAD tan(const VFAD u) {
+  inline VFAD tan(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::tan(u.data.value) ;
     double cu = std::cos(u.data.value) ;
@@ -2435,7 +2434,7 @@ namespace Loci {
     return tmp ;
   }
 
-  inline GPU_DECL VFAD exp(const VFAD u) {
+  inline VFAD exp(const VFAD u) {
     double expu = std::exp(u.data.value) ;
     VFAD tmp ;
     tmp.data.value = expu ;
@@ -2443,7 +2442,7 @@ namespace Loci {
       tmp.data.grad[i] = expu*u.data.grad[i] ;
     return tmp ;
   }
-  inline GPU_DECL VFAD log(const VFAD u) {
+  inline VFAD log(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::log(u.data.value) ;
     double rvalue = 1./u.data.value ;
@@ -2451,7 +2450,7 @@ namespace Loci {
       tmp.data.grad[i] =  u.data.grad[i]*rvalue ;
     return tmp ;
   }
-  inline GPU_DECL VFAD log10(const VFAD u) {
+  inline VFAD log10(const VFAD u) {
     VFAD tmp ;
     const double logof10 = std::log(10.0);
     tmp.data.value = std::log(u.data.value)/logof10 ;
@@ -2461,18 +2460,18 @@ namespace Loci {
     return tmp ;
     //    return VFAD(std::log(u.data.value), u.data.grad/u.data.value)/std::log(10.0);
   }
-  inline GPU_DECL VFAD abs(const VFAD u) {
+  inline VFAD abs(const VFAD u) {
     VFAD tmp(u) ;
     tmp *= (u.data.value<0.0)?-1.0:1.0 ;
     return tmp ;
   }
-  inline GPU_DECL VFAD fabs(const VFAD u) {
+  inline VFAD fabs(const VFAD u) {
     VFAD tmp(u) ;
     tmp *= (u.data.value<0.0)?-1.0:1.0 ;
     return tmp ;
   }
   /* MPGCOMMENT [05-12-2017 15:04] ---> POW */
-  inline GPU_DECL VFAD pow(const VFAD u, const int k) {
+  inline VFAD pow(const VFAD u, const int k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2481,7 +2480,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline GPU_DECL VFAD pow(const VFAD u, const float k) {
+  inline VFAD pow(const VFAD u, const float k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2490,7 +2489,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline GPU_DECL VFAD pow(const VFAD u, const double k) {
+  inline VFAD pow(const VFAD u, const double k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2499,7 +2498,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline GPU_DECL VFAD pow(const VFAD u, const long double k) {
+  inline VFAD pow(const VFAD u, const long double k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2508,7 +2507,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline GPU_DECL VFAD sqrt(const VFAD u) {
+  inline VFAD sqrt(const VFAD u) {
     double su = std::sqrt(u.data.value) ;
     VFAD tmp ;
     tmp.data.value = su ;
@@ -2516,7 +2515,7 @@ namespace Loci {
       tmp.data.grad[i] = 0.5*u.data.grad[i]/max(su,1e-30) ;
     return tmp ;
   }
-  inline GPU_DECL VFAD pow(const VFAD k, const VFAD u) {
+  inline VFAD pow(const VFAD k, const VFAD u) {
     double kpu = std::pow(k.data.value,u.data.value) ;
     double kpum1 = std::pow(k.data.value,u.data.value-1.) ;
     double logk = std::log(k.data.value) ;
@@ -2529,7 +2528,7 @@ namespace Loci {
     //    return VFAD(kpu,std::pow(k.data.value,u.data.value-1.)*k.grad*u.data.value +
     //                kpu*std::log(k.data.value)*u.grad) ;
   }
-  inline GPU_DECL VFAD pow(const int k, const VFAD u) {
+  inline VFAD pow(const int k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2540,7 +2539,7 @@ namespace Loci {
     //    double kpu = std::pow(k,u.data.value) ;
     //    return VFAD(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline GPU_DECL VFAD pow(const float k, const VFAD u) {
+  inline VFAD pow(const float k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2551,7 +2550,7 @@ namespace Loci {
     //    double kpu = std::pow(double(k),u.data.value) ;
     //    return VFAD(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline GPU_DECL VFAD pow(const double k, const VFAD u) {
+  inline VFAD pow(const double k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2562,7 +2561,7 @@ namespace Loci {
     //    double kpu = std::pow(k,u.data.value) ;
     //    return VFAD(kpu,kpu*std::log(k)*u.grad) ;
   }
-  inline GPU_DECL VFAD pow(const long double k, const VFAD u) {
+  inline VFAD pow(const long double k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2575,7 +2574,7 @@ namespace Loci {
   }
 
 
-  inline GPU_DECL VFAD sinh(const VFAD u) {
+  inline VFAD sinh(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::sinh(u.data.value) ;
     double expu = std::exp(u.data.value) ;
@@ -2586,7 +2585,7 @@ namespace Loci {
     //    return VFAD(std::sinh(u.data.value),
     //                0.5*u.grad*(std::exp(u.data.value) + std::exp(-u.data.value))) ;
   }
-  inline GPU_DECL VFAD cosh(const VFAD u) {
+  inline VFAD cosh(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::cosh(u.data.value) ;
     double expu = std::exp(u.data.value) ;
@@ -2597,7 +2596,7 @@ namespace Loci {
     //    return VFAD(std::cosh(u.data.value),
     //                0.5*u.grad*(std::exp(u.data.value) - std::exp(-u.data.value))) ;
   }
-  inline GPU_DECL VFAD tanh(const VFAD u) {
+  inline VFAD tanh(const VFAD u) {
     double ex = std::exp(std::min(u.data.value,350.0)) ;
     double exm = std::exp(std::min(-u.data.value,350.0)) ;
     double dex = ex-exm ;
@@ -2612,7 +2611,7 @@ namespace Loci {
     //                u.grad*(1.-dex*dex/(sex*sex))) ;
   }
 
-  inline GPU_DECL VFAD asin(const VFAD u) {
+  inline VFAD asin(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::asin(u.data.value) ;
     double factor = 1./std::sqrt(1.0-u.data.value*u.data.value) ;
@@ -2621,7 +2620,7 @@ namespace Loci {
     return tmp ;
     //    return VFAD(std::asin(u.data.value), u.grad/std::sqrt(1.0-u.data.value*u.data.value) );
   }
-  inline GPU_DECL VFAD acos(const VFAD u) {
+  inline VFAD acos(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::acos(u.data.value) ;
     double factor = -1./std::sqrt(1.0-u.data.value*u.data.value) ;
@@ -2630,7 +2629,7 @@ namespace Loci {
     return tmp ;
     //return VFAD(std::acos(u.data.value), -u.grad/std::sqrt(1.0-u.data.value*u.data.value) );
   }
-  inline GPU_DECL VFAD atan(const VFAD u) {
+  inline VFAD atan(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::atan(u.data.value) ;
     double factor = 1./(1.0+u.data.value*u.data.value) ;
@@ -2640,11 +2639,11 @@ namespace Loci {
     //    return VFAD(std::atan(u.data.value), u.grad/(1.0+u.data.value*u.data.value) );
   }
   // This will not work in general
-  inline GPU_DECL VFAD atan2(const VFAD u, const VFAD v) {
+  inline VFAD atan2(const VFAD u, const VFAD v) {
     return atan(u/v);
   }
 
-  inline GPU_DECL VFAD asinh(const VFAD u) {
+  inline VFAD asinh(const VFAD u) {
     double strm = std::sqrt(u.data.value*u.data.value+1.) ;
     double uvstrm = u.data.value+strm ;
     VFAD tmp ;
@@ -2655,7 +2654,7 @@ namespace Loci {
     return tmp ;
   //return VFAD(::asinh(u.data.value), u.grad*(u.data.value/strm+1.)/uvstrm) ;
   }
-  inline GPU_DECL VFAD acosh(const VFAD u) {
+  inline VFAD acosh(const VFAD u) {
     double strm = std::sqrt(u.data.value*u.data.value-1.) ;
     double uvstrm = u.data.value+strm ;
     VFAD tmp ;
@@ -2666,7 +2665,7 @@ namespace Loci {
     return tmp ;
     //    return VFAD(::acosh(u.data.value), u.grad*(u.data.value/strm +1.)/uvstrm) ;
   }
-  inline GPU_DECL VFAD atanh(const VFAD u) {
+  inline VFAD atanh(const VFAD u) {
     const double uv = u.data.value ;
     VFAD tmp ;
     tmp.data.value = ::atanh(uv) ;
@@ -2677,31 +2676,31 @@ namespace Loci {
   //    return VFAD(::atanh(uv), .5*u.grad*(1./(1.+uv)+1./(1.-uv))) ;
   }
 
-  inline GPU_DECL VFAD operator +(const double u,const VFAD v)
+  inline VFAD operator +(const double u,const VFAD v)
   { return VFAD(u) + v ; }
-  inline GPU_DECL VFAD operator -(const double u,const VFAD v)
+  inline VFAD operator -(const double u,const VFAD v)
   { return VFAD(u) - v ; }
-  inline GPU_DECL VFAD operator *(const double u,const VFAD v)
+  inline VFAD operator *(const double u,const VFAD v)
   { return VFAD(u)*v ; }
-  inline GPU_DECL VFAD operator /(const double &u,const VFAD &v)
+  inline VFAD operator /(const double &u,const VFAD &v)
   { return VFAD(u)/v ; }
 
   
   //----------------helpers
-  inline GPU_DECL float realToFloat(double v) { return float(v) ; }
-  inline GPU_DECL double realToDouble(double v) { return v ; }
+  inline float realToFloat(double v) { return float(v) ; }
+  inline double realToDouble(double v) { return v ; }
 
-  inline GPU_DECL float realToFloat(const FADd &v) { return float(v.value) ; }
-  inline GPU_DECL double realToDouble(const FADd &v) { return v.value ; }
+  inline float realToFloat(const FADd &v) { return float(v.value) ; }
+  inline double realToDouble(const FADd &v) { return v.value ; }
 
-  inline GPU_DECL float realToFloat(const FAD2d &v) { return float(v.value) ; }
-  inline GPU_DECL double realToDouble(const FAD2d &v) { return v.value ; }
+  inline float realToFloat(const FAD2d &v) { return float(v.value) ; }
+  inline double realToDouble(const FAD2d &v) { return v.value ; }
 
-  inline GPU_DECL float realToFloat(const MFADd &v) { return float(v.value) ; }
-  inline GPU_DECL double realToDouble(const MFADd &v) { return v.value ; }
+  inline float realToFloat(const MFADd &v) { return float(v.value) ; }
+  inline double realToDouble(const MFADd &v) { return v.value ; }
 
-  inline GPU_DECL float realToFloat(const VFAD &v) { return float(v.data.value) ; }
-  inline GPU_DECL double realToDouble(const VFAD &v) { return v.data.value ; }
+  inline float realToFloat(const VFAD &v) { return float(v.data.value) ; }
+  inline double realToDouble(const VFAD &v) { return v.data.value ; }
 
 }
 

--- a/src/include/Tools/autodiff.h
+++ b/src/include/Tools/autodiff.h
@@ -27,6 +27,7 @@
 #include <array>
 #include <math.h>
 #include <Tools/vtypes.h>
+#include <Tools/gpu_attr.h>
 
 namespace Loci {
 
@@ -42,82 +43,82 @@ namespace Loci {
 #ifdef TO_BE_DEPRECATED
     /* MPGCOMMENT [05-12-2017 13:49] ---> constructor */
     template< class T1>
-    FAD2d(T1 a0): value(a0), grad(0.0),grad2(0.0) { }
+    GPU_DECL FAD2d(T1 a0): value(a0), grad(0.0),grad2(0.0) { }
 #endif
-    FAD2d(double a0, double b0, double c0): value(a0), grad(b0), grad2(c0) { }
-    FAD2d(const FAD2d &u) : value(u.value), grad(u.grad), grad2(u.grad2) { }
+    GPU_DECL FAD2d(double a0, double b0, double c0): value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(const FAD2d &u) : value(u.value), grad(u.grad), grad2(u.grad2) { }
 
     FAD2d() = default ;
     // --------------------------------------------------------------------
     // REH ADDED BELOW - 20220202 - Missing code from initial 2017 dev mods
     // --------------------------------------------------------------------
-    FAD2d(int a0         ,int b0)        : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(int a0         ,float b0)        : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(int a0         ,double b0)        : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(int a0         ,long double b0)        : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(float a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(float a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(float a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(float a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(long double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(long double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(long double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
-    FAD2d(long double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(int a0         ,int b0)        : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(int a0         ,float b0)        : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(int a0         ,double b0)        : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(int a0         ,long double b0)        : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(float a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(float a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(float a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(float a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(long double a0      ,int b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(long double a0      ,float b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(long double a0      ,double b0)       : value(a0), grad(b0), grad2(0.0) { }
+    GPU_DECL FAD2d(long double a0      ,long double b0)       : value(a0), grad(b0), grad2(0.0) { }
 
-    FAD2d(double a0      ,int b0        , int c0)       : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,int b0        , float c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,int b0        , double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,int b0        , long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,float b0      , int c0)       : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,float b0      , float c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,float b0      , double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,float b0      , long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,double b0     , int c0)       : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,double b0     , float c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,int b0        , int c0)       : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,int b0        , float c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,int b0        , double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,int b0        , long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,float b0      , int c0)       : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,float b0      , float c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,float b0      , double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,float b0      , long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,double b0     , int c0)       : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,double b0     , float c0)     : value(a0), grad(b0), grad2(c0) { }
     //FAD2d(double a0      ,double b0     , double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,double b0     , long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,long double b0, int c0)       : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,long double b0, float c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,long double b0, double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(double a0      ,long double b0, long double c0)     : value(a0), grad(b0), grad2(c0) { }
-    FAD2d(bool &u)        : value((u)?1.0:0.0), grad(0.0), grad2(0.0) { }
+    GPU_DECL FAD2d(double a0      ,double b0     , long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,long double b0, int c0)       : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,long double b0, float c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,long double b0, double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(double a0      ,long double b0, long double c0)     : value(a0), grad(b0), grad2(c0) { }
+    GPU_DECL FAD2d(bool &u)        : value((u)?1.0:0.0), grad(0.0), grad2(0.0) { }
     //FAD2d(const FAD2d &u) : value(u.value), grad(u.grad), grad2(u.grad2) { }
-    FAD2d(int a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    FAD2d(size_t a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    FAD2d(float a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    FAD2d(double a0)        : value(a0), grad(0.0), grad2(0.0) { }
-    FAD2d(long double a0)        : value(a0), grad(0.0), grad2(0.0) {  }
+    GPU_DECL FAD2d(int a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    GPU_DECL FAD2d(size_t a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    GPU_DECL FAD2d(float a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    GPU_DECL FAD2d(double a0)        : value(a0), grad(0.0), grad2(0.0) { }
+    GPU_DECL FAD2d(long double a0)        : value(a0), grad(0.0), grad2(0.0) {  }
     // --------------------------------------------------------------------
-    void setValue(double val) { value = val ; }
-    FAD2d& operator =(const FAD2d &u) {
+    GPU_DECL void setValue(double val) { value = val ; }
+    GPU_DECL FAD2d& operator =(const FAD2d &u) {
       value = u.value;
       grad = u.grad;
       grad2 = u.grad2 ;
       return *this;
     }
-    FAD2d& operator =(const int &u) {
+    GPU_DECL FAD2d& operator =(const int &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0 ;
       return *this;
     }
-    FAD2d& operator =(const float &u) {
+    GPU_DECL FAD2d& operator =(const float &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0;
       return *this;
     }
-    FAD2d& operator =(const double &u) {
+    GPU_DECL FAD2d& operator =(const double &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0;
       return *this;
     }
-    FAD2d& operator =(const long double &u) {
+    GPU_DECL FAD2d& operator =(const long double &u) {
       value = u;
       grad = 0.0;
       grad2 = 0.0;
@@ -125,142 +126,142 @@ namespace Loci {
     }
 
 
-    FAD2d operator +(const FAD2d &v) const{
+    GPU_DECL FAD2d operator +(const FAD2d &v) const{
       return FAD2d(value+v.value, grad+v.grad, grad2+v.grad2);
     }
-    FAD2d operator +() const{
+    GPU_DECL FAD2d operator +() const{
       return FAD2d(value, grad, grad2);
     }
-    FAD2d operator +(const int &v) const{
+    GPU_DECL FAD2d operator +(const int &v) const{
       return FAD2d(value+(double)v, grad, grad2);
     }
-    FAD2d operator +(const float &v) const{
+    GPU_DECL FAD2d operator +(const float &v) const{
       return FAD2d(value+(double)v, grad, grad2);
     }
-    FAD2d operator +(const double &v) const{
+    GPU_DECL FAD2d operator +(const double &v) const{
       return FAD2d(value+(double)v, grad, grad2);
     }
-    FAD2d operator +(const long double &v) const{
+    GPU_DECL FAD2d operator +(const long double &v) const{
       return FAD2d(double(value+v), grad, grad2);
     }
 
-    FAD2d& operator +=(const FAD2d &u) {
+    GPU_DECL FAD2d& operator +=(const FAD2d &u) {
       value+=u.value;
       grad+=u.grad;
       grad2+=u.grad2 ;
       return *this;
     }
-    FAD2d& operator +=(const int &u) {
+    GPU_DECL FAD2d& operator +=(const int &u) {
       value+=u;
       return *this;
     }
-    FAD2d& operator +=(const float &u) {
+    GPU_DECL FAD2d& operator +=(const float &u) {
       value+=u;
       return *this;
     }
-    FAD2d& operator +=(const double &u) {
+    GPU_DECL FAD2d& operator +=(const double &u) {
       value+=u;
       return *this;
     }
-    FAD2d& operator +=(const long double &u) {
+    GPU_DECL FAD2d& operator +=(const long double &u) {
       value+=u;
       return *this;
     }
 
-    FAD2d operator -(const FAD2d &v) const{
+    GPU_DECL FAD2d operator -(const FAD2d &v) const{
       return FAD2d(value-v.value, grad-v.grad,grad2-v.grad2);
     }
-    FAD2d operator -() const {
+    GPU_DECL FAD2d operator -() const {
       return FAD2d(-value, -grad, -grad2);
     }
-    FAD2d operator -(const int &v) const{
+    GPU_DECL FAD2d operator -(const int &v) const{
       return FAD2d(value-(double)v, grad, grad2);
     }
-    FAD2d operator -(const float &v) const{
+    GPU_DECL FAD2d operator -(const float &v) const{
       return FAD2d(value-(double)v, grad, grad2);
     }
-    FAD2d operator -(const double &v) const{
+    GPU_DECL FAD2d operator -(const double &v) const{
       return FAD2d(value-(double)v, grad, grad2);
     }
-    FAD2d operator -(const long double &v) const{
+    GPU_DECL FAD2d operator -(const long double &v) const{
       return FAD2d(double(value-v), grad, grad2);
     }
 
-    FAD2d& operator -=(const FAD2d &u) {
+    GPU_DECL FAD2d& operator -=(const FAD2d &u) {
       value-=u.value;
       grad-=u.grad;
       grad2 -= u.grad2 ;
       return *this;
     }
-    FAD2d& operator -=(const int &u) {
+    GPU_DECL FAD2d& operator -=(const int &u) {
       value-=u;
       return *this;
     }
-    FAD2d& operator -=(const float &u) {
+    GPU_DECL FAD2d& operator -=(const float &u) {
       value-=u;
       return *this;
     }
-    FAD2d& operator -=(const double &u) {
+    GPU_DECL FAD2d& operator -=(const double &u) {
       value-=u;
       return *this;
     }
-    FAD2d& operator -=(const long double &u) {
+    GPU_DECL FAD2d& operator -=(const long double &u) {
       value-=u;
       return *this;
     }
 
-    FAD2d operator *(const FAD2d &v) const {
+    GPU_DECL FAD2d operator *(const FAD2d &v) const {
       return FAD2d(value*v.value,  grad*v.value + v.grad*value,
                    grad2*v.value + value*v.grad2 + 2.*grad*v.grad);
     }
-    FAD2d operator *(const int &v) const{
+    GPU_DECL FAD2d operator *(const int &v) const{
       return FAD2d(value*(double)v,  grad*(double)v, grad2*(double) v);
     }
-    FAD2d operator *(const float &v) const{
+    GPU_DECL FAD2d operator *(const float &v) const{
       return FAD2d(value*(double)v,  grad*(double)v, grad2*(double) v);
     }
-    FAD2d operator *(const double &v) const{
+    GPU_DECL FAD2d operator *(const double &v) const{
       return FAD2d(value*(double)v,  grad*(double)v, grad2*(double) v);
     }
-    FAD2d operator *(const long double &v) const{
+    GPU_DECL FAD2d operator *(const long double &v) const{
       return FAD2d(double(value*v),  double(grad*v), double(grad2*v));
     }
     //    template<class T> FAD2d& operator *=(const T &u) {
     //      value*=(double)u;
     //      return *this;
     //    }
-    FAD2d& operator *=(const FAD2d &u) {
+    GPU_DECL FAD2d& operator *=(const FAD2d &u) {
       grad2 = grad2*u.value + value*u.grad2 + 2.*grad*u.grad ;
       grad = grad*u.value + u.grad * value;
       value*=u.value;
       return *this;
     }
-    FAD2d& operator *=(const int &u) {
+    GPU_DECL FAD2d& operator *=(const int &u) {
       value*=u;
       grad *=u;
       grad2 *= u ;
       return *this;
     }
-    FAD2d& operator *=(const float &u) {
+    GPU_DECL FAD2d& operator *=(const float &u) {
       value*=u;
       grad *=u;
       grad2 *= u;
       return *this;
     }
-    FAD2d& operator *=(const double &u) {
+    GPU_DECL FAD2d& operator *=(const double &u) {
       value*=u;
       grad *=u;
       grad2 *= u ;
       return *this;
     }
-    FAD2d& operator *=(const long double &u) {
+    GPU_DECL FAD2d& operator *=(const long double &u) {
       value*=u;
       grad *=u;
       grad2 *= u;
       return *this;
     }
 
-    FAD2d operator /(const FAD2d &v) const{
+    GPU_DECL FAD2d operator /(const FAD2d &v) const{
       double d = v.value ;
       double d2 = d*d ;
       double d3 = d*d2 ;
@@ -270,20 +271,20 @@ namespace Loci {
                    2.*v.grad*v.grad*value/d3 -
                    (v.grad*grad+v.grad2*value)/d2) ;
     }
-    FAD2d operator /(const int &v) const{
+    GPU_DECL FAD2d operator /(const int &v) const{
       return FAD2d(value/v, (grad/(double)v), (grad2/double(v)));
     }
-    FAD2d operator /(const float &v) const{
+    GPU_DECL FAD2d operator /(const float &v) const{
       return FAD2d(value/v, (grad/(double)v), (grad2/double(v)));
     }
-    FAD2d operator /(const double &v) const{
+    GPU_DECL FAD2d operator /(const double &v) const{
       return FAD2d(value/v, (grad/(double)v), (grad2/double(v)));
     }
-    FAD2d operator /(const long double &v) const{
+    GPU_DECL FAD2d operator /(const long double &v) const{
       return FAD2d(double(value/v), double(grad/v), double(grad2/v));
     }
 
-    FAD2d& operator /=(const FAD2d &u) {
+    GPU_DECL FAD2d& operator /=(const FAD2d &u) {
       double d = u.value ;
       double d2 = d*d ;
       double d3 = d*d2 ;
@@ -293,25 +294,25 @@ namespace Loci {
       value/=u.value;
       return *this;
     }
-    FAD2d& operator /=(const int &u) {
+    GPU_DECL FAD2d& operator /=(const int &u) {
       value/=u;
       grad /=u;
       grad2 /= u ;
       return *this;
     }
-    FAD2d& operator /=(const float &u) {
+    GPU_DECL FAD2d& operator /=(const float &u) {
       value/=u;
       grad /=u;
       grad2 /=u ;
       return *this;
     }
-    FAD2d& operator /=(const double &u) {
+    GPU_DECL FAD2d& operator /=(const double &u) {
       value/=u;
       grad /=u;
       grad2 /= u ;
       return *this;
     }
-    FAD2d& operator /=(const long double &u) {
+    GPU_DECL FAD2d& operator /=(const long double &u) {
       value/=u;
       grad /=u;
       grad2 /= u ;
@@ -319,94 +320,94 @@ namespace Loci {
     }
 
 
-    bool operator ==(const FAD2d &u)const  {
+    GPU_DECL bool operator ==(const FAD2d &u)const  {
       return ((value==u.value)?true:false);
     }
-    bool operator !=(const FAD2d &u) const {
+    GPU_DECL bool operator !=(const FAD2d &u) const {
       return ((value!=u.value)?true:false);
     }
-    bool operator >(const FAD2d &u) const {
+    GPU_DECL bool operator >(const FAD2d &u) const {
       return ((value>u.value)?true:false);
     }
-    bool operator <(const FAD2d &u) const {
+    GPU_DECL bool operator <(const FAD2d &u) const {
       return ((value<u.value)?true:false);
     }
-    bool operator >=(const FAD2d &u) const {
+    GPU_DECL bool operator >=(const FAD2d &u) const {
       return ((value>=u.value)?true:false);
     }
-    bool operator <=(const FAD2d &u) const {
+    GPU_DECL bool operator <=(const FAD2d &u) const {
       return ((value<=u.value)?true:false);
     }
-    bool operator ==(const int &u) const {
+    GPU_DECL bool operator ==(const int &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const int &u) const {
+    GPU_DECL bool operator !=(const int &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator >(const int &u) const {
+    GPU_DECL bool operator >(const int &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const int &u) const {
+    GPU_DECL bool operator <(const int &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const int &u) const {
+    GPU_DECL bool operator >=(const int &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const int &u) const {
+    GPU_DECL bool operator <=(const int &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const float &u) const {
+    GPU_DECL bool operator ==(const float &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const float &u) const {
+    GPU_DECL bool operator !=(const float &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator >(const float &u) const {
+    GPU_DECL bool operator >(const float &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const float &u) const {
+    GPU_DECL bool operator <(const float &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const float &u) const {
+    GPU_DECL bool operator >=(const float &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const float &u) const {
+    GPU_DECL bool operator <=(const float &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const double &u) const {
+    GPU_DECL bool operator ==(const double &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const double &u) const {
+    GPU_DECL bool operator !=(const double &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator  >(const double &u) const {
+    GPU_DECL bool operator  >(const double &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const double &u) const {
+    GPU_DECL bool operator <(const double &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const double &u) const {
+    GPU_DECL bool operator >=(const double &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const double &u) const {
+    GPU_DECL bool operator <=(const double &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const long double &u) const {
+    GPU_DECL bool operator ==(const long double &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const long double &u) const {
+    GPU_DECL bool operator !=(const long double &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator  >(const long double &u) const {
+    GPU_DECL bool operator  >(const long double &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const long double &u) const {
+    GPU_DECL bool operator <(const long double &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const long double &u) const {
+    GPU_DECL bool operator >=(const long double &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const long double &u) const {
+    GPU_DECL bool operator <=(const long double &u) const {
       return ((value<=u)?true:false);
     }
 
@@ -437,30 +438,30 @@ namespace Loci {
     return stream;
   }
 
-  inline double ceil(const FAD2d u) {
+  inline GPU_DECL double ceil(const FAD2d u) {
     return std::ceil(u.value) ;
   }
-  inline double floor(const FAD2d u) {
+  inline GPU_DECL double floor(const FAD2d u) {
     return std::floor(u.value) ;
   }
 
-  inline FAD2d erf(const FAD2d u) {
+  inline GPU_DECL FAD2d erf(const FAD2d u) {
     double ef = ::erf(u.value) ;
     double efp = (2./sqrt(M_PI))*std::exp(-u.value*u.value) ;
     double efpp = -2.*u.value*efp ;
     return FAD2d(ef,u.grad*efp,u.grad*u.grad*efpp+efp*u.grad2) ;
   }
-  inline FAD2d sin(const FAD2d u) {
+  inline GPU_DECL FAD2d sin(const FAD2d u) {
     double su = std::sin(u.value) ;
     double cu = std::cos(u.value) ;
     return FAD2d(su, u.grad*cu, cu*u.grad2 - u.grad*u.grad*su);
   }
-  inline FAD2d cos(const FAD2d u) {
+  inline GPU_DECL FAD2d cos(const FAD2d u) {
     double su = std::sin(u.value) ;
     double cu = std::cos(u.value) ;
     return FAD2d(cu, -u.grad*su, -su*u.grad2 - u.grad*u.grad*cu);
   }
-  inline FAD2d tan(const FAD2d u) {
+  inline GPU_DECL FAD2d tan(const FAD2d u) {
     double tanu = std::tan(u.value) ;
     double secu = 1./std::cos(u.value) ;
     double secu2 = secu*secu ;
@@ -468,58 +469,58 @@ namespace Loci {
                  u.grad2*secu2+2.*u.grad*u.grad*secu2*tanu) ;
   }
 
-  inline FAD2d exp(const FAD2d u) {
+  inline GPU_DECL FAD2d exp(const FAD2d u) {
     double eu = std::exp(u.value) ;
     return FAD2d(eu, u.grad*eu, eu*u.grad2+u.grad*u.grad*eu);
   }
-  inline FAD2d log(const FAD2d u) {
+  inline GPU_DECL FAD2d log(const FAD2d u) {
     return FAD2d(std::log(u.value), u.grad/u.value,
                  u.grad2/u.value - u.grad*u.grad/(u.value*u.value));
   }
-  inline FAD2d log10(const FAD2d u) {
+  inline GPU_DECL FAD2d log10(const FAD2d u) {
     return FAD2d(std::log(u.value), u.grad/u.value,
                  u.grad2/u.value - u.grad*u.grad/(u.value*u.value))/std::log(10.0);
   }
 
-  inline FAD2d fabs(FAD2d u) {
+  inline GPU_DECL FAD2d fabs(FAD2d u) {
     return FAD2d(std::fabs(u.value),
                  u.grad*( (u.value<0.0)?-1.0:1.0 ),
                  u.grad2*( (u.value<0.0)?-1.0:1.0 )) ;
   }
-  inline FAD2d abs(FAD2d u) {
+  inline GPU_DECL FAD2d abs(FAD2d u) {
     return FAD2d(std::fabs(u.value),
                  u.grad*( (u.value<0.0)?-1.0:1.0 ),
                  u.grad2*( (u.value<0.0)?-1.0:1.0 )) ;
   }
   /* MPGCOMMENT [05-12-2017 15:04] ---> POW */
-  inline FAD2d pow(const FAD2d u, const int k) {
+  inline GPU_DECL FAD2d pow(const FAD2d u, const int k) {
     return FAD2d(std::pow(u.value, k),
                  (double)k * std::pow(u.value, k-1)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k - 2)*std::pow(u.grad, 2)) + std::pow(u.value, k - 1)*u.grad2)) ;
   }
-  inline FAD2d pow(const FAD2d u, const float k) {
+  inline GPU_DECL FAD2d pow(const FAD2d u, const float k) {
     return FAD2d(std::pow(u.value, double(k)),
                  (double)k * std::pow(u.value, k-1.0)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k-2.0)*std::pow(u.grad, 2)) + std::pow(u.value, k-1.0)*u.grad2)) ;
   }
-  inline FAD2d pow(const FAD2d u, const double k) {
+  inline GPU_DECL FAD2d pow(const FAD2d u, const double k) {
     return FAD2d(std::pow(u.value, k),
                  (double)k * std::pow(u.value, k-1.0)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k-2.0)*std::pow(u.grad, 2)) + std::pow(u.value, k - 1)*u.grad2)) ;
   }
-  inline FAD2d pow(const FAD2d u, const long double ki) {
+  inline GPU_DECL FAD2d pow(const FAD2d u, const long double ki) {
     double k = double(ki) ;
     return FAD2d(std::pow(u.value, k),
                  (double)k * std::pow(u.value, k-1.0)*u.grad,
                  k*((k - 1)*(std::pow(u.value, k - 2)*std::pow(u.grad, 2)) + std::pow(u.value, k - 1)*u.grad2)) ;
   }
-  inline FAD2d sqrt(const FAD2d u) {
+  inline GPU_DECL FAD2d sqrt(const FAD2d u) {
 
     double su = std::sqrt(u.value) ;
     return FAD2d(su,0.5*u.grad/std::max(su,1e-30),
                  0.5*u.grad2/(std::max(su,1e-30)) - 0.25*u.grad*u.grad/(std::max(su*su*su,1e-30))) ;
   }
-  inline FAD2d pow(const FAD2d k, const FAD2d u) {
+  inline GPU_DECL FAD2d pow(const FAD2d k, const FAD2d u) {
     double kpu = std::pow(k.value,u.value) ;
     double kpu1 = std::pow(k.value,u.value-1.) ;
     double kpu2 = std::pow(k.value,u.value-2.) ;
@@ -532,25 +533,25 @@ namespace Loci {
                               kpu*(lxu*u.grad)) + kpu*u.grad2)) ;
 
   }
-  inline FAD2d pow(const int k, const FAD2d u) {
+  inline GPU_DECL FAD2d pow(const int k, const FAD2d u) {
     double kpu = std::pow(k,u.value) ;
     double lnk = std::log(double(k)) ;
     return FAD2d(kpu,kpu*lnk*u.grad,
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
-  inline FAD2d pow(const float k, const FAD2d u) {
+  inline GPU_DECL FAD2d pow(const float k, const FAD2d u) {
     double kpu = std::pow(double(k),u.value) ;
     double lnk = std::log(double(k)) ;
     return FAD2d(kpu,kpu*lnk*u.grad,
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
-  inline FAD2d pow(const double k, const FAD2d u) {
+  inline GPU_DECL FAD2d pow(const double k, const FAD2d u) {
     double kpu = std::pow(k,u.value) ;
     double lnk = std::log(double(k)) ;
     return FAD2d(kpu,kpu*lnk*u.grad,
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
-  inline FAD2d pow(const long double ki, const FAD2d u) {
+  inline GPU_DECL FAD2d pow(const long double ki, const FAD2d u) {
     double k = double(ki) ;
     double kpu = std::pow(k,u.value) ;
     double lnk = std::log(double(k)) ;
@@ -558,14 +559,14 @@ namespace Loci {
                  kpu*((lnk*lnk)*(u.grad*u.grad)) + kpu*(lnk*u.grad2)) ;
   }
 
-  inline FAD2d sinh(const FAD2d u) {
+  inline GPU_DECL FAD2d sinh(const FAD2d u) {
     double expu = std::exp(u.value) ;
     double expmu = std::exp(-u.value) ;
     return FAD2d(std::sinh(u.value),
                  0.5*u.grad*(expu + expmu),
                  0.5*(expmu*(u.grad2-u.grad*u.grad)+expu*(u.grad2+u.grad*u.grad))) ;
   }
-  inline FAD2d cosh(const FAD2d u) {
+  inline GPU_DECL FAD2d cosh(const FAD2d u) {
     double expu = std::exp(u.value) ;
     double expmu = std::exp(-u.value) ;
     return FAD2d(std::cosh(u.value),
@@ -574,7 +575,7 @@ namespace Loci {
                       expu*(u.grad2+u.grad*u.grad))) ;
   }
 
-  inline FAD2d tanh(const FAD2d u) {
+  inline GPU_DECL FAD2d tanh(const FAD2d u) {
     double ex = std::exp(std::min(u.value,350.0)) ;
     double exm = std::exp(std::min(-u.value,350.0)) ;
     double dex = ex-exm ;
@@ -585,17 +586,17 @@ namespace Loci {
                  u.grad*u.grad*2.*(rex2-1.)*rex+
                  u.grad2*(1.-rex2)) ;
   }
-  inline FAD2d asin(const FAD2d u) {
+  inline GPU_DECL FAD2d asin(const FAD2d u) {
     double rsrt = 1./std::sqrt(1.-u.value*u.value) ;
     return FAD2d(std::asin(u.value), u.grad*rsrt,
                  u.grad2*rsrt + u.grad*u.grad*u.value*rsrt*rsrt*rsrt);
   }
-  inline FAD2d acos(const FAD2d u) {
+  inline GPU_DECL FAD2d acos(const FAD2d u) {
     double rsrt = 1./std::sqrt(1.-u.value*u.value) ;
     return FAD2d(std::acos(u.value), -u.grad*rsrt,
                  -u.grad2*rsrt - u.grad*u.grad*u.value*rsrt*rsrt*rsrt);
   }
-  inline FAD2d atan(const FAD2d u) {
+  inline GPU_DECL FAD2d atan(const FAD2d u) {
     double rval = 1./(1.+u.value*u.value) ;
     return FAD2d(std::atan(u.value), u.grad*rval,
                  u.grad2*rval-2.*u.grad*u.grad*u.value*rval*rval);
@@ -603,11 +604,11 @@ namespace Loci {
   //-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   // This will not work in general
   //-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  inline FAD2d atan2(const FAD2d u, const FAD2d v) {
+  inline GPU_DECL FAD2d atan2(const FAD2d u, const FAD2d v) {
     return atan(u/v);
   }
 
-  inline FAD2d asinh(const FAD2d u) {
+  inline GPU_DECL FAD2d asinh(const FAD2d u) {
     const double uv = u.value ;
     const double uv2 = uv*uv ;
     const double strm = std::sqrt(uv2+1.) ;
@@ -618,7 +619,7 @@ namespace Loci {
                   - std::pow(uv / strm + 1., 2) / uvstrm2)*u.grad*u.grad
                  + u.grad2*(uv / strm + 1.) / uvstrm) ;
   }
-  inline FAD2d acosh(const FAD2d u) {
+  inline GPU_DECL FAD2d acosh(const FAD2d u) {
     const double uv = u.value ;
     const double uv2 = uv*uv ;
     const double strm = std::sqrt(uv*uv-1.) ;
@@ -629,7 +630,7 @@ namespace Loci {
                   - std::pow(uv / strm + 1., 2) / uvstrm2)*u.grad*u.grad
                  + u.grad2*(uv / strm + 1.) / uvstrm) ;
   }
-  inline FAD2d atanh(const FAD2d u) {
+  inline GPU_DECL FAD2d atanh(const FAD2d u) {
     const double uv = u.value ;
     const double uv2 = uv*uv ;
     const double factor = .5*(1./(1.+uv)+1./(1.-uv)) ;
@@ -639,13 +640,13 @@ namespace Loci {
   }
 
 
-  inline FAD2d operator +(const double u,const FAD2d v)
+  inline GPU_DECL FAD2d operator +(const double u,const FAD2d v)
   { return FAD2d(u+v.value, v.grad, v.grad2); }
-  inline FAD2d operator -(const double u,const FAD2d v)
+  inline GPU_DECL FAD2d operator -(const double u,const FAD2d v)
   { return FAD2d(u-v.value, -v.grad, -v.grad2); }
-  inline FAD2d operator *(const double u,const FAD2d v)
+  inline GPU_DECL FAD2d operator *(const double u,const FAD2d v)
   { return FAD2d(u*v.value,  v.grad*u, v.grad2*u ); }
-  inline FAD2d operator /(const double &u,const FAD2d &v)
+  inline GPU_DECL FAD2d operator /(const double &u,const FAD2d &v)
   { return FAD2d(u/v.value, -u*v.grad/v.value/v.value,
                  2.*u*v.grad*v.grad/(v.value*v.value*v.value) -
                  u*v.grad2/(v.value*v.value)); }
@@ -658,56 +659,56 @@ namespace Loci {
     /* MPGCOMMENT [05-12-2017 13:49] ---> constructor */
 #ifdef TO_BE_DEPRECATED
     template< class T1>
-    FADd(T1 a0): value(a0), grad(0.0) { }
+    GPU_DECL FADd(T1 a0): value(a0), grad(0.0) { }
 #endif
-    FADd(int a0         ,int b0)        : value(a0), grad(b0) { }
-    FADd(int a0         ,float b0)        : value(a0), grad(b0) { }
-    FADd(int a0         ,double b0)        : value(a0), grad(b0) { }
-    FADd(int a0         ,long double b0)        : value(a0), grad(b0) { }
-    FADd(float a0      ,int b0)       : value(a0), grad(b0) { }
-    FADd(float a0      ,float b0)       : value(a0), grad(b0) { }
-    FADd(float a0      ,double b0)       : value(a0), grad(b0) { }
-    FADd(float a0      ,long double b0)       : value(a0), grad(b0) { }
-    FADd(double a0      ,int b0)       : value(a0), grad(b0) { }
-    FADd(double a0      ,float b0)       : value(a0), grad(b0) { }
-    FADd(double a0      ,double b0)       : value(a0), grad(b0) { }
-    FADd(double a0      ,long double b0)       : value(a0), grad(b0) { }
-    FADd(long double a0      ,int b0)       : value(a0), grad(b0) { }
-    FADd(long double a0      ,float b0)       : value(a0), grad(b0) { }
-    FADd(long double a0      ,double b0)       : value(a0), grad(b0) { }
-    FADd(long double a0      ,long double b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(int a0         ,int b0)        : value(a0), grad(b0) { }
+    GPU_DECL FADd(int a0         ,float b0)        : value(a0), grad(b0) { }
+    GPU_DECL FADd(int a0         ,double b0)        : value(a0), grad(b0) { }
+    GPU_DECL FADd(int a0         ,long double b0)        : value(a0), grad(b0) { }
+    GPU_DECL FADd(float a0      ,int b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(float a0      ,float b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(float a0      ,double b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(float a0      ,long double b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(double a0      ,int b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(double a0      ,float b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(double a0      ,double b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(double a0      ,long double b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(long double a0      ,int b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(long double a0      ,float b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(long double a0      ,double b0)       : value(a0), grad(b0) { }
+    GPU_DECL FADd(long double a0      ,long double b0)       : value(a0), grad(b0) { }
 
-    FADd(const double u): value(u),grad(0.0) { }
-    FADd(const float u): value(u),grad(0.0) { }
-    FADd(const int u): value(u),grad(0.0) { }
-    FADd(const size_t u): value(u),grad(0.0) { }
+    GPU_DECL FADd(const double u): value(u),grad(0.0) { }
+    GPU_DECL FADd(const float u): value(u),grad(0.0) { }
+    GPU_DECL FADd(const int u): value(u),grad(0.0) { }
+    GPU_DECL FADd(const size_t u): value(u),grad(0.0) { }
     //    FADd(const FADd &u) : value(u.value), grad(u.grad) { }
     FADd(const FADd &u) = default ;
 
     FADd() = default ;
 
-    void setValue(double val) { value = val ; }
-    FADd& operator =(const FADd &u) {
+    GPU_DECL void setValue(double val) { value = val ; }
+    GPU_DECL FADd& operator =(const FADd &u) {
       value = u.value;
       grad = u.grad;
       return *this;
     }
-    FADd& operator =(const int &u) {
+    GPU_DECL FADd& operator =(const int &u) {
       value = u;
       grad = 0.0;
       return *this;
     }
-    FADd& operator =(const float &u) {
+    GPU_DECL FADd& operator =(const float &u) {
       value = u;
       grad = 0.0;
       return *this;
     }
-    FADd& operator =(const double &u) {
+    GPU_DECL FADd& operator =(const double &u) {
       value = u;
       grad = 0.0;
       return *this;
     }
-    FADd& operator =(const long double &u) {
+    GPU_DECL FADd& operator =(const long double &u) {
       value = u;
       grad = 0.0;
       return *this;
@@ -718,46 +719,46 @@ namespace Loci {
     //    template<class T> FADd operator +(const T &v) const{
     //      return FADd(value+(double)v, grad);
     //    }
-    FADd operator +(const FADd &v) const{
+    GPU_DECL FADd operator +(const FADd &v) const{
       return FADd(value+v.value, grad+v.grad);
     }
-    FADd operator +() const{
+    GPU_DECL FADd operator +() const{
       return FADd(value, grad);
     }
-    FADd operator +(const int &v) const{
+    GPU_DECL FADd operator +(const int &v) const{
       return FADd(value+(double)v, grad);
     }
-    FADd operator +(const float &v) const{
+    GPU_DECL FADd operator +(const float &v) const{
       return FADd(value+(double)v, grad);
     }
-    FADd operator +(const double &v) const{
+    GPU_DECL FADd operator +(const double &v) const{
       return FADd(value+(double)v, grad);
     }
-    FADd operator +(const long double &v) const{
+    GPU_DECL FADd operator +(const long double &v) const{
       return FADd(value+(long double)v, grad);
     }
     //    template<class T> FADd& operator +=(const T &u) {
     //      value+=(double)u;
     //      return *this;
     //    }
-    FADd& operator +=(const FADd &u) {
+    GPU_DECL FADd& operator +=(const FADd &u) {
       value+=u.value;
       grad+=u.grad;
       return *this;
     }
-    FADd& operator +=(const int &u) {
+    GPU_DECL FADd& operator +=(const int &u) {
       value+=u;
       return *this;
     }
-    FADd& operator +=(const float &u) {
+    GPU_DECL FADd& operator +=(const float &u) {
       value+=u;
       return *this;
     }
-    FADd& operator +=(const double &u) {
+    GPU_DECL FADd& operator +=(const double &u) {
       value+=u;
       return *this;
     }
-    FADd& operator +=(const long double &u) {
+    GPU_DECL FADd& operator +=(const long double &u) {
       value+=u;
       return *this;
     }
@@ -767,46 +768,46 @@ namespace Loci {
     //    template<class T> FADd operator -(const T &v) const{
     //      return FADd(value-(double)v, grad);
     //    }
-    FADd operator -(const FADd &v) const{
+    GPU_DECL FADd operator -(const FADd &v) const{
       return FADd(value-v.value, grad-v.grad);
     }
-    FADd operator -() const {
+    GPU_DECL FADd operator -() const {
       return FADd(-value, -grad);
     }
-    FADd operator -(const int &v) const{
+    GPU_DECL FADd operator -(const int &v) const{
       return FADd(value-(double)v, grad);
     }
-    FADd operator -(const float &v) const{
+    GPU_DECL FADd operator -(const float &v) const{
       return FADd(value-(double)v, grad);
     }
-    FADd operator -(const double &v) const{
+    GPU_DECL FADd operator -(const double &v) const{
       return FADd(value-(double)v, grad);
     }
-    FADd operator -(const long double &v) const{
+    GPU_DECL FADd operator -(const long double &v) const{
       return FADd(value-(long double)v, grad);
     }
     //    template<class T> FADd& operator -=(const T &u) {
     //      value-=(double)u;
     //      return *this;
     //    }
-    FADd& operator -=(const FADd &u) {
+    GPU_DECL FADd& operator -=(const FADd &u) {
       value-=u.value;
       grad-=u.grad;
       return *this;
     }
-    FADd& operator -=(const int &u) {
+    GPU_DECL FADd& operator -=(const int &u) {
       value-=u;
       return *this;
     }
-    FADd& operator -=(const float &u) {
+    GPU_DECL FADd& operator -=(const float &u) {
       value-=u;
       return *this;
     }
-    FADd& operator -=(const double &u) {
+    GPU_DECL FADd& operator -=(const double &u) {
       value-=u;
       return *this;
     }
-    FADd& operator -=(const long double &u) {
+    GPU_DECL FADd& operator -=(const long double &u) {
       value-=u;
       return *this;
     }
@@ -815,46 +816,46 @@ namespace Loci {
     //    template<class T> FADd operator *(const T &v) const{
     //      return FADd(value*(double)v, grad);
     //    }
-    FADd operator *(const FADd &v) const {
+    GPU_DECL FADd operator *(const FADd &v) const {
       return FADd(value*v.value,  grad*v.value + v.grad*value);
     }
-    FADd operator *(const int &v) const{
+    GPU_DECL FADd operator *(const int &v) const{
       return FADd(value*(double)v,  grad*(double)v);
     }
-    FADd operator *(const float &v) const{
+    GPU_DECL FADd operator *(const float &v) const{
       return FADd(value*(double)v,  grad*(double)v);
     }
-    FADd operator *(const double &v) const{
+    GPU_DECL FADd operator *(const double &v) const{
       return FADd(value*(double)v,  grad*(double)v);
     }
-    FADd operator *(const long double &v) const{
+    GPU_DECL FADd operator *(const long double &v) const{
       return FADd(value*(long double)v,  grad*(long double)v);
     }
     //    template<class T> FADd& operator *=(const T &u) {
     //      value*=(double)u;
     //      return *this;
     //    }
-    FADd& operator *=(const FADd &u) {
+    GPU_DECL FADd& operator *=(const FADd &u) {
       grad = grad*u.value + u.grad * value;
       value*=u.value;
       return *this;
     }
-    FADd& operator *=(const int &u) {
+    GPU_DECL FADd& operator *=(const int &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
     }
-    FADd& operator *=(const float &u) {
+    GPU_DECL FADd& operator *=(const float &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
     }
-    FADd& operator *=(const double &u) {
+    GPU_DECL FADd& operator *=(const double &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
     }
-    FADd& operator *=(const long double &u) {
+    GPU_DECL FADd& operator *=(const long double &u) {
       value*=u;
       grad *=u;// + (u.grad is zero) * value;
       return *this;
@@ -864,46 +865,46 @@ namespace Loci {
     //    template<class T> FADd operator /(const T &v) const{
     //      return FADd(value/(double)v, grad);
     //    }
-    FADd operator /(const FADd &v) const{
+    GPU_DECL FADd operator /(const FADd &v) const{
       return FADd(value/v.value, (grad*v.value - value*v.grad)/v.value/v.value);
     }
-    FADd operator /(const int &v) const{
+    GPU_DECL FADd operator /(const int &v) const{
       return FADd(value/v, (grad/(double)v));
     }
-    FADd operator /(const float &v) const{
+    GPU_DECL FADd operator /(const float &v) const{
       return FADd(value/v, (grad/(double)v));
     }
-    FADd operator /(const double &v) const{
+    GPU_DECL FADd operator /(const double &v) const{
       return FADd(value/v, (grad/(double)v));
     }
-    FADd operator /(const long double &v) const{
+    GPU_DECL FADd operator /(const long double &v) const{
       return FADd(value/v, (grad/(long double)v));
     }
     //    template<class T> FADd& operator /=(const T &u) {
     //      value/=(double)u;
     //      return *this;
     //    }
-    FADd& operator /=(const FADd &u) {
+    GPU_DECL FADd& operator /=(const FADd &u) {
       grad = (grad*u.value - value * u.grad) / u.value / u.value;
       value/=u.value;
       return *this;
     }
-    FADd& operator /=(const int &u) {
+    GPU_DECL FADd& operator /=(const int &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
     }
-    FADd& operator /=(const float &u) {
+    GPU_DECL FADd& operator /=(const float &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
     }
-    FADd& operator /=(const double &u) {
+    GPU_DECL FADd& operator /=(const double &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
     }
-    FADd& operator /=(const long double &u) {
+    GPU_DECL FADd& operator /=(const long double &u) {
       value/=u;
       grad /=u;// (grad*u.value /*- value * u.grad=0*/) / u / u;
       return *this;
@@ -929,94 +930,94 @@ namespace Loci {
     //    template<class T> bool operator <=(const T &u) const {
     //      return ((value<=(double)u)?true:false);
     //    }
-    bool operator ==(const FADd &u)const  {
+    GPU_DECL bool operator ==(const FADd &u)const  {
       return ((value==u.value)?true:false);
     }
-    bool operator !=(const FADd &u) const {
+    GPU_DECL bool operator !=(const FADd &u) const {
       return ((value!=u.value)?true:false);
     }
-    bool operator >(const FADd &u) const {
+    GPU_DECL bool operator >(const FADd &u) const {
       return ((value>u.value)?true:false);
     }
-    bool operator <(const FADd &u) const {
+    GPU_DECL bool operator <(const FADd &u) const {
       return ((value<u.value)?true:false);
     }
-    bool operator >=(const FADd &u) const {
+    GPU_DECL bool operator >=(const FADd &u) const {
       return ((value>=u.value)?true:false);
     }
-    bool operator <=(const FADd &u) const {
+    GPU_DECL bool operator <=(const FADd &u) const {
       return ((value<=u.value)?true:false);
     }
-    bool operator ==(const int &u) const {
+    GPU_DECL bool operator ==(const int &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const int &u) const {
+    GPU_DECL bool operator !=(const int &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator >(const int &u) const {
+    GPU_DECL bool operator >(const int &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const int &u) const {
+    GPU_DECL bool operator <(const int &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const int &u) const {
+    GPU_DECL bool operator >=(const int &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const int &u) const {
+    GPU_DECL bool operator <=(const int &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const float &u) const {
+    GPU_DECL bool operator ==(const float &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const float &u) const {
+    GPU_DECL bool operator !=(const float &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator >(const float &u) const {
+    GPU_DECL bool operator >(const float &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const float &u) const {
+    GPU_DECL bool operator <(const float &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const float &u) const {
+    GPU_DECL bool operator >=(const float &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const float &u) const {
+    GPU_DECL bool operator <=(const float &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const double &u) const {
+    GPU_DECL bool operator ==(const double &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const double &u) const {
+    GPU_DECL bool operator !=(const double &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator  >(const double &u) const {
+    GPU_DECL bool operator  >(const double &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const double &u) const {
+    GPU_DECL bool operator <(const double &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const double &u) const {
+    GPU_DECL bool operator >=(const double &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const double &u) const {
+    GPU_DECL bool operator <=(const double &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const long double &u) const {
+    GPU_DECL bool operator ==(const long double &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const long double &u) const {
+    GPU_DECL bool operator !=(const long double &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator  >(const long double &u) const {
+    GPU_DECL bool operator  >(const long double &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const long double &u) const {
+    GPU_DECL bool operator <(const long double &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const long double &u) const {
+    GPU_DECL bool operator >=(const long double &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const long double &u) const {
+    GPU_DECL bool operator <=(const long double &u) const {
       return ((value<=u)?true:false);
     }
 
@@ -1052,98 +1053,98 @@ namespace Loci {
     return stream;
   }
 
-  inline double ceil(const FADd u) {
+  inline GPU_DECL double ceil(const FADd u) {
     return std::ceil(u.value) ;
   }
-  inline double floor(const FADd u) {
+  inline GPU_DECL double floor(const FADd u) {
     return std::floor(u.value) ;
   }
 
-  inline FADd erf(const FADd u) {
+  inline GPU_DECL FADd erf(const FADd u) {
     double ef = ::erf(u.value) ;
     double efp = (2./sqrt(M_PI))*std::exp(-u.value*u.value) ;
     return FADd(ef,u.grad*efp) ;
   }
-  inline FADd sin(const FADd u) {
+  inline GPU_DECL FADd sin(const FADd u) {
     return FADd(std::sin(u.value), u.grad*std::cos(u.value));
   }
-  inline FADd cos(const FADd u) {
+  inline GPU_DECL FADd cos(const FADd u) {
     return FADd(std::cos(u.value), -u.grad*std::sin(u.value));
   }
-  inline FADd tan(const FADd u) {
+  inline GPU_DECL FADd tan(const FADd u) {
     return FADd(std::tan(u.value), u.grad/pow(std::cos(u.value),2)) ;
   }
 
-  inline FADd exp(const FADd u) {
+  inline GPU_DECL FADd exp(const FADd u) {
     return FADd(std::exp(u.value), u.grad*std::exp(u.value));
   }
-  inline FADd log(const FADd u) {
+  inline GPU_DECL FADd log(const FADd u) {
     return FADd(std::log(u.value), u.grad/u.value);
   }
-  inline FADd log10(const FADd u) {
+  inline GPU_DECL FADd log10(const FADd u) {
     return FADd(std::log(u.value), u.grad/u.value)/std::log(10.0);
   }
-  inline FADd abs(const FADd u) {
+  inline GPU_DECL FADd abs(const FADd u) {
     return FADd(std::fabs(u.value),
                 u.grad*( (u.value<0.0)?-1.0:1.0 ) );
   }
-  inline FADd fabs(const FADd u) {
+  inline GPU_DECL FADd fabs(const FADd u) {
     return FADd(std::fabs(u.value),
                 u.grad*( (u.value<0.0)?-1.0:1.0 ) );
   }
   /* MPGCOMMENT [05-12-2017 15:04] ---> POW */
-  inline FADd pow(const FADd u, const int k) {
+  inline GPU_DECL FADd pow(const FADd u, const int k) {
     return FADd(std::pow(u.value, k),
                 (double)k * std::pow(u.value, (double)k-1.0)*u.grad );
   }
-  inline FADd pow(const FADd u, const float k) {
+  inline GPU_DECL FADd pow(const FADd u, const float k) {
     return FADd(std::pow(u.value, double(k)),
                 (double)k * std::pow(u.value, (double)k-1.0)*u.grad );
   }
-  inline FADd pow(const FADd u, const double k) {
+  inline GPU_DECL FADd pow(const FADd u, const double k) {
     return FADd(std::pow(u.value, k),
                 k * std::pow(u.value, k-1.0)*u.grad );
   }
-  inline FADd pow(const FADd u, const long double k) {
+  inline GPU_DECL FADd pow(const FADd u, const long double k) {
     return FADd(std::pow(u.value,  double(k)),
                 (double)k * std::pow(u.value,  (double)k-1.0)*u.grad );
   }
-  inline FADd sqrt(const FADd u) {
+  inline GPU_DECL FADd sqrt(const FADd u) {
     double su = std::sqrt(u.value) ;
     return FADd(su,0.5*u.grad/std::max(su,1e-30)) ;
   }
-  inline FADd pow(const FADd k, const FADd u) {
+  inline GPU_DECL FADd pow(const FADd k, const FADd u) {
     double kpu = std::pow(k.value,u.value) ;
     return FADd(kpu,std::pow(k.value,u.value-1.)*k.grad*u.value +
                 kpu*std::log(k.value)*u.grad) ;
   }
-  inline FADd pow(const int k, const FADd u) {
+  inline GPU_DECL FADd pow(const int k, const FADd u) {
     double kpu = std::pow(k,u.value) ;
     return FADd(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline FADd pow(const float k, const FADd u) {
+  inline GPU_DECL FADd pow(const float k, const FADd u) {
     double kpu = std::pow(double(k),u.value) ;
     return FADd(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline FADd pow(const double k, const FADd u) {
+  inline GPU_DECL FADd pow(const double k, const FADd u) {
     double kpu = std::pow(k,u.value) ;
     return FADd(kpu,kpu*std::log(k)*u.grad) ;
   }
-  inline FADd pow(const long double k, const FADd u) {
+  inline GPU_DECL FADd pow(const long double k, const FADd u) {
     double kpu = std::pow(double(k),u.value) ;
     return FADd(kpu,kpu*std::log(k)*u.grad) ;
   }
 
 
-  inline FADd sinh(const FADd u) {
+  inline GPU_DECL FADd sinh(const FADd u) {
     return FADd(std::sinh(u.value),
                 0.5*u.grad*(std::exp(u.value) + std::exp(-u.value))) ;
   }
-  inline FADd cosh(const FADd u) {
+  inline GPU_DECL FADd cosh(const FADd u) {
     return FADd(std::cosh(u.value),
                 0.5*u.grad*(std::exp(u.value) - std::exp(-u.value))) ;
   }
-  inline FADd tanh(const FADd u) {
+  inline GPU_DECL FADd tanh(const FADd u) {
     double ex = std::exp(std::min(u.value,350.0)) ;
     double exm = std::exp(std::min(-u.value,350.0)) ;
     double dex = ex-exm ;
@@ -1152,42 +1153,42 @@ namespace Loci {
                 u.grad*(1.-dex*dex/(sex*sex))) ;
   }
 
-  inline FADd asin(const FADd u) {
+  inline GPU_DECL FADd asin(const FADd u) {
     return FADd(std::asin(u.value), u.grad/std::sqrt(1.0-u.value*u.value) );
   }
-  inline FADd acos(const FADd u) {
+  inline GPU_DECL FADd acos(const FADd u) {
     return FADd(std::acos(u.value), -u.grad/std::sqrt(1.0-u.value*u.value) );
   }
-  inline FADd atan(const FADd u) {
+  inline GPU_DECL FADd atan(const FADd u) {
     return FADd(std::atan(u.value), u.grad/(1.0+u.value*u.value) );
   }
   // This will not work in general
-  inline FADd atan2(const FADd u, const FADd v) {
+  inline GPU_DECL FADd atan2(const FADd u, const FADd v) {
     return atan(u/v);
   }
 
-  inline FADd asinh(const FADd u) {
+  inline GPU_DECL FADd asinh(const FADd u) {
     double strm = std::sqrt(u.value*u.value+1.) ;
     double uvstrm = u.value+strm ;
     return FADd(::asinh(u.value), u.grad*(u.value/strm+1.)/uvstrm) ;
   }
-  inline FADd acosh(const FADd u) {
+  inline GPU_DECL FADd acosh(const FADd u) {
     double strm = std::sqrt(u.value*u.value-1.) ;
     double uvstrm = u.value+strm ;
     return FADd(::acosh(u.value), u.grad*(u.value/strm +1.)/uvstrm) ;
   }
-  inline FADd atanh(const FADd u) {
+  inline GPU_DECL FADd atanh(const FADd u) {
     const double uv = u.value ;
     return FADd(::atanh(uv), .5*u.grad*(1./(1.+uv)+1./(1.-uv))) ;
   }
 
-  inline FADd operator +(const double u,const FADd v)
+  inline GPU_DECL FADd operator +(const double u,const FADd v)
   { return FADd(u+v.value, v.grad); }
-  inline FADd operator -(const double u,const FADd v)
+  inline GPU_DECL FADd operator -(const double u,const FADd v)
   { return FADd(u-v.value, -v.grad); }
-  inline FADd operator *(const double u,const FADd v)
+  inline GPU_DECL FADd operator *(const double u,const FADd v)
   { return FADd(u*v.value,  v.grad*u); }
-  inline FADd operator /(const double &u,const FADd &v)
+  inline GPU_DECL FADd operator /(const double &u,const FADd &v)
   { return FADd(u/v.value, -u*v.grad/v.value/v.value); }
 
 
@@ -1208,263 +1209,263 @@ namespace Loci {
     //      this->maxN = s;
     //    }
     template< class T1>
-    MFADd(T1 a0) : value(a0), grad()
+    GPU_DECL MFADd(T1 a0) : value(a0), grad()
     { for(int i=0;i<MFAD_SIZE;++i) grad[i] =0 ; }
-    MFADd() : value(0.0), grad()
+    GPU_DECL MFADd() : value(0.0), grad()
     { for(int i=0;i<MFAD_SIZE;++i) grad[i] =0 ; }
     //explicit MFADd(int u) : value(u), grad(){ }
     //explicit MFADd(float u) : value(u), grad() { }
     //explicit MFADd(double u) : value(u), grad() { }
     //explicit MFADd(long double u) : value(u), grad() { }
-    MFADd(double u, size_t n) : value(u), grad()
+    GPU_DECL MFADd(double u, size_t n) : value(u), grad()
     { for(int i=0;i<MFAD_SIZE;++i) grad[i] =0 ; }
     //explicit MFADd(bool &u)  : value((u)?1.0:0.0), grad() { }
-    MFADd(const double u, const double * g, const int n): value(u), grad() {
+    GPU_DECL MFADd(const double u, const double * g, const int n): value(u), grad() {
       for (size_t i=0; i<maxN; i++) this->grad[i]=g[i];
     }
-    MFADd(const MFADd &u, size_t n): value(u.value), grad() {
+    GPU_DECL MFADd(const MFADd &u, size_t n): value(u.value), grad() {
       for (size_t i=0; i<maxN; i++) this->grad[i]=u.grad[i];
     }
-    MFADd(const MFADd &u): value(u.value), grad() {
+    GPU_DECL MFADd(const MFADd &u): value(u.value), grad() {
       for (size_t i=0; i<maxN; i++) this->grad[i]=u.grad[i];
     }
 
-    void setValue(double val) { value = val ; }
-    MFADd& operator =(const MFADd &u) {
+    GPU_DECL void setValue(double val) { value = val ; }
+    GPU_DECL MFADd& operator =(const MFADd &u) {
       this->value = u.value;
       for (size_t i=0; i<maxN; i++) this->grad[i]=u.grad[i];
       return *this;
     }
-    MFADd& operator =(const int &u) {
+    GPU_DECL MFADd& operator =(const int &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
-    MFADd& operator =(const float &u) {
+    GPU_DECL MFADd& operator =(const float &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
-    MFADd& operator =(const double &u) {
+    GPU_DECL MFADd& operator =(const double &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
-    MFADd& operator =(const long double &u) {
+    GPU_DECL MFADd& operator =(const long double &u) {
       this->value = u ;
       for (size_t i=0; i<maxN; i++) this->grad[i] = 0.0 ;
       return *this;
     }
 
-    MFADd operator +(const MFADd &v) const{
+    GPU_DECL MFADd operator +(const MFADd &v) const{
       size_t s = maxN;
       MFADd out(this->value+v.value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]+v.grad[i];
       return out;
     }
-    MFADd operator +() const {
+    GPU_DECL MFADd operator +() const {
       size_t s = maxN;
       MFADd out(this->value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator +(const int &v) const{
+    GPU_DECL MFADd operator +(const int &v) const{
       size_t s = maxN;
       MFADd out(this->value+(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator +(const float &v) const{
+    GPU_DECL MFADd operator +(const float &v) const{
       size_t s = maxN;
       MFADd out(this->value+(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator +(const double &v) const{
+    GPU_DECL MFADd operator +(const double &v) const{
       size_t s = maxN;
       MFADd out(this->value+(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator +(const long double &v) const{
+    GPU_DECL MFADd operator +(const long double &v) const{
       size_t s = maxN;
       MFADd out(this->value+(long double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
 
-    MFADd& operator +=(const MFADd &u) {
+    GPU_DECL MFADd& operator +=(const MFADd &u) {
       this->value+=u.value;
       for (size_t i=0; i<maxN; i++) this->grad[i]+=u.grad[i];
       return *this;
     }
-    MFADd& operator +=(const int &u) {
+    GPU_DECL MFADd& operator +=(const int &u) {
       this->value+=u;
       return *this;
     }
-    MFADd& operator +=(const float &u) {
+    GPU_DECL MFADd& operator +=(const float &u) {
       this->value+=u;
       return *this;
     }
-    MFADd& operator +=(const double &u) {
+    GPU_DECL MFADd& operator +=(const double &u) {
       this->value+=u;
       return *this;
     }
-    MFADd& operator +=(const long double &u) {
+    GPU_DECL MFADd& operator +=(const long double &u) {
       this->value+=u;
       return *this;
     }
 
-    MFADd operator -(const MFADd &v) const{
+    GPU_DECL MFADd operator -(const MFADd &v) const{
       size_t s = maxN ;
       MFADd out(this->value-v.value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]-v.grad[i];
       return out;
     }
-    MFADd operator -() const {
+    GPU_DECL MFADd operator -() const {
       size_t s = maxN;
       MFADd out(-this->value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = -this->grad[i];
       return out;
     }
-    MFADd operator -(const int &v) const{
+    GPU_DECL MFADd operator -(const int &v) const{
       size_t s = maxN;
       MFADd out(this->value-(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator -(const float &v) const{
+    GPU_DECL MFADd operator -(const float &v) const{
       size_t s = maxN;
       MFADd out(this->value-(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator -(const double &v) const{
+    GPU_DECL MFADd operator -(const double &v) const{
       size_t s = maxN;
       MFADd out(this->value-(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
-    MFADd operator -(const long double &v) const{
+    GPU_DECL MFADd operator -(const long double &v) const{
       size_t s = maxN;
       MFADd out(this->value-(long double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i];
       return out;
     }
 
-    MFADd& operator -=(const MFADd &u) {
+    GPU_DECL MFADd& operator -=(const MFADd &u) {
       this->value -= u.value;
       for (size_t i=0; i<maxN; i++) this->grad[i]-=u.grad[i];
       return *this;
     }
-    MFADd& operator -=(const int &u) {
+    GPU_DECL MFADd& operator -=(const int &u) {
       this->value -= u;
       return *this;
     }
-    MFADd& operator -=(const float &u) {
+    GPU_DECL MFADd& operator -=(const float &u) {
       this->value -= u;
       return *this;
     }
-    MFADd& operator -=(const double &u) {
+    GPU_DECL MFADd& operator -=(const double &u) {
       this->value -= u;
       return *this;
     }
-    MFADd& operator -=(const long double &u) {
+    GPU_DECL MFADd& operator -=(const long double &u) {
       this->value -= u;
       return *this;
     }
 
-    MFADd operator *(const MFADd &v) const {
+    GPU_DECL MFADd operator *(const MFADd &v) const {
       size_t s = maxN ;
       MFADd out(this->value*v.value,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]*v.value + v.grad[i]*this->value;
       return out;
     }
-    MFADd operator *(const int &v) const {
+    GPU_DECL MFADd operator *(const int &v) const {
       size_t s = maxN;
       MFADd out(this->value*(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (double)v;
       return out;
     }
-    MFADd operator *(const float &v) const {
+    GPU_DECL MFADd operator *(const float &v) const {
       size_t s = maxN;
       MFADd out(this->value*(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (double)v;
       return out;
     }
-    MFADd operator *(const double &v) const {
+    GPU_DECL MFADd operator *(const double &v) const {
       size_t s = maxN;
       MFADd out(this->value*(double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (double)v;
       return out;
     }
-    MFADd operator *(const long double &v) const {
+    GPU_DECL MFADd operator *(const long double &v) const {
       size_t s = maxN;
       MFADd out(this->value*(long double)v,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i] * (long double)v;
       return out;
     }
 
-    MFADd& operator *=(const MFADd &u) {
+    GPU_DECL MFADd& operator *=(const MFADd &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] = this->grad[i]*u.value + u.grad[i] * this->value;
       this->value*=u.value;
       return *this;
     }
-    MFADd& operator *=(const int &u) {
+    GPU_DECL MFADd& operator *=(const int &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
-    MFADd& operator *=(const float &u) {
+    GPU_DECL MFADd& operator *=(const float &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
-    MFADd& operator *=(const double &u) {
+    GPU_DECL MFADd& operator *=(const double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
-    MFADd& operator *=(const long double &u) {
+    GPU_DECL MFADd& operator *=(const long double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] *= u;
       this->value *=u ;
       return *this;
     }
 
-    MFADd operator /(const MFADd &v) const{
+    GPU_DECL MFADd operator /(const MFADd &v) const{
       size_t s = maxN ;
       double div = this->value/v.value;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = (this->grad[i] - div*v.grad[i])/v.value;
       return out;
     }
-    MFADd operator /(const int &v) const{
+    GPU_DECL MFADd operator /(const int &v) const{
       size_t s = maxN;
       double div = this->value/(double)v;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]/(double)v;
       return out;
     }
-    MFADd operator /(const float &v) const{
+    GPU_DECL MFADd operator /(const float &v) const{
       size_t s = maxN;
       double div = this->value/(double)v;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]/(double)v;
       return out;
     }
-    MFADd operator /(const double &v) const{
+    GPU_DECL MFADd operator /(const double &v) const{
       size_t s = maxN;
       double div = this->value/(double)v;
       MFADd out(div,s);
       for (size_t i=0; i<s; i++) out.grad[i] = this->grad[i]/(double)v;
       return out;
     }
-    MFADd operator /(const long double &v) const{
+    GPU_DECL MFADd operator /(const long double &v) const{
       size_t s = maxN;
       double div = this->value/(long double)v;
       MFADd out(div,s);
@@ -1472,126 +1473,126 @@ namespace Loci {
       return out;
     }
 
-    MFADd& operator /=(const MFADd &u) {
+    GPU_DECL MFADd& operator /=(const MFADd &u) {
       size_t s = maxN;
       double div = this->value/u.value;
       for (size_t i=0; i<s; i++) this->grad[i] = (this->grad[i] - div*u.grad[i])/u.value;
       this->value = div ;
       return *this;
     }
-    MFADd& operator /=(const int &u) {
+    GPU_DECL MFADd& operator /=(const int &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
-    MFADd& operator /=(const float &u) {
+    GPU_DECL MFADd& operator /=(const float &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
-    MFADd& operator /=(const double &u) {
+    GPU_DECL MFADd& operator /=(const double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
-    MFADd& operator /=(const long double &u) {
+    GPU_DECL MFADd& operator /=(const long double &u) {
       size_t s = maxN;
       for (size_t i=0; i<s; i++) this->grad[i] /= u;
       this->value /= u ;
       return *this;
     }
 
-    bool operator ==(const MFADd &u)const  {
+    GPU_DECL bool operator ==(const MFADd &u)const  {
       return ((this->value==u.value)?true:false);
     }
-    bool operator !=(const MFADd &u) const {
+    GPU_DECL bool operator !=(const MFADd &u) const {
       return ((this->value!=u.value)?true:false);
     }
-    bool operator >(const MFADd &u) const {
+    GPU_DECL bool operator >(const MFADd &u) const {
       return ((this->value>u.value)?true:false);
     }
-    bool operator <(const MFADd &u) const {
+    GPU_DECL bool operator <(const MFADd &u) const {
       return ((this->value<u.value)?true:false);
     }
-    bool operator >=(const MFADd &u) const {
+    GPU_DECL bool operator >=(const MFADd &u) const {
       return ((this->value>=u.value)?true:false);
     }
-    bool operator <=(const MFADd &u) const {
+    GPU_DECL bool operator <=(const MFADd &u) const {
       return ((this->value<=u.value)?true:false);
     }
-    bool operator ==(const int &u) const {
+    GPU_DECL bool operator ==(const int &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const int &u) const {
+    GPU_DECL bool operator !=(const int &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator >(const int &u) const {
+    GPU_DECL bool operator >(const int &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const int &u) const {
+    GPU_DECL bool operator <(const int &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const int &u) const {
+    GPU_DECL bool operator >=(const int &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const int &u) const {
+    GPU_DECL bool operator <=(const int &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const float &u) const {
+    GPU_DECL bool operator ==(const float &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const float &u) const {
+    GPU_DECL bool operator !=(const float &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator >(const float &u) const {
+    GPU_DECL bool operator >(const float &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const float &u) const {
+    GPU_DECL bool operator <(const float &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const float &u) const {
+    GPU_DECL bool operator >=(const float &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const float &u) const {
+    GPU_DECL bool operator <=(const float &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const double &u) const {
+    GPU_DECL bool operator ==(const double &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const double &u) const {
+    GPU_DECL bool operator !=(const double &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator  >(const double &u) const {
+    GPU_DECL bool operator  >(const double &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const double &u) const {
+    GPU_DECL bool operator <(const double &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const double &u) const {
+    GPU_DECL bool operator >=(const double &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const double &u) const {
+    GPU_DECL bool operator <=(const double &u) const {
       return ((value<=u)?true:false);
     }
-    bool operator ==(const long double &u) const {
+    GPU_DECL bool operator ==(const long double &u) const {
       return ((value==u)?true:false);
     }
-    bool operator !=(const long double &u) const {
+    GPU_DECL bool operator !=(const long double &u) const {
       return ((value!=u)?true:false);
     }
-    bool operator  >(const long double &u) const {
+    GPU_DECL bool operator  >(const long double &u) const {
       return ((value>u)?true:false);
     }
-    bool operator <(const long double &u) const {
+    GPU_DECL bool operator <(const long double &u) const {
       return ((value<u)?true:false);
     }
-    bool operator >=(const long double &u) const {
+    GPU_DECL bool operator >=(const long double &u) const {
       return ((value>=u)?true:false);
     }
-    bool operator <=(const long double &u) const {
+    GPU_DECL bool operator <=(const long double &u) const {
       return ((value<=u)?true:false);
     }
   } ;
@@ -1642,13 +1643,13 @@ namespace Loci {
   using std::max;
   using std::min;
 
-  inline double ceil(const MFADd u) {
+  inline GPU_DECL double ceil(const MFADd u) {
     return std::ceil(u.value) ;
   }
-  inline double floor(const MFADd u) {
+  inline GPU_DECL double floor(const MFADd u) {
     return std::floor(u.value) ;
   }
-  inline MFADd erf(const MFADd u) {
+  inline GPU_DECL MFADd erf(const MFADd u) {
     double ef = ::erf(u.value) ;
     size_t s = MFADd::maxN ;
     MFADd out(ef,s) ;
@@ -1657,116 +1658,116 @@ namespace Loci {
       out.grad[i] = u.grad[i]*efp ;
     return out ;
   }
-  inline MFADd sin(const MFADd u) {
+  inline GPU_DECL MFADd sin(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::sin(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*std::cos(u.value);
     return out;
   }
-  inline MFADd cos(const MFADd u) {
+  inline GPU_DECL MFADd cos(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::cos(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = -u.grad[i]*std::sin(u.value);
     return out;
   }
-  inline MFADd tan(const MFADd u) {
+  inline GPU_DECL MFADd tan(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::tan(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/pow(std::cos(u.value),2) ;
     return out;
   }
 
-  inline MFADd exp(const MFADd u) {
+  inline GPU_DECL MFADd exp(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::exp(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*std::exp(u.value);
     return out;
   }
-  inline MFADd log(const MFADd u) {
+  inline GPU_DECL MFADd log(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::log(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/u.value ;
     return out;
   }
-  inline MFADd log10(const MFADd u) {
+  inline GPU_DECL MFADd log10(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::log(u.value)/std::log(10.0),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/u.value/std::log(10.0);
     return out;
   }
-  inline MFADd abs(const MFADd u) {
+  inline GPU_DECL MFADd abs(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::fabs(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*( (u.value<0.0)?-1.0:1.0 );
     return out;
   }
-  inline MFADd fabs(const MFADd u) {
+  inline GPU_DECL MFADd fabs(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::fabs(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*( (u.value<0.0)?-1.0:1.0 );
     return out;
   }
 
-  inline MFADd pow(const MFADd u, const int k) {
+  inline GPU_DECL MFADd pow(const MFADd u, const int k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, k),s);
     for (size_t i=0; i<s; i++) out.grad[i] = (double)k * std::pow(u.value, (double)k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const MFADd u, const float k) {
+  inline GPU_DECL MFADd pow(const MFADd u, const float k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, double(k)),s);
     for (size_t i=0; i<s; i++) out.grad[i] = (double)k * std::pow(u.value, (double)k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const MFADd u, const double k) {
+  inline GPU_DECL MFADd pow(const MFADd u, const double k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, k),s);
     for (size_t i=0; i<s; i++) out.grad[i] = k * std::pow(u.value, k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const MFADd u, const long double k) {
+  inline GPU_DECL MFADd pow(const MFADd u, const long double k) {
     size_t s = MFADd::maxN;
     MFADd out(std::pow(u.value, double(k)),s);
     for (size_t i=0; i<s; i++) out.grad[i] = (double)k * std::pow(u.value, (double)k-1.0)*u.grad[i] ;
     return out ;
   }
-  inline MFADd sqrt(const MFADd u) {
+  inline GPU_DECL MFADd sqrt(const MFADd u) {
     size_t s = MFADd::maxN;
     double sq = std::sqrt(u.value);
     MFADd out(sq,s) ;
     for (size_t i=0; i<s; i++) out.grad[i] = 0.5*u.grad[i]/::max(sq,1e-30) ;
     return out;
   }
-  inline MFADd pow(const MFADd k, const MFADd u) {
+  inline GPU_DECL MFADd pow(const MFADd k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k.value,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = std::pow(k.value,u.value-1.)*k.grad[i]*u.value + kpu*std::log(k.value)*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const int k, const MFADd u) {
+  inline GPU_DECL MFADd pow(const int k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = kpu*std::log(double(k))*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const float k, const MFADd u) {
+  inline GPU_DECL MFADd pow(const float k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = kpu*std::log(double(k))*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const double k, const MFADd u) {
+  inline GPU_DECL MFADd pow(const double k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(k,u.value) ;
     MFADd out(kpu,s);
     for (size_t i=0; i<s; i++) out.grad[i] = kpu*std::log(k)*u.grad[i] ;
     return out ;
   }
-  inline MFADd pow(const long double k, const MFADd u) {
+  inline GPU_DECL MFADd pow(const long double k, const MFADd u) {
     size_t s = MFADd::maxN;
     double kpu = std::pow(double(k),u.value) ;
     MFADd out(kpu,s);
@@ -1774,56 +1775,56 @@ namespace Loci {
     return out ;
   }
 
-  inline MFADd max (const MFADd &a, const MFADd& b) {
+  inline GPU_DECL MFADd max (const MFADd &a, const MFADd& b) {
     size_t s = MFADd::maxN;
     MFADd out((a.value<b.value)?b.value:a.value);
     for (size_t i=0; i<s; i++) out.grad[i] = (a.value<b.value)?b.grad[i]:a.grad[i];
     return out;
   }
-  inline MFADd max (const MFADd &a, const int& b) {
+  inline GPU_DECL MFADd max (const MFADd &a, const int& b) {
     return max(a,MFADd((double)b));
   }
-  inline MFADd max (const MFADd &a, const float& b) {
+  inline GPU_DECL MFADd max (const MFADd &a, const float& b) {
     return max(a,MFADd((double)b));
   }
-  inline MFADd max (const MFADd &a, const double & b) {
+  inline GPU_DECL MFADd max (const MFADd &a, const double & b) {
     return max(a,MFADd((double)b));
   }
-  inline MFADd max (const MFADd &a, const long double & b) {
+  inline GPU_DECL MFADd max (const MFADd &a, const long double & b) {
     return max(a,MFADd((double)b));
   }
-  inline MFADd min (const MFADd &a, const MFADd& b) {
+  inline GPU_DECL MFADd min (const MFADd &a, const MFADd& b) {
     size_t s = MFADd::maxN;
     MFADd out((a.value<b.value)?a.value:b.value);
     for (size_t i=0; i<s; i++) out.grad[i] = (a.value<b.value)?a.grad[i]:b.grad[i];
     return out;
   }
-  inline MFADd min (const MFADd &a, const int& b) {
+  inline GPU_DECL MFADd min (const MFADd &a, const int& b) {
     return min(a, MFADd((double)b));
   }
-  inline MFADd min (const MFADd &a, const float& b) {
+  inline GPU_DECL MFADd min (const MFADd &a, const float& b) {
     return min(a, MFADd((double)b));
   }
-  inline MFADd min (const MFADd &a, const double& b) {
+  inline GPU_DECL MFADd min (const MFADd &a, const double& b) {
     return min(a, MFADd((double)b));
   }
-  inline MFADd min (const MFADd &a, const long double& b) {
+  inline GPU_DECL MFADd min (const MFADd &a, const long double& b) {
     return min(a, MFADd((double)b));
   }
 
-  inline MFADd sinh(const MFADd u) {
+  inline GPU_DECL MFADd sinh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::sinh(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = 0.5*u.grad[i]*(std::exp(u.value) + std::exp(-(u.value))) ;
     return out;
   }
-  inline MFADd cosh(const MFADd u) {
+  inline GPU_DECL MFADd cosh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::cosh(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = 0.5*u.grad[i]*(std::exp(u.value) - std::exp(-(u.value))) ;
     return out;
   }
-  inline MFADd tanh(const MFADd u) {
+  inline GPU_DECL MFADd tanh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::tanh(u.value),s);
     double ex = std::exp(::min(u.value,350.0)) ;
@@ -1834,29 +1835,29 @@ namespace Loci {
     return out;
   }
 
-  inline MFADd asin(const MFADd u) {
+  inline GPU_DECL MFADd asin(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::asin(u.value),s);
     double val = std::sqrt(1.0-u.value*u.value);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/val;
     return out;
   }
-  inline MFADd acos(const MFADd u) {
+  inline GPU_DECL MFADd acos(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::acos(u.value),s);
     double val = std::sqrt(1.0-u.value*u.value);
     for (size_t i=0; i<s; i++) out.grad[i] = -u.grad[i]/val;
     return out;
   }
-  inline MFADd atan(const MFADd u) {
+  inline GPU_DECL MFADd atan(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(std::atan(u.value),s);
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]/(u.value*u.value + 1.0);
     return out;
   }
-  inline MFADd atan2(const MFADd u, const MFADd v) { return atan(u/v); }
+  inline GPU_DECL MFADd atan2(const MFADd u, const MFADd v) { return atan(u/v); }
 
-  inline MFADd asinh(const MFADd u) {
+  inline GPU_DECL MFADd asinh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(::asinh(u.value),s);
     double strm = std::sqrt(u.value*u.value+1.) ;
@@ -1864,7 +1865,7 @@ namespace Loci {
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*(u.value/strm+1.)/uvstrm ;
     return out;
   }
-  inline MFADd acosh(const MFADd u) {
+  inline GPU_DECL MFADd acosh(const MFADd u) {
     size_t s = MFADd::maxN;
     MFADd out(::acosh(u.value),s);
     double strm = std::sqrt(u.value*u.value-1.) ;
@@ -1872,7 +1873,7 @@ namespace Loci {
     for (size_t i=0; i<s; i++) out.grad[i] = u.grad[i]*(u.value/strm +1.)/uvstrm ;
     return out;
   }
-  inline MFADd atanh(const MFADd u) {
+  inline GPU_DECL MFADd atanh(const MFADd u) {
     size_t s = MFADd::maxN;
     const double uv = u.value ;
     MFADd out(::atanh(uv),s);
@@ -1880,25 +1881,25 @@ namespace Loci {
     return out;
   }
 
-  inline MFADd operator +(const double u,const MFADd v) {
+  inline GPU_DECL MFADd operator +(const double u,const MFADd v) {
     size_t s = MFADd::maxN;
     MFADd out(u+v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = v.grad[i];
     return out;
   }
-  inline MFADd operator -(const double u,const MFADd v) {
+  inline GPU_DECL MFADd operator -(const double u,const MFADd v) {
     size_t s = MFADd::maxN;
     MFADd out(u-v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = v.grad[i];
     return out;
   }
-  inline MFADd operator *(const double u,const MFADd v) {
+  inline GPU_DECL MFADd operator *(const double u,const MFADd v) {
     size_t s = MFADd::maxN;
     MFADd out(u*v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = u * v.grad[i];
     return out;
   }
-  inline MFADd operator /(const double &u,const MFADd &v) {
+  inline GPU_DECL MFADd operator /(const double &u,const MFADd &v) {
     size_t s = MFADd::maxN;
     MFADd out(u/v.value,s);
     for (size_t i=0; i<s; i++) out.grad[i] = -u*v.grad[i]/v.value/v.value;
@@ -1941,22 +1942,22 @@ namespace Loci {
 
 #endif
 
-    VFAD(const double u) {
+    GPU_DECL VFAD(const double u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
     }
-    VFAD(const int u) {
+    GPU_DECL VFAD(const int u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
     }
-    VFAD(const size_t u) {
+    GPU_DECL VFAD(const size_t u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
     }
-    VFAD(const float u) {
+    GPU_DECL VFAD(const float u) {
       data.value = u ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0. ;
@@ -1966,31 +1967,31 @@ namespace Loci {
 
     VFAD() = default ;
 
-    void setValue(double val) { data.value = val ; }
-    VFAD& operator =(const VFAD &u) {
+    GPU_DECL void setValue(double val) { data.value = val ; }
+    GPU_DECL VFAD& operator =(const VFAD &u) {
       data.value = u.data.value;
       data.grad = u.data.grad;
       return *this;
     }
-    VFAD& operator =(const int &u) {
+    GPU_DECL VFAD& operator =(const int &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
       return *this;
     }
-    VFAD& operator =(const float &u) {
+    GPU_DECL VFAD& operator =(const float &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
       return *this;
     }
-    VFAD& operator =(const double &u) {
+    GPU_DECL VFAD& operator =(const double &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
       return *this;
     }
-    VFAD& operator =(const long double &u) {
+    GPU_DECL VFAD& operator =(const long double &u) {
       data.value = u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = 0.0;
@@ -1998,7 +1999,7 @@ namespace Loci {
     }
 
 
-    VFAD operator +(const VFAD &v) const{
+    GPU_DECL VFAD operator +(const VFAD &v) const{
       VFAD tmp(*this) ;
       tmp.data.value += v.data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
@@ -2006,139 +2007,139 @@ namespace Loci {
       
       return tmp ;
     }
-    VFAD operator +() const{
+    GPU_DECL VFAD operator +() const{
       return VFAD(*this);
     }
-    VFAD operator +(const int &v) const{
+    GPU_DECL VFAD operator +(const int &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
-    VFAD operator +(const float &v) const{
+    GPU_DECL VFAD operator +(const float &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
-    VFAD operator +(const double &v) const{
+    GPU_DECL VFAD operator +(const double &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
-    VFAD operator +(const long double &v) const{
+    GPU_DECL VFAD operator +(const long double &v) const{
       VFAD tmp = *this ;
       tmp.data.value += v ;
       return tmp ;
     }
 
-    VFAD& operator +=(const VFAD &u) {
+    GPU_DECL VFAD& operator +=(const VFAD &u) {
       data.value+=u.data.value;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] += u.data.grad[i];
       return *this;
     }
-    VFAD& operator +=(const int &u) {
+    GPU_DECL VFAD& operator +=(const int &u) {
       data.value+=u;
       return *this;
     }
-    VFAD& operator +=(const float &u) {
+    GPU_DECL VFAD& operator +=(const float &u) {
       data.value+=u;
       return *this;
     }
-    VFAD& operator +=(const double &u) {
+    GPU_DECL VFAD& operator +=(const double &u) {
       data.value+=u;
       return *this;
     }
-    VFAD& operator +=(const long double &u) {
+    GPU_DECL VFAD& operator +=(const long double &u) {
       data.value+=u;
       return *this;
     }
 
-    VFAD operator -(const VFAD &v) const{
+    GPU_DECL VFAD operator -(const VFAD &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v.data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] -= v.data.grad[i] ;
       return tmp ;
     }
-    VFAD operator -() const {
+    GPU_DECL VFAD operator -() const {
       VFAD tmp ;
       tmp.data.value = -data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] = -data.grad[i] ;
       return tmp ;
     }
-    VFAD operator -(const int &v) const{
+    GPU_DECL VFAD operator -(const int &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    VFAD operator -(const float &v) const{
+    GPU_DECL VFAD operator -(const float &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    VFAD operator -(const double &v) const{
+    GPU_DECL VFAD operator -(const double &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    VFAD operator -(const long double &v) const{
+    GPU_DECL VFAD operator -(const long double &v) const{
       VFAD tmp = *this ;
       tmp.data.value -= v ;
       return tmp ;
     }
-    VFAD& operator -=(const VFAD &u) {
+    GPU_DECL VFAD& operator -=(const VFAD &u) {
       data.value-=u.data.value;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i]-=u.data.grad[i];
       return *this;
     }
-    VFAD& operator -=(const int &u) {
+    GPU_DECL VFAD& operator -=(const int &u) {
       data.value-=u;
       return *this;
     }
-    VFAD& operator -=(const float &u) {
+    GPU_DECL VFAD& operator -=(const float &u) {
       data.value-=u;
       return *this;
     }
-    VFAD& operator -=(const double &u) {
+    GPU_DECL VFAD& operator -=(const double &u) {
       data.value-=u;
       return *this;
     }
-    VFAD& operator -=(const long double &u) {
+    GPU_DECL VFAD& operator -=(const long double &u) {
       data.value-=u;
       return *this;
     }
 
-    VFAD operator *(const VFAD &v) const {
+    GPU_DECL VFAD operator *(const VFAD &v) const {
       VFAD tmp ;
       tmp.data.value = data.value*v.data.value ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] = data.grad[i]*v.data.value+data.value*v.data.grad[i] ;
       return tmp ;
     }
-    VFAD operator *(const int &v) const{
+    GPU_DECL VFAD operator *(const int &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] *= v ;
       return tmp ;
     }
-    VFAD operator *(const float &v) const{
+    GPU_DECL VFAD operator *(const float &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] *= v ;
       return tmp ;
     }
-    VFAD operator *(const double &v) const{
+    GPU_DECL VFAD operator *(const double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] *= v ;
       return tmp ;
     }
-    VFAD operator *(const long double &v) const{
+    GPU_DECL VFAD operator *(const long double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value *= v ;
       for(int i=0;i<VFAD_SIZE;++i)
@@ -2146,38 +2147,38 @@ namespace Loci {
       return tmp ;
     }
 
-    VFAD& operator *=(const VFAD &u) {
+    GPU_DECL VFAD& operator *=(const VFAD &u) {
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = data.grad[i]*u.data.value + u.data.grad[i]*data.value;
       data.value*=u.data.value;
       return *this;
     }
-    VFAD& operator *=(const int &u) {
+    GPU_DECL VFAD& operator *=(const int &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
-    VFAD& operator *=(const float &u) {
+    GPU_DECL VFAD& operator *=(const float &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
-    VFAD& operator *=(const double &u) {
+    GPU_DECL VFAD& operator *=(const double &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i) 
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
-    VFAD& operator *=(const long double &u) {
+    GPU_DECL VFAD& operator *=(const long double &u) {
       data.value*=u;
       for(int i=0;i<VFAD_SIZE;++i) 
         data.grad[i] *=u;// + (u.grad is zero) * data.value;
       return *this;
     }
 
-    VFAD operator /(const VFAD &v) const{
+    GPU_DECL VFAD operator /(const VFAD &v) const{
       VFAD tmp ;
       tmp.data.value = data.value/v.data.value ;
       float value2 = 1./max(v.data.value*v.data.value,1e-30) ;
@@ -2186,28 +2187,28 @@ namespace Loci {
                            data.value*v.data.grad[i])*value2 ;
       return tmp ;
     }
-    VFAD operator /(const int &v) const{
+    GPU_DECL VFAD operator /(const int &v) const{
       VFAD tmp(*this) ;
       tmp.data.value /= double(v) ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] /= float(v) ;
       return tmp ;
     }
-    VFAD operator /(const float &v) const{ 
+    GPU_DECL VFAD operator /(const float &v) const{ 
       VFAD tmp(*this) ;
       tmp.data.value /= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] /= v ;
       return tmp ;
     }
-    VFAD operator /(const double &v) const{
+    GPU_DECL VFAD operator /(const double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value /= v ;
       for(int i=0;i<VFAD_SIZE;++i)
         tmp.data.grad[i] /= v ;
       return tmp ;
     }
-    VFAD operator /(const long double &v) const{
+    GPU_DECL VFAD operator /(const long double &v) const{
       VFAD tmp(*this) ;
       tmp.data.value /= v ;
       for(int i=0;i<VFAD_SIZE;++i)
@@ -2215,7 +2216,7 @@ namespace Loci {
       return tmp ;
     }
 
-    VFAD& operator /=(const VFAD &u) {
+    GPU_DECL VFAD& operator /=(const VFAD &u) {
       float value2 = 1./max(u.data.value*u.data.value,1e-30) ;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] = (data.grad[i]*u.data.value -
@@ -2223,119 +2224,119 @@ namespace Loci {
       data.value /= u.data.value;
       return *this;
     }
-    VFAD& operator /=(const int &u) {
+    GPU_DECL VFAD& operator /=(const int &u) {
       data.value/=double(u);
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=float(u);
       return *this;
     }
-    VFAD& operator /=(const float &u) {
+    GPU_DECL VFAD& operator /=(const float &u) {
       data.value/=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=u;
       return *this;
     }
-    VFAD& operator /=(const double &u) {
+    GPU_DECL VFAD& operator /=(const double &u) {
       data.value/=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=u;
       return *this;
     }
-    VFAD& operator /=(const long double &u) {
+    GPU_DECL VFAD& operator /=(const long double &u) {
       data.value/=u;
       for(int i=0;i<VFAD_SIZE;++i)
         data.grad[i] /=u;
       return *this;
     }
 
-    bool operator ==(const VFAD &u)const  {
+    GPU_DECL bool operator ==(const VFAD &u)const  {
       return ((data.value==u.data.value)?true:false);
     }
-    bool operator !=(const VFAD &u) const {
+    GPU_DECL bool operator !=(const VFAD &u) const {
       return ((data.value!=u.data.value)?true:false);
     }
-    bool operator >(const VFAD &u) const {
+    GPU_DECL bool operator >(const VFAD &u) const {
       return ((data.value>u.data.value)?true:false);
     }
-    bool operator <(const VFAD &u) const {
+    GPU_DECL bool operator <(const VFAD &u) const {
       return ((data.value<u.data.value)?true:false);
     }
-    bool operator >=(const VFAD &u) const {
+    GPU_DECL bool operator >=(const VFAD &u) const {
       return ((data.value>=u.data.value)?true:false);
     }
-    bool operator <=(const VFAD &u) const {
+    GPU_DECL bool operator <=(const VFAD &u) const {
       return ((data.value<=u.data.value)?true:false);
     }
-    bool operator ==(const int &u) const {
+    GPU_DECL bool operator ==(const int &u) const {
       return ((data.value==u)?true:false);
     }
-    bool operator !=(const int &u) const {
+    GPU_DECL bool operator !=(const int &u) const {
       return ((data.value!=u)?true:false);
     }
-    bool operator >(const int &u) const {
+    GPU_DECL bool operator >(const int &u) const {
       return ((data.value>u)?true:false);
     }
-    bool operator <(const int &u) const {
+    GPU_DECL bool operator <(const int &u) const {
       return ((data.value<u)?true:false);
     }
-    bool operator >=(const int &u) const {
+    GPU_DECL bool operator >=(const int &u) const {
       return ((data.value>=u)?true:false);
     }
-    bool operator <=(const int &u) const {
+    GPU_DECL bool operator <=(const int &u) const {
       return ((data.value<=u)?true:false);
     }
-    bool operator ==(const float &u) const {
+    GPU_DECL bool operator ==(const float &u) const {
       return ((data.value==u)?true:false);
     }
-    bool operator !=(const float &u) const {
+    GPU_DECL bool operator !=(const float &u) const {
       return ((data.value!=u)?true:false);
     }
-    bool operator >(const float &u) const {
+    GPU_DECL bool operator >(const float &u) const {
       return ((data.value>u)?true:false);
     }
-    bool operator <(const float &u) const {
+    GPU_DECL bool operator <(const float &u) const {
       return ((data.value<u)?true:false);
     }
-    bool operator >=(const float &u) const {
+    GPU_DECL bool operator >=(const float &u) const {
       return ((data.value>=u)?true:false);
     }
-    bool operator <=(const float &u) const {
+    GPU_DECL bool operator <=(const float &u) const {
       return ((data.value<=u)?true:false);
     }
-    bool operator ==(const double &u) const {
+    GPU_DECL bool operator ==(const double &u) const {
       return ((data.value==u)?true:false);
     }
-    bool operator !=(const double &u) const {
+    GPU_DECL bool operator !=(const double &u) const {
       return ((data.value!=u)?true:false);
     }
-    bool operator  >(const double &u) const {
+    GPU_DECL bool operator  >(const double &u) const {
       return ((data.value>u)?true:false);
     }
-    bool operator <(const double &u) const {
+    GPU_DECL bool operator <(const double &u) const {
       return ((data.value<u)?true:false);
     }
-    bool operator >=(const double &u) const {
+    GPU_DECL bool operator >=(const double &u) const {
       return ((data.value>=u)?true:false);
     }
-    bool operator <=(const double &u) const {
+    GPU_DECL bool operator <=(const double &u) const {
       return ((data.value<=u)?true:false);
     }
-    bool operator ==(const long double &u) const {
+    GPU_DECL bool operator ==(const long double &u) const {
       return ((data.value==u)?true:false);
     }
-    bool operator !=(const long double &u) const {
+    GPU_DECL bool operator !=(const long double &u) const {
       return ((data.value!=u)?true:false);
     }
-    bool operator  >(const long double &u) const {
+    GPU_DECL bool operator  >(const long double &u) const {
       return ((data.value>u)?true:false);
     }
-    bool operator <(const long double &u) const {
+    GPU_DECL bool operator <(const long double &u) const {
       return ((data.value<u)?true:false);
     }
-    bool operator >=(const long double &u) const {
+    GPU_DECL bool operator >=(const long double &u) const {
       return ((data.value>=u)?true:false);
     }
-    bool operator <=(const long double &u) const {
+    GPU_DECL bool operator <=(const long double &u) const {
       return ((data.value<=u)?true:false);
     }
 
@@ -2390,14 +2391,14 @@ namespace Loci {
     return stream;
   }
 
-  inline double ceil(const VFAD u) {
+  inline GPU_DECL double ceil(const VFAD u) {
     return std::ceil(u.data.value) ;
   }
-  inline double floor(const VFAD u) {
+  inline GPU_DECL double floor(const VFAD u) {
     return std::floor(u.data.value) ;
   }
 
-  inline VFAD erf(const VFAD u) {
+  inline GPU_DECL VFAD erf(const VFAD u) {
     double ef = ::erf(u.data.value) ;
     double efp = (2./sqrt(M_PI))*std::exp(-u.data.value*u.data.value) ;
     VFAD tmp ;
@@ -2406,7 +2407,7 @@ namespace Loci {
       tmp.data.grad[i] = u.data.grad[i]*efp ;
     return tmp ;
   }
-  inline VFAD sin(const VFAD u) {
+  inline GPU_DECL VFAD sin(const VFAD u) {
     double su = std::sin(u.data.value) ;
     double cu = std::cos(u.data.value) ;
     VFAD tmp ;
@@ -2415,7 +2416,7 @@ namespace Loci {
       tmp.data.grad[i] = u.data.grad[i]*cu ;
     return tmp ;
   }
-  inline VFAD cos(const VFAD u) {
+  inline GPU_DECL VFAD cos(const VFAD u) {
     double su = std::sin(u.data.value) ;
     double cu = std::cos(u.data.value) ;
     VFAD tmp ;
@@ -2424,7 +2425,7 @@ namespace Loci {
       tmp.data.grad[i] = -u.data.grad[i]*su ;
     return tmp ;
   }
-  inline VFAD tan(const VFAD u) {
+  inline GPU_DECL VFAD tan(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::tan(u.data.value) ;
     double cu = std::cos(u.data.value) ;
@@ -2434,7 +2435,7 @@ namespace Loci {
     return tmp ;
   }
 
-  inline VFAD exp(const VFAD u) {
+  inline GPU_DECL VFAD exp(const VFAD u) {
     double expu = std::exp(u.data.value) ;
     VFAD tmp ;
     tmp.data.value = expu ;
@@ -2442,7 +2443,7 @@ namespace Loci {
       tmp.data.grad[i] = expu*u.data.grad[i] ;
     return tmp ;
   }
-  inline VFAD log(const VFAD u) {
+  inline GPU_DECL VFAD log(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::log(u.data.value) ;
     double rvalue = 1./u.data.value ;
@@ -2450,7 +2451,7 @@ namespace Loci {
       tmp.data.grad[i] =  u.data.grad[i]*rvalue ;
     return tmp ;
   }
-  inline VFAD log10(const VFAD u) {
+  inline GPU_DECL VFAD log10(const VFAD u) {
     VFAD tmp ;
     const double logof10 = std::log(10.0);
     tmp.data.value = std::log(u.data.value)/logof10 ;
@@ -2460,18 +2461,18 @@ namespace Loci {
     return tmp ;
     //    return VFAD(std::log(u.data.value), u.data.grad/u.data.value)/std::log(10.0);
   }
-  inline VFAD abs(const VFAD u) {
+  inline GPU_DECL VFAD abs(const VFAD u) {
     VFAD tmp(u) ;
     tmp *= (u.data.value<0.0)?-1.0:1.0 ;
     return tmp ;
   }
-  inline VFAD fabs(const VFAD u) {
+  inline GPU_DECL VFAD fabs(const VFAD u) {
     VFAD tmp(u) ;
     tmp *= (u.data.value<0.0)?-1.0:1.0 ;
     return tmp ;
   }
   /* MPGCOMMENT [05-12-2017 15:04] ---> POW */
-  inline VFAD pow(const VFAD u, const int k) {
+  inline GPU_DECL VFAD pow(const VFAD u, const int k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2480,7 +2481,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline VFAD pow(const VFAD u, const float k) {
+  inline GPU_DECL VFAD pow(const VFAD u, const float k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2489,7 +2490,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline VFAD pow(const VFAD u, const double k) {
+  inline GPU_DECL VFAD pow(const VFAD u, const double k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2498,7 +2499,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline VFAD pow(const VFAD u, const long double k) {
+  inline GPU_DECL VFAD pow(const VFAD u, const long double k) {
     double pk = std::pow(u.data.value,k) ;
     double pkm1 = std::pow(u.data.value,k-1) ;
     VFAD tmp ;
@@ -2507,7 +2508,7 @@ namespace Loci {
       tmp.data.grad[i] = double(k)*pkm1*u.data.grad[i] ;
     return tmp ;
   }
-  inline VFAD sqrt(const VFAD u) {
+  inline GPU_DECL VFAD sqrt(const VFAD u) {
     double su = std::sqrt(u.data.value) ;
     VFAD tmp ;
     tmp.data.value = su ;
@@ -2515,7 +2516,7 @@ namespace Loci {
       tmp.data.grad[i] = 0.5*u.data.grad[i]/max(su,1e-30) ;
     return tmp ;
   }
-  inline VFAD pow(const VFAD k, const VFAD u) {
+  inline GPU_DECL VFAD pow(const VFAD k, const VFAD u) {
     double kpu = std::pow(k.data.value,u.data.value) ;
     double kpum1 = std::pow(k.data.value,u.data.value-1.) ;
     double logk = std::log(k.data.value) ;
@@ -2528,7 +2529,7 @@ namespace Loci {
     //    return VFAD(kpu,std::pow(k.data.value,u.data.value-1.)*k.grad*u.data.value +
     //                kpu*std::log(k.data.value)*u.grad) ;
   }
-  inline VFAD pow(const int k, const VFAD u) {
+  inline GPU_DECL VFAD pow(const int k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2539,7 +2540,7 @@ namespace Loci {
     //    double kpu = std::pow(k,u.data.value) ;
     //    return VFAD(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline VFAD pow(const float k, const VFAD u) {
+  inline GPU_DECL VFAD pow(const float k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2550,7 +2551,7 @@ namespace Loci {
     //    double kpu = std::pow(double(k),u.data.value) ;
     //    return VFAD(kpu,kpu*std::log(double(k))*u.grad) ;
   }
-  inline VFAD pow(const double k, const VFAD u) {
+  inline GPU_DECL VFAD pow(const double k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2561,7 +2562,7 @@ namespace Loci {
     //    double kpu = std::pow(k,u.data.value) ;
     //    return VFAD(kpu,kpu*std::log(k)*u.grad) ;
   }
-  inline VFAD pow(const long double k, const VFAD u) {
+  inline GPU_DECL VFAD pow(const long double k, const VFAD u) {
     double kpu = std::pow(k,u.data.value) ;
     double logk = std::log(k) ;
     VFAD tmp ;
@@ -2574,7 +2575,7 @@ namespace Loci {
   }
 
 
-  inline VFAD sinh(const VFAD u) {
+  inline GPU_DECL VFAD sinh(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::sinh(u.data.value) ;
     double expu = std::exp(u.data.value) ;
@@ -2585,7 +2586,7 @@ namespace Loci {
     //    return VFAD(std::sinh(u.data.value),
     //                0.5*u.grad*(std::exp(u.data.value) + std::exp(-u.data.value))) ;
   }
-  inline VFAD cosh(const VFAD u) {
+  inline GPU_DECL VFAD cosh(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::cosh(u.data.value) ;
     double expu = std::exp(u.data.value) ;
@@ -2596,7 +2597,7 @@ namespace Loci {
     //    return VFAD(std::cosh(u.data.value),
     //                0.5*u.grad*(std::exp(u.data.value) - std::exp(-u.data.value))) ;
   }
-  inline VFAD tanh(const VFAD u) {
+  inline GPU_DECL VFAD tanh(const VFAD u) {
     double ex = std::exp(std::min(u.data.value,350.0)) ;
     double exm = std::exp(std::min(-u.data.value,350.0)) ;
     double dex = ex-exm ;
@@ -2611,7 +2612,7 @@ namespace Loci {
     //                u.grad*(1.-dex*dex/(sex*sex))) ;
   }
 
-  inline VFAD asin(const VFAD u) {
+  inline GPU_DECL VFAD asin(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::asin(u.data.value) ;
     double factor = 1./std::sqrt(1.0-u.data.value*u.data.value) ;
@@ -2620,7 +2621,7 @@ namespace Loci {
     return tmp ;
     //    return VFAD(std::asin(u.data.value), u.grad/std::sqrt(1.0-u.data.value*u.data.value) );
   }
-  inline VFAD acos(const VFAD u) {
+  inline GPU_DECL VFAD acos(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::acos(u.data.value) ;
     double factor = -1./std::sqrt(1.0-u.data.value*u.data.value) ;
@@ -2629,7 +2630,7 @@ namespace Loci {
     return tmp ;
     //return VFAD(std::acos(u.data.value), -u.grad/std::sqrt(1.0-u.data.value*u.data.value) );
   }
-  inline VFAD atan(const VFAD u) {
+  inline GPU_DECL VFAD atan(const VFAD u) {
     VFAD tmp ;
     tmp.data.value = std::atan(u.data.value) ;
     double factor = 1./(1.0+u.data.value*u.data.value) ;
@@ -2639,11 +2640,11 @@ namespace Loci {
     //    return VFAD(std::atan(u.data.value), u.grad/(1.0+u.data.value*u.data.value) );
   }
   // This will not work in general
-  inline VFAD atan2(const VFAD u, const VFAD v) {
+  inline GPU_DECL VFAD atan2(const VFAD u, const VFAD v) {
     return atan(u/v);
   }
 
-  inline VFAD asinh(const VFAD u) {
+  inline GPU_DECL VFAD asinh(const VFAD u) {
     double strm = std::sqrt(u.data.value*u.data.value+1.) ;
     double uvstrm = u.data.value+strm ;
     VFAD tmp ;
@@ -2654,7 +2655,7 @@ namespace Loci {
     return tmp ;
   //return VFAD(::asinh(u.data.value), u.grad*(u.data.value/strm+1.)/uvstrm) ;
   }
-  inline VFAD acosh(const VFAD u) {
+  inline GPU_DECL VFAD acosh(const VFAD u) {
     double strm = std::sqrt(u.data.value*u.data.value-1.) ;
     double uvstrm = u.data.value+strm ;
     VFAD tmp ;
@@ -2665,7 +2666,7 @@ namespace Loci {
     return tmp ;
     //    return VFAD(::acosh(u.data.value), u.grad*(u.data.value/strm +1.)/uvstrm) ;
   }
-  inline VFAD atanh(const VFAD u) {
+  inline GPU_DECL VFAD atanh(const VFAD u) {
     const double uv = u.data.value ;
     VFAD tmp ;
     tmp.data.value = ::atanh(uv) ;
@@ -2676,31 +2677,31 @@ namespace Loci {
   //    return VFAD(::atanh(uv), .5*u.grad*(1./(1.+uv)+1./(1.-uv))) ;
   }
 
-  inline VFAD operator +(const double u,const VFAD v)
+  inline GPU_DECL VFAD operator +(const double u,const VFAD v)
   { return VFAD(u) + v ; }
-  inline VFAD operator -(const double u,const VFAD v)
+  inline GPU_DECL VFAD operator -(const double u,const VFAD v)
   { return VFAD(u) - v ; }
-  inline VFAD operator *(const double u,const VFAD v)
+  inline GPU_DECL VFAD operator *(const double u,const VFAD v)
   { return VFAD(u)*v ; }
-  inline VFAD operator /(const double &u,const VFAD &v)
+  inline GPU_DECL VFAD operator /(const double &u,const VFAD &v)
   { return VFAD(u)/v ; }
 
   
   //----------------helpers
-  inline float realToFloat(double v) { return float(v) ; }
-  inline double realToDouble(double v) { return v ; }
+  inline GPU_DECL float realToFloat(double v) { return float(v) ; }
+  inline GPU_DECL double realToDouble(double v) { return v ; }
 
-  inline float realToFloat(const FADd &v) { return float(v.value) ; }
-  inline double realToDouble(const FADd &v) { return v.value ; }
+  inline GPU_DECL float realToFloat(const FADd &v) { return float(v.value) ; }
+  inline GPU_DECL double realToDouble(const FADd &v) { return v.value ; }
 
-  inline float realToFloat(const FAD2d &v) { return float(v.value) ; }
-  inline double realToDouble(const FAD2d &v) { return v.value ; }
+  inline GPU_DECL float realToFloat(const FAD2d &v) { return float(v.value) ; }
+  inline GPU_DECL double realToDouble(const FAD2d &v) { return v.value ; }
 
-  inline float realToFloat(const MFADd &v) { return float(v.value) ; }
-  inline double realToDouble(const MFADd &v) { return v.value ; }
+  inline GPU_DECL float realToFloat(const MFADd &v) { return float(v.value) ; }
+  inline GPU_DECL double realToDouble(const MFADd &v) { return v.value ; }
 
-  inline float realToFloat(const VFAD &v) { return float(v.data.value) ; }
-  inline double realToDouble(const VFAD &v) { return v.data.value ; }
+  inline GPU_DECL float realToFloat(const VFAD &v) { return float(v.data.value) ; }
+  inline GPU_DECL double realToDouble(const VFAD &v) { return v.data.value ; }
 
 }
 

--- a/src/include/Tools/basic_types.h
+++ b/src/include/Tools/basic_types.h
@@ -39,6 +39,7 @@
 #include <Tools/parse.h>
 #include <Tools/expr.h>
 #include <Tools/unit_type.h>
+#include <Tools/gpu_attr.h>
 
 namespace Loci {
 
@@ -73,24 +74,24 @@ namespace Loci {
   template<typename T, typename Op >
   struct ArrayUnaryC{
     const Op op1;
-    ArrayUnaryC(const Op& a): op1(a) {}
-    T operator[](const size_t i) const { return -op1[i] ;  }
+    GPU_DECL ArrayUnaryC(const Op& a): op1(a) {}
+    GPU_DECL T operator[](const size_t i) const { return -op1[i] ;  }
   } ;
   // base version of unary operator
   template <typename T, typename Op>
   struct ArrayUnaryB{
     const Op &op1;
-    ArrayUnaryB(const Op& a): op1(a) {}
-    T operator[](const size_t i) const { return -op1[i] ;  }
+    GPU_DECL ArrayUnaryB(const Op& a): op1(a) {}
+    GPU_DECL T operator[](const size_t i) const { return -op1[i] ;  }
   } ;
 
   template <typename T, typename Op>
   struct ArrayOperator {
     const Op op ;
-    ArrayOperator(const Op &t):op(t) {}
-    T operator[](const size_t i) const { return op[i]; }
-    const Op &data() const { return op; }
-    ArrayOperator<T,ArrayUnaryC<T,Op> > operator-() const { return ArrayOperator<T,ArrayUnaryC<T,Op> >(op) ; }
+    GPU_DECL ArrayOperator(const Op &t):op(t) {}
+    GPU_DECL T operator[](const size_t i) const { return op[i]; }
+    GPU_DECL const Op &data() const { return op; }
+    GPU_DECL ArrayOperator<T,ArrayUnaryC<T,Op> > operator-() const { return ArrayOperator<T,ArrayUnaryC<T,Op> >(op) ; }
   } ;
 
   //---------------------------------------------------------------------------
@@ -101,16 +102,16 @@ namespace Loci {
   struct ArrayAdd{
     const Op1& op1;
     const Op2& op2;
-    ArrayAdd(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
+    GPU_DECL ArrayAdd(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
   } ;
   // Case where left argument of add is a temporary (thus we need to copy)
   template<typename T, typename Op1 , typename Op2>
   struct ArrayAddL{
     const Op1 op1;
     const Op2& op2;
-    ArrayAddL(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
+    GPU_DECL ArrayAddL(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
   } ;
 
   // case where right argument of add is a temporary (thus we need to copy)
@@ -118,16 +119,16 @@ namespace Loci {
   struct ArrayAddR{
     const Op1 &op1;
     const Op2 op2;
-    ArrayAddR(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
+    GPU_DECL ArrayAddR(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
   } ;
 
   template<typename T, typename Op1 , typename Op2>
   struct ArrayAddLR{
     const Op1 op1;
     const Op2 op2;
-    ArrayAddLR(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
+    GPU_DECL ArrayAddLR(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] + op2[i] ;  }
   } ;
   
   // Case where left side is a double constant
@@ -135,36 +136,36 @@ namespace Loci {
   struct ArrayAddLC {
     const double op1;
     const Op2& op2;
-    ArrayAddLC(const double& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1 + op2[i] ;  }
+    GPU_DECL ArrayAddLC(const double& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1 + op2[i] ;  }
   } ;
   // Case where right side is a double constant
   template<typename T, typename Op1 >
   struct ArrayAddRC{
     const Op1 &op1;
     const double op2;
-    ArrayAddRC(const Op1& a, const double &b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] + op2 ;  }
+    GPU_DECL ArrayAddRC(const Op1& a, const double &b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] + op2 ;  }
   } ;
 
   // General operators for packaged expressions
   // function template for the + operator
   template<typename T, typename R1, typename R2>
-  inline ArrayOperator<T, ArrayAddLR<T, R1, R2> >
+  inline GPU_DECL ArrayOperator<T, ArrayAddLR<T, R1, R2> >
   operator+ (const ArrayOperator<T, R1>& a, const ArrayOperator<T, R2>& b){
     return ArrayOperator<T, ArrayAddLR<T, R1, R2> >(ArrayAddLR<T, R1, R2 >(a.data(), b.data()));
   }
   // case where expression is added to a constant on the right
   // function template for the + operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArrayAddRC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArrayAddRC<T, R1> >
   operator+ (const ArrayOperator<T, R1>& a, const double& b){
     return ArrayOperator<T, ArrayAddRC<T, R1> >(ArrayAddRC<T, R1 >(a.data(), b));
   }
   // case where constant on the left is added to an expression
   // function template for the + operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArrayAddLC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArrayAddLC<T, R1> >
   operator+ (const double &a, const ArrayOperator<T, R1>& b){
     return ArrayOperator<T, ArrayAddLC<T, R1> >(ArrayAddLC<T, R1 >(a, b.data()));
   }
@@ -178,16 +179,16 @@ namespace Loci {
   struct ArraySub{
     const Op1& op1;
     const Op2& op2;
-    ArraySub(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
+    GPU_DECL ArraySub(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
   } ;
   // Case where left argument of add is a temporary (thus we need to copy)
   template<typename T, typename Op1 , typename Op2>
   struct ArraySubL{
     const Op1 op1;
     const Op2& op2;
-    ArraySubL(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
+    GPU_DECL ArraySubL(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
   } ;
 
   // case where right argument of add is a temporary (thus we need to copy)
@@ -195,52 +196,52 @@ namespace Loci {
   struct ArraySubR{
     const Op1 &op1;
     const Op2 op2;
-    ArraySubR(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
+    GPU_DECL ArraySubR(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
   } ;
 
   template<typename T, typename Op1 , typename Op2>
   struct ArraySubLR{
     const Op1 op1;
     const Op2 op2;
-    ArraySubLR(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
+    GPU_DECL ArraySubLR(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] - op2[i] ;  }
   } ;
   // Case where left side is a double constant
   template<typename T, typename Op2>
   struct ArraySubLC {
     const double op1;
     const Op2& op2;
-    ArraySubLC(const double& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1 - op2[i] ;  }
+    GPU_DECL ArraySubLC(const double& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1 - op2[i] ;  }
   } ;
   // Case where right side is a double constant
   template<typename T, typename Op1 >
   struct ArraySubRC{
     const Op1 &op1;
     const double op2;
-    ArraySubRC(const Op1& a, const double &b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] - op2 ;  }
+    GPU_DECL ArraySubRC(const Op1& a, const double &b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] - op2 ;  }
   } ;
 
   // General operators for packaged expressions
   // function template for the - operator
   template<typename T, typename R1, typename R2>
-  inline ArrayOperator<T, ArraySubLR<T, R1, R2> >
+  inline GPU_DECL ArrayOperator<T, ArraySubLR<T, R1, R2> >
   operator- (const ArrayOperator<T, R1>& a, const ArrayOperator<T, R2>& b){
     return ArrayOperator<T, ArraySubLR<T, R1, R2> >(ArraySubLR<T, R1, R2 >(a.data(), b.data()));
   }
   // case where expression is added to a constant on the right
   // function template for the - operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArraySubRC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArraySubRC<T, R1> >
   operator- (const ArrayOperator<T, R1>& a, const double& b){
     return ArrayOperator<T, ArraySubRC<T, R1> >(ArraySubRC<T, R1 >(a.data(), b));
   }
   // case where constant on the left is added to an expression
   // function template for the - operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArraySubLC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArraySubLC<T, R1> >
   operator- (const double &a, const ArrayOperator<T, R1>& b){
     return ArrayOperator<T, ArraySubLC<T, R1> >(ArraySubLC<T, R1 >(a, b.data()));
   }
@@ -253,16 +254,16 @@ namespace Loci {
   struct ArrayMul{
     const Op1& op1;
     const Op2& op2;
-    ArrayMul(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
+    GPU_DECL ArrayMul(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
   } ;
   // Case where left argument of add is a temporary (thus we need to copy)
   template<typename T, typename Op1 , typename Op2>
   struct ArrayMulL{
     const Op1 op1;
     const Op2& op2;
-    ArrayMulL(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
+    GPU_DECL ArrayMulL(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
   } ;
 
   // case where right argument of add is a temporary (thus we need to copy)
@@ -270,8 +271,8 @@ namespace Loci {
   struct ArrayMulR{
     const Op1 &op1;
     const Op2 op2;
-    ArrayMulR(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
+    GPU_DECL ArrayMulR(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
   } ;
 
   // case where right argument of add is a temporary (thus we need to copy)
@@ -279,8 +280,8 @@ namespace Loci {
   struct ArrayMulLR{
     const Op1 op1;
     const Op2 op2;
-    ArrayMulLR(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
+    GPU_DECL ArrayMulLR(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] * op2[i] ;  }
   } ;
 
   // Case where left side is a double constant
@@ -288,36 +289,36 @@ namespace Loci {
   struct ArrayMulLC {
     const double op1;
     const Op2& op2;
-    ArrayMulLC(const double& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1 * op2[i] ;  }
+    GPU_DECL ArrayMulLC(const double& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1 * op2[i] ;  }
   } ;
   // Case where right side is a double constant
   template<typename T, typename Op1 >
   struct ArrayMulRC{
     const Op1 &op1;
     const double op2;
-    ArrayMulRC(const Op1& a, const double &b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] * op2 ;  }
+    GPU_DECL ArrayMulRC(const Op1& a, const double &b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] * op2 ;  }
   } ;
 
   // General operators for packaged expressions
   // function template for the * operator
   template<typename T, typename R1, typename R2>
-  inline ArrayOperator<T, ArrayMulLR<T, R1, R2> >
+  inline GPU_DECL ArrayOperator<T, ArrayMulLR<T, R1, R2> >
   operator* (const ArrayOperator<T, R1>& a, const ArrayOperator<T, R2>& b){
     return ArrayOperator<T, ArrayMulLR<T, R1, R2> >(ArrayMulLR<T, R1, R2 >(a.data(), b.data()));
   }
   // case where expression is added to a constant on the right
   // function template for the * operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArrayMulRC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArrayMulRC<T, R1> >
   operator* (const ArrayOperator<T, R1>& a, const double& b){
     return ArrayOperator<T, ArrayMulRC<T, R1> >(ArrayMulRC<T, R1 >(a.data(), b));
   }
   // case where constant on the left is added to an expression
   // function template for the * operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArrayMulLC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArrayMulLC<T, R1> >
   operator* (const double &a, const ArrayOperator<T, R1>& b){
     return ArrayOperator<T, ArrayMulLC<T, R1> >(ArrayMulLC<T, R1 >(a, b.data()));
   }
@@ -330,16 +331,16 @@ namespace Loci {
   struct ArrayDiv{
     const Op1& op1;
     const Op2& op2;
-    ArrayDiv(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
+    GPU_DECL ArrayDiv(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
   } ;
   // Case where left argument of add is a temporary (thus we need to copy)
   template<typename T, typename Op1 , typename Op2>
   struct ArrayDivL{
     const Op1 op1;
     const Op2& op2;
-    ArrayDivL(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
+    GPU_DECL ArrayDivL(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
   } ;
 
   // case where right argument of add is a temporary (thus we need to copy)
@@ -347,15 +348,15 @@ namespace Loci {
   struct ArrayDivR{
     const Op1 &op1;
     const Op2 op2;
-    ArrayDivR(const Op1& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
+    GPU_DECL ArrayDivR(const Op1& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
   } ;
   template<typename T, typename Op1 , typename Op2>
   struct ArrayDivLR{
     const Op1 op1;
     const Op2 op2;
-    ArrayDivLR(const Op1& a, const Op2& b): op1(a), op2(b) {}
-    T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
+    GPU_DECL ArrayDivLR(const Op1& a, const Op2& b): op1(a), op2(b) {}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] / op2[i] ;  }
   } ;
 
   // Case where left side is a double constant
@@ -363,36 +364,36 @@ namespace Loci {
   struct ArrayDivLC {
     const double op1;
     const Op2& op2;
-    ArrayDivLC(const double& a, const Op2& b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1 / op2[i] ;  }
+    GPU_DECL ArrayDivLC(const double& a, const Op2& b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1 / op2[i] ;  }
   } ;
   // Case where right side is a double constant
   template<typename T, typename Op1 >
   struct ArrayDivRC{
     const Op1 &op1;
     const double op2;
-    ArrayDivRC(const Op1& a, const double &b): op1(a), op2(b){}
-    T operator[](const size_t i) const { return op1[i] / op2 ;  }
+    GPU_DECL ArrayDivRC(const Op1& a, const double &b): op1(a), op2(b){}
+    GPU_DECL T operator[](const size_t i) const { return op1[i] / op2 ;  }
   } ;
 
   // General operators for packaged expressions
   // function template for the / operator
   template<typename T, typename R1, typename R2>
-  inline ArrayOperator<T, ArrayDivLR<T, R1, R2> >
+  inline GPU_DECL ArrayOperator<T, ArrayDivLR<T, R1, R2> >
   operator/ (const ArrayOperator<T, R1>& a, const ArrayOperator<T, R2>& b){
     return ArrayOperator<T, ArrayDivLR<T, R1, R2> >(ArrayDivLR<T, R1, R2 >(a.data(), b.data()));
   }
   // case where expression is added to a constant on the right
   // function template for the / operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArrayDivRC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArrayDivRC<T, R1> >
   operator/ (const ArrayOperator<T, R1>& a, const double& b){
     return ArrayOperator<T, ArrayDivRC<T, R1> >(ArrayDivRC<T, R1 >(a.data(), b));
   }
   // case where constant on the left is added to an expression
   // function template for the / operator
   template<typename T, typename R1>
-  inline ArrayOperator<T, ArrayDivLC<T, R1> >
+  inline GPU_DECL ArrayOperator<T, ArrayDivLC<T, R1> >
   operator/ (const double &a, const ArrayOperator<T, R1>& b){
     return ArrayOperator<T, ArrayDivLC<T, R1> >(ArrayDivLC<T, R1 >(a, b.data()));
   }
@@ -1116,68 +1117,68 @@ namespace Loci {
     Array() = default ;
     // constructor to create an array initialized to a single value
     explicit Array(const T &v) { for(size_t i=0;i<n;++i) x[i] = v ; }
-    Array<T,n> &operator=(const T &v) {
+    GPU_DECL Array<T,n> &operator=(const T &v) {
       for(size_t i=0;i<n;++i)
 	x[i] = v ;
       return *this ;
     }
     // Expression template interface for unary operator
-    ArrayOperator<T,ArrayUnaryB<T,Array<T,n> > > operator-() {
+    GPU_DECL ArrayOperator<T,ArrayUnaryB<T,Array<T,n> > > operator-() {
       return ArrayOperator<T,ArrayUnaryB<T,Array<T,n> > >(ArrayUnaryB<T,Array<T,n> >(*this)) ;
     }
 						       
     // Expression template loop hoisting for assignment operators
-    template <typename R> Array<T,n> &operator=(const ArrayOperator<T,R> &v) {
+    template <typename R> GPU_DECL Array<T,n> &operator=(const ArrayOperator<T,R> &v) {
       for(size_t i=0;i<n;++i) {
 	x[i] = v[i];
       }
       return *this ;
     }
-    template <typename R> Array<T,n> &operator+=(const ArrayOperator<T,R> &v) {
+    template <typename R> GPU_DECL Array<T,n> &operator+=(const ArrayOperator<T,R> &v) {
       for(size_t i=0;i<n;++i)
 	x[i] += v[i];
       return *this ;
     }
-    template <typename R> Array<T,n> &operator-=(const ArrayOperator<T,R> &v) {
+    template <typename R> GPU_DECL Array<T,n> &operator-=(const ArrayOperator<T,R> &v) {
       for(size_t i=0;i<n;++i)
 	x[i] -= v[i];
       return *this ;
     }
-    template <typename R> Array<T,n> &operator*=(const ArrayOperator<T,R> &v) {
+    template <typename R> GPU_DECL Array<T,n> &operator*=(const ArrayOperator<T,R> &v) {
       for(size_t i=0;i<n;++i)
 	x[i] *= v[i];
       return *this ;
     }
-    template <typename R> Array<T,n> &operator/=(const ArrayOperator<T,R> &v) {
+    template <typename R> GPU_DECL Array<T,n> &operator/=(const ArrayOperator<T,R> &v) {
       for(size_t i=0;i<n;++i)
 	x[i] /= v[i];
       return *this ;
     }
 
-    Array<T,n> &operator +=(const Array<T,n> &v)
+    GPU_DECL Array<T,n> &operator +=(const Array<T,n> &v)
     { for(size_t i=0;i<n;++i) x[i] += v.x[i] ; return *this ; }
-    Array<T,n> &operator -=(const Array<T,n> &v)
+    GPU_DECL Array<T,n> &operator -=(const Array<T,n> &v)
     { for(size_t i=0;i<n;++i) x[i] -= v.x[i] ; return *this ; }
-    Array<T,n> &operator *=(const Array<T,n> &v)
+    GPU_DECL Array<T,n> &operator *=(const Array<T,n> &v)
     { for(size_t i=0;i<n;++i) x[i] *= v.x[i] ; return *this ; }
-    Array<T,n> &operator /=(const Array<T,n> &v)
+    GPU_DECL Array<T,n> &operator /=(const Array<T,n> &v)
     { for(size_t i=0;i<n;++i) x[i] /= v.x[i] ; return *this ; }
 
-    T &operator[](size_t indx) { return x[indx]; }
-    const T &operator[](size_t indx) const { return x[indx] ; }
-    T &operator[](int indx) { return x[indx]; }
-    const T &operator[](int indx) const { return x[indx] ; }
-    T &operator[](unsigned char indx) { return x[indx]; }
-    const T &operator[](unsigned char indx) const { return x[indx] ; }
-    T &operator[](unsigned int indx) { return x[indx]; }
-    const T &operator[](unsigned int indx) const { return x[indx] ; }
+    GPU_DECL T &operator[](size_t indx) { return x[indx]; }
+    GPU_DECL const T &operator[](size_t indx) const { return x[indx] ; }
+    GPU_DECL T &operator[](int indx) { return x[indx]; }
+    GPU_DECL const T &operator[](int indx) const { return x[indx] ; }
+    GPU_DECL T &operator[](unsigned char indx) { return x[indx]; }
+    GPU_DECL const T &operator[](unsigned char indx) const { return x[indx] ; }
+    GPU_DECL T &operator[](unsigned int indx) { return x[indx]; }
+    GPU_DECL const T &operator[](unsigned int indx) const { return x[indx] ; }
 
-    iterator begin() { return &x[0] ; }
-    iterator end() { return begin()+n ; }
-    const_iterator begin() const { return &x[0] ; }
-    const_iterator end() const { return begin()+n ; }
+    GPU_DECL iterator begin() { return &x[0] ; }
+    GPU_DECL iterator end() { return begin()+n ; }
+    GPU_DECL const_iterator begin() const { return &x[0] ; }
+    GPU_DECL const_iterator end() const { return begin()+n ; }
 
-    size_t size() const  { return n ; }
+    GPU_DECL size_t size() const  { return n ; }
     
   } ;
 
@@ -1191,32 +1192,32 @@ namespace Loci {
   // Summation
   // Operator for the sum of two arrays
   template<typename T, size_t n>
-  inline ArrayOperator<T, ArrayAdd<T,Array<T,n>,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T, ArrayAdd<T,Array<T,n>,Array<T,n> > >
   operator+ (const Array<T, n>& a, const Array<T, n>& b){
     return ArrayOperator<T, ArrayAdd<T, Array<T,n>, Array<T,n> > >(ArrayAdd<T, Array<T,n>, Array<T,n> >(a, b));
   }
   // Adding an expression to an array
   template<typename T, size_t n, typename R>
-  inline ArrayOperator<T,ArrayAddL<T,R,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayAddL<T,R,Array<T,n> > >
   operator+(const R &a, const Array<T,n> &b) {
     return ArrayOperator<T,ArrayAddL<T,R,Array<T,n> > >(ArrayAddL<T,R,Array<T,n> >(a.data(),b)) ;
   }
   // Adding an array to an expression
   template<typename T, size_t n,typename R >
-  inline ArrayOperator<T,ArrayAddR<T,Array<T,n>,R > >
+  inline GPU_DECL ArrayOperator<T,ArrayAddR<T,Array<T,n>,R > >
   operator+(const Array<T,n> &a, const  R &b) {
     return ArrayOperator<T,ArrayAddR<T,Array<T,n>,R > >(ArrayAddR<T,Array<T,n>,R>(a,b.data())) ;
   }
   // Operator for constant + array
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArrayAddLC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayAddLC<T,Array<T,n> > >
   operator+(const double a, const Array<T,n> &b) {
     return ArrayOperator<T,ArrayAddLC<T,Array<T,n> > >(ArrayAddLC<T,Array<T,n> >(a,b)) ;
   }
 
   // Operator for array + constant
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArrayAddRC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayAddRC<T,Array<T,n> > >
   operator+(const Array<T,n> &a, const  double b) {
     return ArrayOperator<T,ArrayAddRC<T,Array<T,n> > >(ArrayAddRC<T,Array<T,n> >(a,b)) ;
   }
@@ -1224,32 +1225,32 @@ namespace Loci {
   // Subtraction
   // Operator for the sum of two arrays
   template<typename T, size_t n>
-  inline ArrayOperator<T, ArraySub<T,Array<T,n>,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T, ArraySub<T,Array<T,n>,Array<T,n> > >
   operator- (const Array<T, n>& a, const Array<T, n>& b){
     return ArrayOperator<T, ArraySub<T, Array<T,n>, Array<T,n> > >(ArraySub<T, Array<T,n>, Array<T,n> >(a, b));
   }
   // Subing an expression to an array
   template<typename T, size_t n, typename R>
-  inline ArrayOperator<T,ArraySubL<T,R,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArraySubL<T,R,Array<T,n> > >
   operator-(const R &a, const Array<T,n> &b) {
     return ArrayOperator<T,ArraySubL<T,R,Array<T,n> > >(ArraySubL<T,R,Array<T,n> >(a.data(),b)) ;
   }
   // Subing an array to an expression
   template<typename T, size_t n,typename R >
-  inline ArrayOperator<T,ArraySubR<T,Array<T,n>,R > >
+  inline GPU_DECL ArrayOperator<T,ArraySubR<T,Array<T,n>,R > >
   operator-(const Array<T,n> &a, const  R &b) {
     return ArrayOperator<T,ArraySubR<T,Array<T,n>,R > >(ArraySubR<T,Array<T,n>,R>(a,b.data())) ;
   }
   // Operator for constant - array
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArraySubLC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArraySubLC<T,Array<T,n> > >
   operator-(const double a, const Array<T,n> &b) {
     return ArrayOperator<T,ArraySubLC<T,Array<T,n> > >(ArraySubLC<T,Array<T,n> >(a,b)) ;
   }
 
   // Operator for array - constant
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArraySubRC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArraySubRC<T,Array<T,n> > >
   operator-(const Array<T,n> &a, const  double b) {
     return ArrayOperator<T,ArraySubRC<T,Array<T,n> > >(ArraySubRC<T,Array<T,n> >(a,b)) ;
   }
@@ -1257,32 +1258,32 @@ namespace Loci {
   // Multiplication
   // Operator for the sum of two arrays
   template<typename T, size_t n>
-  inline ArrayOperator<T, ArrayMul<T,Array<T,n>,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T, ArrayMul<T,Array<T,n>,Array<T,n> > >
   operator* (const Array<T, n>& a, const Array<T, n>& b){
     return ArrayOperator<T, ArrayMul<T, Array<T,n>, Array<T,n> > >(ArrayMul<T, Array<T,n>, Array<T,n> >(a, b));
   }
   // Muling an expression to an array
   template<typename T, size_t n, typename R>
-  inline ArrayOperator<T,ArrayMulL<T,R,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayMulL<T,R,Array<T,n> > >
   operator*(const R &a, const Array<T,n> &b) {
     return ArrayOperator<T,ArrayMulL<T,R,Array<T,n> > >(ArrayMulL<T,R,Array<T,n> >(a.data(),b)) ;
   }
   // Muling an array to an expression
   template<typename T, size_t n,typename R >
-  inline ArrayOperator<T,ArrayMulR<T,Array<T,n>,R > >
+  inline GPU_DECL ArrayOperator<T,ArrayMulR<T,Array<T,n>,R > >
   operator*(const Array<T,n> &a, const  R &b) {
     return ArrayOperator<T,ArrayMulR<T,Array<T,n>,R > >(ArrayMulR<T,Array<T,n>,R>(a,b.data())) ;
   }
   // Operator for constant * array
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArrayMulLC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayMulLC<T,Array<T,n> > >
   operator*(const double a, const Array<T,n> &b) {
     return ArrayOperator<T,ArrayMulLC<T,Array<T,n> > >(ArrayMulLC<T,Array<T,n> >(a,b)) ;
   }
 
   // Operator for array * constant
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArrayMulRC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayMulRC<T,Array<T,n> > >
   operator*(const Array<T,n> &a, const  double b) {
     return ArrayOperator<T,ArrayMulRC<T,Array<T,n> > >(ArrayMulRC<T,Array<T,n> >(a,b)) ;
   }
@@ -1291,32 +1292,32 @@ namespace Loci {
   // Division
   // Operator for the sum of two arrays
   template<typename T, size_t n>
-  inline ArrayOperator<T, ArrayDiv<T,Array<T,n>,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T, ArrayDiv<T,Array<T,n>,Array<T,n> > >
   operator/ (const Array<T, n>& a, const Array<T, n>& b){
     return ArrayOperator<T, ArrayDiv<T, Array<T,n>, Array<T,n> > >(ArrayDiv<T, Array<T,n>, Array<T,n> >(a, b));
   }
   // Diving an expression to an array
   template<typename T, size_t n, typename R>
-  inline ArrayOperator<T,ArrayDivL<T,R,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayDivL<T,R,Array<T,n> > >
   operator/(const R &a, const Array<T,n> &b) {
     return ArrayOperator<T,ArrayDivL<T,R,Array<T,n> > >(ArrayDivL<T,R,Array<T,n> >(a.data(),b)) ;
   }
   // Diving an array to an expression
   template<typename T, size_t n,typename R >
-  inline ArrayOperator<T,ArrayDivR<T,Array<T,n>,R > >
+  inline GPU_DECL ArrayOperator<T,ArrayDivR<T,Array<T,n>,R > >
   operator/(const Array<T,n> &a, const  R &b) {
     return ArrayOperator<T,ArrayDivR<T,Array<T,n>,R > >(ArrayDivR<T,Array<T,n>,R>(a,b.data())) ;
   }
   // Operator for constant / array
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArrayDivLC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayDivLC<T,Array<T,n> > >
   operator/(const double a, const Array<T,n> &b) {
     return ArrayOperator<T,ArrayDivLC<T,Array<T,n> > >(ArrayDivLC<T,Array<T,n> >(a,b)) ;
   }
 
   // Operator for array / constant
   template<typename T, size_t n >
-  inline ArrayOperator<T,ArrayDivRC<T,Array<T,n> > >
+  inline GPU_DECL ArrayOperator<T,ArrayDivRC<T,Array<T,n> > >
   operator/(const Array<T,n> &a, const  double b) {
     return ArrayOperator<T,ArrayDivRC<T,Array<T,n> > >(ArrayDivRC<T,Array<T,n> >(a,b)) ;
   }
@@ -1560,10 +1561,10 @@ namespace Loci {
   template <class T> 
   struct vector3d {
     T x,y,z ;
-    vector3d() =default ;
-    vector3d(const vector3d &v): x(v.x),y(v.y),z(v.z) {}
-    vector3d(T xx,T yy, T zz) : x(xx),y(yy),z(zz) {}
-    template <class S> vector3d(const vector3d<S> &v): x(v.x),y(v.y),z(v.z) {}
+    vector3d() = default ;
+    GPU_DECL vector3d(const vector3d &v): x(v.x),y(v.y),z(v.z) {}
+    GPU_DECL vector3d(T xx,T yy, T zz) : x(xx),y(yy),z(zz) {}
+    template <class S> GPU_DECL vector3d(const vector3d<S> &v): x(v.x),y(v.y),z(v.z) {}
     //    template <class S> vector3d(const Array<S,3> &a) {x=a[0];y=a[1];z=a[2];}
     // template <class S> operator Array<S,3>() {
     //   Array<S,3> a ;
@@ -1572,8 +1573,8 @@ namespace Loci {
     //   a[2] = z ;
     //   return a;
     // }
-    T &operator[](size_t i) { FATAL(i>2) ; return (&x)[i] ; }
-    const T &operator[](size_t i) const { FATAL(i>2) ; return (&x)[i] ; }
+    GPU_DECL T &operator[](size_t i) { FATAL(i>2) ; return (&x)[i] ; }
+    GPU_DECL const T &operator[](size_t i) const { FATAL(i>2) ; return (&x)[i] ; }
   } ;
   
   template <class T> inline std::ostream & operator<<(std::ostream &s, const vector3d<T> &v)
@@ -1588,91 +1589,91 @@ namespace Loci {
     return s ;
   }
 
-  template <class T> inline T dot(const vector3d<T> &v1, const vector3d<T> &v2) {
+  template <class T> inline GPU_DECL T dot(const vector3d<T> &v1, const vector3d<T> &v2) {
     return v1.x*v2.x + v1.y*v2.y + v1.z*v2.z ;
   }
 
-  template <class T> inline T norm(const vector3d<T> &v) {
+  template <class T> inline GPU_DECL T norm(const vector3d<T> &v) {
     return sqrt(v.x*v.x+v.y*v.y+v.z*v.z) ;
   }
 
-  template<class T> inline vector3d<T> cross(const vector3d<T> &v1, const vector3d<T> &v2) {
+  template<class T> inline GPU_DECL vector3d<T> cross(const vector3d<T> &v1, const vector3d<T> &v2) {
     return vector3d<T>(v1.y*v2.z-v1.z*v2.y,
                        v1.z*v2.x-v1.x*v2.z,
                        v1.x*v2.y-v1.y*v2.x) ;
   }
 
-  template<class T> inline vector3d<T> cross(const vector3d<T> &v1, const T ra2[]) {
+  template<class T> inline GPU_DECL vector3d<T> cross(const vector3d<T> &v1, const T ra2[]) {
     return vector3d<T>(v1.y*ra2[2]-v1.z*ra2[1],
                        v1.z*ra2[0]-v1.x*ra2[2],
                        v1.x*ra2[1]-v1.y*ra2[0]) ;
   }
-  template<class T> inline vector3d<T> cross(const T ra1[], const vector3d<T> &v2) {
+  template<class T> inline GPU_DECL vector3d<T> cross(const T ra1[], const vector3d<T> &v2) {
     return vector3d<T>(ra1[1]*v2.z-ra1[2]*v2.y,
                        ra1[2]*v2.x-ra1[0]*v2.z,
                        ra1[0]*v2.y-ra1[1]*v2.x) ;
   }
 
-  template<class T,class S> inline vector3d<T> &operator*=(vector3d<T> &target, S val) {
+  template<class T,class S> inline GPU_DECL vector3d<T> &operator*=(vector3d<T> &target, S val) {
     target.x *= val ;
     target.y *= val ;
     target.z *= val ;
     return target ;
   }
 
-  template<class T,class S> inline vector3d<T> &operator/=(vector3d<T> &target, S val) {
+  template<class T,class S> inline GPU_DECL vector3d<T> &operator/=(vector3d<T> &target, S val) {
     target.x /= val ;
     target.y /= val ;
     target.z /= val ;
     return target ;
   }
   
-  template<class T> inline vector3d<T> operator+=(vector3d<T> &target, const vector3d<T> &val) {
+  template<class T> inline GPU_DECL vector3d<T> operator+=(vector3d<T> &target, const vector3d<T> &val) {
     target.x += val.x ;
     target.y += val.y ;
     target.z += val.z ;
     return target ;
   }
 
-  template<class T> inline vector3d<T> operator-=(vector3d<T> &target, const vector3d<T> &val) {
+  template<class T> inline GPU_DECL vector3d<T> operator-=(vector3d<T> &target, const vector3d<T> &val) {
     target.x -= val.x ;
     target.y -= val.y ;
     target.z -= val.z ;
     return target ;
   }
 
-  template<class T> inline vector3d<T> operator+(const vector3d<T> &v1, const vector3d<T> &v2) {
+  template<class T> inline GPU_DECL vector3d<T> operator+(const vector3d<T> &v1, const vector3d<T> &v2) {
     return vector3d<T>(v1.x+v2.x,v1.y+v2.y,v1.z+v2.z) ;
   }
 
-  template<class T> inline vector3d<T> operator-(const vector3d<T> &v1, const vector3d<T> &v2) {
+  template<class T> inline GPU_DECL vector3d<T> operator-(const vector3d<T> &v1, const vector3d<T> &v2) {
     return vector3d<T>(v1.x-v2.x,v1.y-v2.y,v1.z-v2.z) ;
   }
 
-  template<class T,class S> inline vector3d<T> operator*(const vector3d<T> &v1, S r2) {
+  template<class T,class S> inline GPU_DECL vector3d<T> operator*(const vector3d<T> &v1, S r2) {
     return vector3d<T>(v1.x*r2,v1.y*r2,v1.z*r2) ;
   }
-  template<class T,class S> inline vector3d<T> operator*(S r1, const vector3d<T> &v2) {
+  template<class T,class S> inline GPU_DECL vector3d<T> operator*(S r1, const vector3d<T> &v2) {
     return vector3d<T>(v2.x*r1,v2.y*r1,v2.z*r1) ;
   }
 
-  template<class T,class S> inline vector3d<T> operator/(const vector3d<T> &v1, S r2) {
+  template<class T,class S> inline GPU_DECL vector3d<T> operator/(const vector3d<T> &v1, S r2) {
     return vector3d<T>(v1.x/r2,v1.y/r2,v1.z/r2) ;
   }
 
   template<class T>  struct tensor3d : public vector3d<vector3d< T > > {
     tensor3d() = default ;
-    tensor3d(vector3d<T> xx,vector3d<T> yy, vector3d<T> zz)
+    GPU_DECL tensor3d(vector3d<T> xx,vector3d<T> yy, vector3d<T> zz)
       : vector3d<vector3d< T> > (xx,yy,zz) {}
-    tensor3d(const tensor3d &v) : vector3d<vector3d< T> >(v) {}
+    GPU_DECL tensor3d(const tensor3d &v) : vector3d<vector3d< T> >(v) {}
   } ;
 
-  template<class T> inline vector3d<T> dot(const tensor3d<T> &t,
+  template<class T> inline GPU_DECL vector3d<T> dot(const tensor3d<T> &t,
                                            const vector3d<T> &v) {
     return vector3d<T>(dot(t.x,v),dot(t.y,v),dot(t.z,v)) ;
   }
 
-  template<class T> inline tensor3d<T> product(const tensor3d<T> &t1,
+  template<class T> inline GPU_DECL tensor3d<T> product(const tensor3d<T> &t1,
                                                const tensor3d<T> &t2) {
     tensor3d<T> temp ;
     temp.x.x = t1.x.x*t2.x.x+t1.x.y*t2.y.x+t1.x.z*t2.z.x ;
@@ -1690,22 +1691,22 @@ namespace Loci {
     return temp ;
   }
 
-  inline vector3d<float> realToFloat(vector3d<double> v) { return vector3d<float>(float(v.x),float(v.y),float(v.z)); }
-  inline vector3d<double> realToDouble(vector3d<double> v) { return v ; }
+  inline GPU_DECL vector3d<float> realToFloat(vector3d<double> v) { return vector3d<float>(float(v.x),float(v.y),float(v.z)); }
+  inline GPU_DECL vector3d<double> realToDouble(vector3d<double> v) { return v ; }
 
 
 #ifndef NO_AUTODIFF
-  inline vector3d<float> realToFloat(vector3d<MFADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline vector3d<double> realToDouble(vector3d<MFADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline GPU_DECL vector3d<float> realToFloat(vector3d<MFADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline GPU_DECL vector3d<double> realToDouble(vector3d<MFADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 
-  inline vector3d<float> realToFloat(vector3d<FADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline vector3d<double> realToDouble(vector3d<FADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline GPU_DECL vector3d<float> realToFloat(vector3d<FADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline GPU_DECL vector3d<double> realToDouble(vector3d<FADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 
-  inline vector3d<float> realToFloat(vector3d<FAD2d> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline vector3d<double> realToDouble(vector3d<FAD2d> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline GPU_DECL vector3d<float> realToFloat(vector3d<FAD2d> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline GPU_DECL vector3d<double> realToDouble(vector3d<FAD2d> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 
-  inline vector3d<float> realToFloat(vector3d<VFAD> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline vector3d<double> realToDouble(vector3d<VFAD> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline GPU_DECL vector3d<float> realToFloat(vector3d<VFAD> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline GPU_DECL vector3d<double> realToDouble(vector3d<VFAD> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 #endif
   
   //---------------------vector2d------------------//
@@ -1713,9 +1714,9 @@ namespace Loci {
   struct vector2d {
     T x,y ;
     vector2d() = default ; 
-    vector2d(T xx,T yy) : x(xx),y(yy) {}
-    vector2d(const vector2d &v) {x=v.x;y=v.y;}
-    T &operator[](int i) {
+    GPU_DECL vector2d(T xx,T yy) : x(xx),y(yy) {}
+    GPU_DECL vector2d(const vector2d &v) {x=v.x;y=v.y;}
+    GPU_DECL T &operator[](int i) {
       FATAL(i>1) ;
       switch(i) {
       case 0:
@@ -1726,7 +1727,7 @@ namespace Loci {
         return y ;
       }
     }
-    const T &operator[](int i) const {
+    GPU_DECL const T &operator[](int i) const {
       FATAL(i>1) ;
       switch(i) {
       case 0:
@@ -1751,68 +1752,68 @@ namespace Loci {
     return s ;
   }
 
-  template <class T> inline T dot(const vector2d<T> &v1, const vector2d<T> &v2) {
+  template <class T> inline GPU_DECL T dot(const vector2d<T> &v1, const vector2d<T> &v2) {
     return v1.x*v2.x + v1.y*v2.y ;
   }
 
-  template <class T> inline T dot(const vector2d<T> &v1, const T ra2[]) {
+  template <class T> inline GPU_DECL T dot(const vector2d<T> &v1, const T ra2[]) {
     return v1.x*ra2[0] + v1.y*ra2[1] ;
   }
 
-  template <class T> inline T norm(const vector2d<T> &v) {
+  template <class T> inline GPU_DECL T norm(const vector2d<T> &v) {
     return sqrt(v.x*v.x+v.y*v.y) ;
   }
 
-  template<class T> inline T cross(const vector2d<T> &v1, const vector2d<T> &v2) {
+  template<class T> inline GPU_DECL T cross(const vector2d<T> &v1, const vector2d<T> &v2) {
     return v1.x*v2.y-v1.y*v2.x ;
   }
 
-  template<class T> inline T cross(const vector2d<T> &v1, const T ra2[]) {
+  template<class T> inline GPU_DECL T cross(const vector2d<T> &v1, const T ra2[]) {
     return v1.x*ra2[1]-v1.y*ra2[0] ;
   }
 
 
-  template<class T,class S> inline vector2d<T> &operator*=(vector2d<T> &target, S val) {
+  template<class T,class S> inline GPU_DECL vector2d<T> &operator*=(vector2d<T> &target, S val) {
     target.x *= val ;
     target.y *= val ;
     return target ;
   }
 
-  template<class T,class S> inline vector2d<T> &operator/=(vector2d<T> &target, S val) {
+  template<class T,class S> inline GPU_DECL vector2d<T> &operator/=(vector2d<T> &target, S val) {
     target.x /= val ;
     target.y /= val ;
     return target ;
   }
 
-  template<class T> inline vector2d<T> operator+=(vector2d<T> &target, const vector2d<T> &val) {
+  template<class T> inline GPU_DECL vector2d<T> operator+=(vector2d<T> &target, const vector2d<T> &val) {
     target.x += val.x ;
     target.y += val.y ;
     return target ;
   }
 
-  template<class T> inline vector2d<T> operator-=(vector2d<T> &target, const vector2d<T> &val) {
+  template<class T> inline GPU_DECL vector2d<T> operator-=(vector2d<T> &target, const vector2d<T> &val) {
     target.x -= val.x ;
     target.y -= val.y ;
     return target ;
   }
 
-  template<class T> inline vector2d<T> operator+(const vector2d<T> &v1, const vector2d<T> &v2) {
+  template<class T> inline GPU_DECL vector2d<T> operator+(const vector2d<T> &v1, const vector2d<T> &v2) {
     return vector2d<T>(v1.x+v2.x,v1.y+v2.y) ;
   }
 
-  template<class T> inline vector2d<T> operator-(const vector2d<T> &v1, const vector2d<T> &v2) {
+  template<class T> inline GPU_DECL vector2d<T> operator-(const vector2d<T> &v1, const vector2d<T> &v2) {
     return vector2d<T>(v1.x-v2.x,v1.y-v2.y) ;
   }
 
-  template<class T,class S> inline vector2d<T> operator*(const vector2d<T> &v1, S r2) {
+  template<class T,class S> inline GPU_DECL vector2d<T> operator*(const vector2d<T> &v1, S r2) {
     return vector2d<T>(v1.x*r2,v1.y*r2) ;
   }
 
-  template<class T,class S> inline vector2d<T> operator*(S r1, const vector2d<T> &v2) {
+  template<class T,class S> inline GPU_DECL vector2d<T> operator*(S r1, const vector2d<T> &v2) {
     return vector2d<T>(v2.x*r1,v2.y*r1) ;
   }
 
-  template<class T,class S> inline vector2d<T> operator/(const vector2d<T> &v1, S r2) {
+  template<class T,class S> inline GPU_DECL vector2d<T> operator/(const vector2d<T> &v1, S r2) {
     return vector2d<T>(v1.x/r2,v1.y/r2) ;
   }
 
@@ -2321,31 +2322,31 @@ namespace Loci {
 
   /// Operator to set a variable to it zero value to be used inside of
   /// templated functions that need to initialize variables for summation
-  inline void setZero(double &val) { val = double(0) ; }
-  inline void setZero(long double &val) { val = (long double) 0 ; }
-  inline void setZero(float &val) { val = float(0) ; }
-  inline void setZero(int &val) { val = int(0) ; }
-  inline void setZero(unsigned int &val) { val = (unsigned int) 0 ; }
-  inline void setZero(long &val) { val = long(0) ; }
-  inline void setZero(unsigned long &val) { val = (unsigned long) 0 ; }
-  inline void setZero(short &val) { val = short(0) ; }
-  inline void setZero(unsigned short &val) { val = (unsigned short) 0 ; }
-  inline void setZero(char &val) { val = char(0) ; }
-  inline void setZero(unsigned char &val) { val = (unsigned char) 0 ; }
-  inline void setZero(bool &val) { val = false ; }
-  template<class T> inline void setZero(vector2d<T> &val) 
+  inline GPU_DECL void setZero(double &val) { val = double(0) ; }
+  inline GPU_DECL void setZero(long double &val) { val = (long double) 0 ; }
+  inline GPU_DECL void setZero(float &val) { val = float(0) ; }
+  inline GPU_DECL void setZero(int &val) { val = int(0) ; }
+  inline GPU_DECL void setZero(unsigned int &val) { val = (unsigned int) 0 ; }
+  inline GPU_DECL void setZero(long &val) { val = long(0) ; }
+  inline GPU_DECL void setZero(unsigned long &val) { val = (unsigned long) 0 ; }
+  inline GPU_DECL void setZero(short &val) { val = short(0) ; }
+  inline GPU_DECL void setZero(unsigned short &val) { val = (unsigned short) 0 ; }
+  inline GPU_DECL void setZero(char &val) { val = char(0) ; }
+  inline GPU_DECL void setZero(unsigned char &val) { val = (unsigned char) 0 ; }
+  inline GPU_DECL void setZero(bool &val) { val = false ; }
+  template<class T> inline GPU_DECL void setZero(vector2d<T> &val) 
   { setZero(val.x) ; setZero(val.y) ; }
-  template<class T> inline void setZero(vector3d<T> &val) 
+  template<class T> inline GPU_DECL void setZero(vector3d<T> &val) 
   { setZero(val.x) ; setZero(val.y) ; setZero(val.z) ; }
-  template<class T, size_t n> inline void setZero(Array<T,n> &val) 
+  template<class T, size_t n> inline GPU_DECL void setZero(Array<T,n> &val) 
   { for(size_t i=0;i<n;++i) setZero(val.x[i]) ; }
 
 #ifndef NO_AUTODIFF
-  inline void setZero(FAD2d &val)
+  inline GPU_DECL void setZero(FAD2d &val)
   { setZero(val.value) ; setZero(val.grad) ; setZero(val.grad2) ; }
-  inline void setZero(FADd &val)
+  inline GPU_DECL void setZero(FADd &val)
   { setZero(val.value) ; setZero(val.grad) ;  }
-  inline void setZero(VFAD &val)
+  inline GPU_DECL void setZero(VFAD &val)
   { setZero(val.data.value) ;
     for(size_t i=0;i<VFAD::maxN;++i)
       setZero(val.data.grad[i]) ; }

--- a/src/include/Tools/basic_types.h
+++ b/src/include/Tools/basic_types.h
@@ -1696,17 +1696,17 @@ namespace Loci {
 
 
 #ifndef NO_AUTODIFF
-  inline GPU_DECL vector3d<float> realToFloat(vector3d<MFADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline GPU_DECL vector3d<double> realToDouble(vector3d<MFADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline vector3d<float> realToFloat(vector3d<MFADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline vector3d<double> realToDouble(vector3d<MFADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 
-  inline GPU_DECL vector3d<float> realToFloat(vector3d<FADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline GPU_DECL vector3d<double> realToDouble(vector3d<FADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline vector3d<float> realToFloat(vector3d<FADd> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline vector3d<double> realToDouble(vector3d<FADd> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 
-  inline GPU_DECL vector3d<float> realToFloat(vector3d<FAD2d> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline GPU_DECL vector3d<double> realToDouble(vector3d<FAD2d> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline vector3d<float> realToFloat(vector3d<FAD2d> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline vector3d<double> realToDouble(vector3d<FAD2d> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 
-  inline GPU_DECL vector3d<float> realToFloat(vector3d<VFAD> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
-  inline GPU_DECL vector3d<double> realToDouble(vector3d<VFAD> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
+  inline vector3d<float> realToFloat(vector3d<VFAD> v) { return vector3d<float>(realToFloat(v.x),realToFloat(v.y),realToFloat(v.z)); }
+  inline vector3d<double> realToDouble(vector3d<VFAD> v) { return vector3d<double>(realToDouble(v.x),realToDouble(v.y),realToDouble(v.z)); }
 #endif
   
   //---------------------vector2d------------------//
@@ -2323,7 +2323,7 @@ namespace Loci {
   /// Operator to set a variable to it zero value to be used inside of
   /// templated functions that need to initialize variables for summation
   inline GPU_DECL void setZero(double &val) { val = double(0) ; }
-  inline GPU_DECL void setZero(long double &val) { val = (long double) 0 ; }
+  inline void setZero(long double &val) { val = (long double) 0 ; }
   inline GPU_DECL void setZero(float &val) { val = float(0) ; }
   inline GPU_DECL void setZero(int &val) { val = int(0) ; }
   inline GPU_DECL void setZero(unsigned int &val) { val = (unsigned int) 0 ; }
@@ -2342,11 +2342,11 @@ namespace Loci {
   { for(size_t i=0;i<n;++i) setZero(val.x[i]) ; }
 
 #ifndef NO_AUTODIFF
-  inline GPU_DECL void setZero(FAD2d &val)
+  inline void setZero(FAD2d &val)
   { setZero(val.value) ; setZero(val.grad) ; setZero(val.grad2) ; }
-  inline GPU_DECL void setZero(FADd &val)
+  inline void setZero(FADd &val)
   { setZero(val.value) ; setZero(val.grad) ;  }
-  inline GPU_DECL void setZero(VFAD &val)
+  inline void setZero(VFAD &val)
   { setZero(val.data.value) ;
     for(size_t i=0;i<VFAD::maxN;++i)
       setZero(val.data.grad[i]) ; }

--- a/src/include/Tools/gpu_attr.h
+++ b/src/include/Tools/gpu_attr.h
@@ -1,0 +1,10 @@
+#ifndef LOCI_GPU_ATTR_H
+#define LOCI_GPU_ATTR_H
+
+#ifdef __CUDACC__
+#define GPU_DECL __host__ __device__
+#else
+#define GPU_DECL 
+#endif
+
+#endif


### PR DESCRIPTION
operators involving the Loci composite types such as vector3d, Array etc. A C macro, GPU_DECL, is defined for this purpose that adds these attributes only when nvcc compiler is used. This change allows use of the composite types in $cudarules.