### PR TITLE
added capability for more name options to be provided to vogtools

### DIFF
--- a/src/FVMtools/cobalt2vog.cc
+++ b/src/FVMtools/cobalt2vog.cc
@@ -213,11 +213,10 @@ int main(int ac, char *av[]) {
     cout << endl ;
   }
 
-  string filename = av[1] ;
-  filename += ".cog" ;
-
-  string outfile = av[1] ;
-  outfile += ".vog" ;
+  string input_name = av[1] ;
+  string case_name = VOG::stripSuffix(input_name,".cog") ;
+  string filename = case_name + ".cog" ;
+  string outfile = case_name + ".vog" ;
 
   store<vector3d<double> > pos;
   Map cl, cr;
@@ -256,7 +255,7 @@ int main(int ac, char *av[]) {
   vector<BC_descriptor> bcs ;
 
   if(MPI_rank == 0) {
-    string tagsfile = string(av[1]) + ".tags" ;
+    string tagsfile = case_name + ".tags" ;
     bcs = readTags(tagsfile) ;
     if(bcs.size() != 0) {
       cout << "boundary faces:"<< endl ;

--- a/src/FVMtools/fluent2vog.cc
+++ b/src/FVMtools/fluent2vog.cc
@@ -1019,25 +1019,32 @@ int main(int ac, char *av[]) {
     cout << endl ;
   }
 
-  string filename = av[1] ;
-  // Try ".cas file first as modern fluent outputs this file extension
-  filename += ".cas" ;
-  int validfile = 1 ;
-  // Only run stat on processor rank 0
-  if(Loci::MPI_rank == 0) {
-    struct stat statbuf ;
-    if(stat(filename.c_str(),&statbuf))
-      validfile = 0 ;
-  }
-  // broadcast results of stat call to other processors
-  MPI_Bcast(&validfile,1,MPI_INT,0,MPI_COMM_WORLD) ;
-  // If .cas file is not valid, then switch to older .msh extension
-  if(!validfile)
-    filename = string(av[1])+".msh" ;
-  
+  string input_name = av[1] ;
+  string case_name = input_name ;
+  string filename = input_name ;
 
-  string outfile = av[1] ;
-  outfile += ".vog" ;
+  if(VOG::hasSuffix(input_name,".cas")) {
+    case_name = VOG::stripSuffix(input_name,".cas") ;
+  } else if(VOG::hasSuffix(input_name,".msh")) {
+    case_name = VOG::stripSuffix(input_name,".msh") ;
+  } else {
+    // Try ".cas" first as modern fluent outputs this file extension.
+    filename = case_name + ".cas" ;
+    int validfile = 1 ;
+    // Only run stat on processor rank 0.
+    if(Loci::MPI_rank == 0) {
+      struct stat statbuf ;
+      if(stat(filename.c_str(),&statbuf))
+        validfile = 0 ;
+    }
+    // Broadcast results of stat call to other processors.
+    MPI_Bcast(&validfile,1,MPI_INT,0,MPI_COMM_WORLD) ;
+    // If ".cas" file is not valid, then switch to older ".msh" extension.
+    if(!validfile)
+      filename = case_name + ".msh" ;
+  }
+
+  string outfile = case_name + ".vog" ;
 
   store<vector3d<double> > pos;
   Map cl, cr;
@@ -1082,4 +1089,3 @@ int main(int ac, char *av[]) {
   Loci::Finalize() ;
   return 0 ;
 }
-

--- a/src/FVMtools/msh2vog.cc
+++ b/src/FVMtools/msh2vog.cc
@@ -216,11 +216,9 @@ int main(int ac, char *av[]) {
     cout << endl ;
   }
 
-  string filename = av[1] ;
-  filename += ".msh" ;
-
-  string outfile = av[1] ;
-  outfile += ".vog" ;
+  string input_name = av[1] ;
+  string filename = VOG::ensureSuffix(input_name,".msh") ;
+  string outfile = VOG::stripSuffix(input_name,".msh") + ".vog" ;
 
   ifstream gridfile(filename.c_str(),ios::in) ;
   if(gridfile.fail()) {

--- a/src/FVMtools/plot3d2vog.cc
+++ b/src/FVMtools/plot3d2vog.cc
@@ -1200,36 +1200,56 @@ if(Lref == "")
   MPI_Bcast(&posScale,1,MPI_DOUBLE,0,MPI_COMM_WORLD) ;
   int read_type = 0 ;
   bool found_file = false ;
-  char* filename = av[1] ;
-  char buf[512] ;
-  bzero(buf,512) ;
-  snprintf(buf,511,"%s.grd",av[1]) ;
-  string file = string(buf) ;
+  string input_name = av[1] ;
+  bool explicit_ascii = VOG::hasSuffix(input_name,".grd") ;
+  bool explicit_binary = VOG::hasSuffix(input_name,".grd.b8") ;
+  string case_name = input_name ;
+  if(explicit_binary)
+    case_name = VOG::stripSuffix(input_name,".grd.b8") ;
+  else if(explicit_ascii)
+    case_name = VOG::stripSuffix(input_name,".grd") ;
+  string file = input_name ;
   if(Loci::MPI_rank == 0) {
-    bool found_ascii=false ;
-    bool found_binary = false ;
     struct stat finfo ;
-    if(stat(buf,&finfo)==0 && (S_ISREG(finfo.st_mode))) {
-      found_ascii = true ;
-      found_file = true ;
-    }
-    snprintf(buf,511,"%s.grd.b8",av[1]) ;
-    if(stat(buf,&finfo)==0 && (S_ISREG(finfo.st_mode))) {
-      found_binary = true ;
-      found_file = true ;
-    }
-    if(found_binary && found_ascii) {
-      cerr << "both ascii file, '" << file << "' and binary file, '" << buf
-	   << "', found.  Remove one file to disambiguate." << endl ;
-      Loci::Abort() ;
-    }
-    if(found_binary) {
-      file = string(buf) ;
-      read_type = 1 ;
-    }
-    if(!found_file) {
-      cerr << "unable to find file '"<< file << "' or '" << buf << "'" << endl ;
-      Loci::Abort() ;
+    if(explicit_ascii || explicit_binary) {
+      if(stat(file.c_str(),&finfo)==0 && (S_ISREG(finfo.st_mode)))
+        found_file = true ;
+      if(explicit_binary)
+        read_type = 1 ;
+      if(!found_file) {
+        cerr << "unable to find file '"<< file << "'" << endl ;
+        Loci::Abort() ;
+      }
+    } else {
+      bool found_ascii=false ;
+      bool found_binary = false ;
+      string ascii_file = input_name + ".grd" ;
+      string binary_file = input_name + ".grd.b8" ;
+      if(stat(ascii_file.c_str(),&finfo)==0 && (S_ISREG(finfo.st_mode))) {
+        found_ascii = true ;
+        found_file = true ;
+      }
+      if(stat(binary_file.c_str(),&finfo)==0 && (S_ISREG(finfo.st_mode))) {
+        found_binary = true ;
+        found_file = true ;
+      }
+      if(found_binary && found_ascii) {
+        cerr << "both ascii file, '" << ascii_file << "' and binary file, '"
+             << binary_file << "', found.  Remove one file to disambiguate."
+             << endl ;
+        Loci::Abort() ;
+      }
+      if(found_binary) {
+        file = binary_file ;
+        read_type = 1 ;
+      } else {
+        file = ascii_file ;
+      }
+      if(!found_file) {
+        cerr << "unable to find file '"<< ascii_file << "' or '" << binary_file
+             << "'" << endl ;
+        Loci::Abort() ;
+      }
     }
   }
 
@@ -2017,7 +2037,7 @@ if(Lref == "")
     VOG::optimizeMesh(pos,cl,cr,face2node) ;
   }
 
-  string outfile = string(filename) + ".vog" ;
+  string outfile = case_name + ".vog" ;
   if(MPI_rank == 0)
     cout << "writing VOG file" << endl ;
 

--- a/src/FVMtools/ugrid2vog.cc
+++ b/src/FVMtools/ugrid2vog.cc
@@ -3167,8 +3167,7 @@ int main(int ac, char* av[]) {
   bool optimize = true ;
   bool cellVertexTransform = false ;
   Loci::Init(&ac,&av) ;
-  const char *filename ;
-  std::string tmp_str ;
+  std::string case_name ;
   bool binary = 0;
   string Lref = "NOSCALE" ;
   bool swapbyte = false ;
@@ -3239,7 +3238,7 @@ int main(int ac, char* av[]) {
   }
 
   if(ac == 2) {
-    tmp_str.append(av[1]) ;
+    case_name = av[1] ;
   } else {
     cerr << "Usage: ugrid2vog <options> <file>" << endl
          << "Where options are listed below and <file> is the filename sans postfix" << endl
@@ -3280,27 +3279,26 @@ int main(int ac, char* av[]) {
 
   if(swapbyte)
     reverse_byteorder = !reverse_byteorder ;
-  int loc = 0;
-  loc = tmp_str.find('.') ;
-  std::string new_str = tmp_str.substr(0, loc) ;
-  filename = new_str.c_str() ;
-  char buf[512] ;
-  bzero(buf,512) ;
+  if(VOG::hasSuffix(case_name,".b8.ugrid"))
+    case_name = VOG::stripSuffix(case_name,".b8.ugrid") ;
+  else if(VOG::hasSuffix(case_name,".ugrid"))
+    case_name = VOG::stripSuffix(case_name,".ugrid") ;
+
   if(!binary) {
     struct stat fstat ;
-    snprintf(buf,511,"%s.ugrid",filename) ;
-    if(stat(buf,&fstat)<0) {
+    string ascii_file = case_name + ".ugrid" ;
+    if(stat(ascii_file.c_str(),&fstat)<0) {
       binary = true ;
     }
   }
 
+  string infile ;
   if(!binary)
-    snprintf(buf,511,"%s.ugrid",filename) ;
+    infile = case_name + ".ugrid" ;
   else
-    snprintf(buf,511,"%s.b8.ugrid",filename) ;
-  string infile = buf ;
+    infile = case_name + ".b8.ugrid" ;
 
-  string outfile = string(filename) + string(".vog") ;
+  string outfile = case_name + string(".vog") ;
 
 
   store<vector3d<double> > pos ;
@@ -3312,7 +3310,7 @@ int main(int ac, char* av[]) {
   vector<Array<int,8> > hexs ;
   readUGRID(infile, binary, pos,qfaces,tfaces,tets,pyramids,prisms,hexs) ;
 
-  string splitfile = string(filename) + string(".split") ;
+  string splitfile = case_name + string(".split") ;
   vector<quadSplit> splits;
   int num_hex = hexs.size();
   int P = Loci::MPI_processes;
@@ -3342,7 +3340,7 @@ int main(int ac, char* av[]) {
   vector<int> transsurf ;
 
   if(MPI_rank == 0) {
-    string tagsfile = string(filename) + ".tags" ;
+    string tagsfile = case_name + ".tags" ;
     bcs = readTags(tagsfile) ;
     if(bcs.size() == 0) {
       cerr << "unable to read '" << tagsfile << "'" << endl ;

--- a/src/FVMtools/vogtools.cc
+++ b/src/FVMtools/vogtools.cc
@@ -49,6 +49,24 @@ namespace Loci {
 namespace VOG {
   
   //#define MEMDIAG
+
+  bool hasSuffix(const std::string &value, const std::string &suffix) {
+    if(suffix.size() > value.size())
+      return false ;
+    return value.compare(value.size()-suffix.size(),suffix.size(),suffix) == 0 ;
+  }
+
+  std::string stripSuffix(const std::string &value, const std::string &suffix) {
+    if(hasSuffix(value,suffix))
+      return value.substr(0,value.size()-suffix.size()) ;
+    return value ;
+  }
+
+  std::string ensureSuffix(const std::string &value, const std::string &suffix) {
+    if(hasSuffix(value,suffix))
+      return value ;
+    return value + suffix ;
+  }
   
 #ifdef MEMDIAG
   void *memtop =0;

--- a/src/FVMtools/vogtools.h
+++ b/src/FVMtools/vogtools.h
@@ -45,5 +45,15 @@ namespace VOG {
                           Map &cl, Map &cr, multiMap &face2node) ;
   extern std::vector<int> simplePartitionVec(int mn, int mx, int p) ;
 
-}
+  /// Return true if `value` ends with `suffix`.
+  extern bool hasSuffix(const std::string &value, const std::string &suffix) ;
+  /// Return `value` with trailing `suffix` removed, if present, otherwise
+  /// return `value` unchanged.
+  extern std::string stripSuffix(const std::string &value,
+                                 const std::string &suffix) ;
+  /// Return `value` with `suffix` appended, unless it already has it, in
+  /// which case return `value` unchanged.
+  extern std::string ensureSuffix(const std::string &value,
+                                  const std::string &suffix) ;
 
+}


### PR DESCRIPTION
When I use the `msh2vog `utility, sometimes I give it the filename like `case.msh` and it tries to open `case.msh.msh`. Updated the `msh2vog `and other utilities that used a rigid input format to allow for users to give things like `case `or `case.msh`, or whatever suffix is used for the mesh format.