### PR TITLE
added common type for vars file options of list_input to Loci

### DIFF
--- a/src/include/Loci_types.h
+++ b/src/include/Loci_types.h
@@ -44,10 +44,10 @@ namespace Loci {
 #ifdef NO_OFFSETOF
       size_t offset1 = reinterpret_cast<char *>(&(tmp.value)) - reinterpret_cast<char *>(&tmp) ;
 #else
-      size_t offset1 = offsetof(FADd,value) ;	
+      size_t offset1 = offsetof(FADd,value) ;
 #endif
       H5Tinsert(vDatatype,"value",offset1,H5T_NATIVE_DOUBLE) ;
- 
+
 #ifdef NO_OFFSETOF
       size_t offset2 = reinterpret_cast<char *>(&(tmp.grad)) - reinterpret_cast<char *>(&tmp) ;
 #else
@@ -55,7 +55,7 @@ namespace Loci {
 #endif
       H5Tinsert(vDatatype,"grad",offset2,H5T_NATIVE_DOUBLE) ;
       return vDatatype ;
-    }		
+    }
     std::ostream &output(std::ostream &s, const void *p) const
       { s << *(reinterpret_cast<const FADd *>(p)) ; return s ;}
     std::istream &input(std::istream &s, void *p) const
@@ -63,7 +63,7 @@ namespace Loci {
     int bytesize() const
     { return sizeof(FADd) ; }
   } ;
-  
+
   template<> struct data_schema_traits<FADd> {
     typedef IDENTITY_CONVERTER Schema_Converter ;
     static DatatypeP get_type() {
@@ -81,10 +81,10 @@ namespace Loci {
 #ifdef NO_OFFSETOF
       size_t offset1 = reinterpret_cast<char *>(&(tmp.value)) - reinterpret_cast<char *>(&tmp) ;
 #else
-      size_t offset1 = offsetof(FAD2d,value) ;	
+      size_t offset1 = offsetof(FAD2d,value) ;
 #endif
       H5Tinsert(vDatatype,"value",offset1,H5T_NATIVE_DOUBLE) ;
- 
+
 #ifdef NO_OFFSETOF
       size_t offset2 = reinterpret_cast<char *>(&(tmp.grad)) - reinterpret_cast<char *>(&tmp) ;
 #else
@@ -99,7 +99,7 @@ namespace Loci {
 #endif
       H5Tinsert(vDatatype,"grad2",offset3,H5T_NATIVE_DOUBLE) ;
       return vDatatype ;
-    }		
+    }
     std::ostream &output(std::ostream &s, const void *p) const
       { s << *(reinterpret_cast<const FAD2d *>(p)) ; return s ;}
     std::istream &input(std::istream &s, void *p) const
@@ -107,7 +107,7 @@ namespace Loci {
     int bytesize() const
     { return sizeof(FAD2d) ; }
   } ;
-  
+
   template<> struct data_schema_traits<FAD2d> {
     typedef IDENTITY_CONVERTER Schema_Converter ;
     static DatatypeP get_type() {
@@ -125,7 +125,7 @@ namespace Loci {
 #ifdef NO_OFFSETOF
       size_t offset1 = reinterpret_cast<char *>(&(tmp.value)) - reinterpret_cast<char *>(&tmp) ;
 #else
-      size_t offset1 = offsetof(MFADd,value) ;	
+      size_t offset1 = offsetof(MFADd,value) ;
 #endif
       H5Tinsert(vDatatype,"value",offset1,H5T_NATIVE_DOUBLE) ;
 
@@ -144,7 +144,7 @@ namespace Loci {
       //#endif
       //      H5Tinsert(vDatatype,"maxN",offset3,H5T_NATIVE_INT) ;
       return vDatatype ;
-    }		
+    }
     std::ostream &output(std::ostream &s, const void *p) const
       { s << *(reinterpret_cast<const MFADd *>(p)) ; return s ;}
     std::istream &input(std::istream &s, void *p) const
@@ -152,7 +152,7 @@ namespace Loci {
     int bytesize() const
     { return sizeof(MFADd) ; }
   } ;
-  
+
   template<> struct data_schema_traits<MFADd> {
     typedef IDENTITY_CONVERTER Schema_Converter ;
     static DatatypeP get_type() {
@@ -170,7 +170,7 @@ namespace Loci {
 #ifdef NO_OFFSETOF
       size_t offset1 = reinterpret_cast<char *>(&(tmp.data.value)) - reinterpret_cast<char *>(&tmp) ;
 #else
-      size_t offset1 = offsetof(VFAD,data.value) ;	
+      size_t offset1 = offsetof(VFAD,data.value) ;
 #endif
       H5Tinsert(vDatatype,"value",offset1,H5T_NATIVE_DOUBLE) ;
 
@@ -185,7 +185,7 @@ namespace Loci {
       H5Tinsert(vDatatype,"grad",offset2,atype->get_hdf5_type()) ;
 
       return vDatatype ;
-    }		
+    }
     std::ostream &output(std::ostream &s, const void *p) const
       { s << *(reinterpret_cast<const VFAD *>(p)) ; return s ;}
     std::istream &input(std::istream &s, void *p) const
@@ -193,7 +193,7 @@ namespace Loci {
     int bytesize() const
     { return sizeof(VFAD) ; }
   } ;
-  
+
   template<> struct data_schema_traits<VFAD> {
     typedef IDENTITY_CONVERTER Schema_Converter ;
     static DatatypeP get_type() {
@@ -201,7 +201,7 @@ namespace Loci {
     }
   };
 
-  
+
   template <class T>
     struct data_schema_traits< vector3d<T> > {
       typedef IDENTITY_CONVERTER Schema_Converter;
@@ -228,9 +228,9 @@ namespace Loci {
         return DatatypeP(ct) ;
       }
     };
-  
-    
-  
+
+
+
   template <class T>
     struct  data_schema_traits< vector2d<T> > {
     public:
@@ -243,9 +243,9 @@ namespace Loci {
         return DatatypeP(ct) ;
       }
     };
-  
-  
-  
+
+
+
 
   template <class T,size_t n> inline std::ostream &
     operator<<(std::ostream &s, const Array<T,n> &v) {
@@ -261,8 +261,8 @@ namespace Loci {
     return s ;
   }
 
-  
-  template <class T,size_t n> 
+
+  template <class T,size_t n>
   class data_schema_traits< Array<T,n> > {
   public:
     typedef IDENTITY_CONVERTER Schema_Converter;
@@ -286,8 +286,8 @@ namespace Loci {
     return s ;
   }
 
-  
-  template <class T,size_t n> 
+
+  template <class T,size_t n>
   class data_schema_traits< vtype<T,n> > {
   public:
     typedef IDENTITY_CONVERTER Schema_Converter;
@@ -297,7 +297,7 @@ namespace Loci {
     }
   };
 
-  template <> 
+  template <>
   class data_schema_traits< vtype<float,8> > {
   public:
     typedef IDENTITY_CONVERTER Schema_Converter;
@@ -308,7 +308,7 @@ namespace Loci {
     }
   };
 
-  template <> 
+  template <>
   class data_schema_traits< vtype<double,4> > {
   public:
     typedef IDENTITY_CONVERTER Schema_Converter;
@@ -319,7 +319,7 @@ namespace Loci {
     }
   };
 
-  template <> 
+  template <>
   class data_schema_traits< vtype<int32_t,8> > {
   public:
     typedef IDENTITY_CONVERTER Schema_Converter;
@@ -329,7 +329,7 @@ namespace Loci {
                            sizeof(vtype<int32_t,8>),1,&dim) ;
     }
   };
-  
+
   template <> struct data_schema_traits<options_list> {
     typedef USER_DEFINED_CONVERTER Schema_Converter ;
     typedef char Converter_Base_Type ;
@@ -390,7 +390,7 @@ namespace Loci {
     typedef double Converter_Base_Type ;
     typedef UnitValueConverter<EnergyValue> Converter_Type ;
   } ;
-  
+
   template<> struct data_schema_traits<PowerValue> {
     typedef USER_DEFINED_CONVERTER Schema_Converter ;
     typedef double Converter_Base_Type ;
@@ -420,19 +420,19 @@ namespace Loci {
     typedef double Converter_Base_Type ;
     typedef UnitValueConverter<KinematicViscosityValue> Converter_Type ;
   } ;
-  
+
   template<> struct data_schema_traits<ThermalConductivityValue> {
     typedef USER_DEFINED_CONVERTER Schema_Converter ;
     typedef double Converter_Base_Type ;
     typedef UnitValueConverter<ThermalConductivityValue> Converter_Type ;
   } ;
-  
+
   template<> struct data_schema_traits<VolumeValue> {
     typedef USER_DEFINED_CONVERTER Schema_Converter ;
     typedef double Converter_Base_Type ;
     typedef UnitValueConverter<VolumeValue> Converter_Type ;
   } ;
-  
+
   template<> struct data_schema_traits<TemperatureValue> {
     typedef USER_DEFINED_CONVERTER Schema_Converter ;
     typedef double Converter_Base_Type ;
@@ -443,7 +443,61 @@ namespace Loci {
     typedef double Converter_Base_Type ;
     typedef UnitValueConverter<PressureValue> Converter_Type ;
   } ;
-      
+
+  /// Class to allow for simple comma-separated lists in vars file values.
+  class list_input {
+  public:
+    // Raw list expression from the vars option (whitespace removed).
+    std::string namelist;
+
+    // Output operator for list_input, which prints the raw list expression.
+    friend std::ostream& operator<<(std::ostream& s, const list_input& n) {
+      s << n.namelist << std::endl;
+      return s;
+    }
+
+    // Input operator for list_input, which reads in characters until a newline, removing whitespace.
+    friend std::istream& operator>>(std::istream& s, list_input& n) {
+      n.namelist = std::string();
+      while (s.peek() != '\n' && s.peek() != '\r' && s.peek() != EOF) {
+        char c = s.get();
+        if (c != ' ' && c != '\t') n.namelist += c;
+      }
+      return s;
+    }
+};
+
+  /// Class to serialize list_input.
+  class list_input_schema_converter {
+    list_input &ref ;
+  public:
+    explicit list_input_schema_converter(list_input &iref): ref(iref) {}
+    int getSize() const {
+      return ref.namelist.size() ;
+    }
+    void getState(char *buf, int &size) {
+      size = getSize() ;
+      for(int i=0;i<size;++i) {
+        buf[i] = ref.namelist[i] ;
+      }
+    }
+    void setState(char *buf, int size) {
+      ref.namelist = "" ;
+      for(int i=0;i<size;++i) {
+        ref.namelist += buf[i] ;
+      }
+    }
+  } ;
+
+  /// Schema converter for list_input.
+  template<> struct data_schema_traits<list_input> {
+    typedef USER_DEFINED_CONVERTER Schema_Converter ;
+
+    typedef char Converter_Base_Type ;
+    typedef list_input_schema_converter Converter_Type ;
+  } ;
+
+
 }
 
 #endif


### PR DESCRIPTION
I've seen this list_input used in the vars file parsing and I thought maybe it would make sense to be part of Loci. I put it in the Loci_types.h, but if it makes more sense somewhere else, I can change it.