### PR TITLE
moved componentID definition to the overset header.

### DIFF
--- a/src/FVMOverset/holeCutting.loci
+++ b/src/FVMOverset/holeCutting.loci
@@ -62,7 +62,6 @@ namespace Loci {
 
   /// Parametric rule to build the names of the components from the existing
   /// grid volume tags.
-  $type componentName_X blackbox<string> ;
   $rule blackbox(componentName_X<-volumeTag(X)),parametric(volumeTag(X)),
   prelude {
     *$componentName_X = *$volumeTag(X) ;
@@ -112,7 +111,6 @@ namespace Loci {
   }
 
 
-  $type componentID store<int> ;
   /// Assign component ID to each cell
   $rule pointwise(componentID<-cellcenter,componentID_X),
   constraint(volumeTag(X)), parametric(volumeTag(X)) {

--- a/src/include/FVMOverset/overset.lh
+++ b/src/include/FVMOverset/overset.lh
@@ -70,8 +70,11 @@ $type crossComponentDistGrad_node store<Loci::vector3d<float> > ;
 $type crossComponentID_node store<int> ;
 $type distanceFieldGradient store<Loci::vector3d<float> > ;
 
-/// Stores the component ID of a component that a node belongs to
+/// The component ID of a component that a node belongs to
 $type componentID_node store<int> ;
+
+/// The component ID of a component that a cell belongs to.
+$type componentID store<int> ;
 
 /// For a component X, stores the the sequence of transform ancestry to
 /// associated with that component.


### PR DESCRIPTION
I noticed that componentID wasn't in the header and had to be retyped in the local .loci files to be used in a source file instead of being available from the overset header. Also got rid of a type in the holeCutting.loci as it was already existing in the overset header.