### PR TITLE
Update to add nvtx diagnostics with -g option to lpp

### DIFF
--- a/src/conf/Loci.conf
+++ b/src/conf/Loci.conf
@@ -74,10 +74,10 @@ LPP_I_SUFFIX=lcc~
 .SUFFIXES: .o .lo .c .cc .cpp .$(LPP_I_SUFFIX) .C .cu .f90 .lcu~
 
 %.$(LPP_I_SUFFIX) : %.loci
-	$(LPP) -x $(LOCI_INCLUDES) $(INCLUDES) $*.loci -o $*.$(LPP_I_SUFFIX)
+	$(LPP) $(LPP_FLAGS) -x $(LOCI_INCLUDES) $(INCLUDES) $*.loci -o $*.$(LPP_I_SUFFIX)
 
 %.lcu~ : %.cloci
-	$(LPP) $(LOCI_INCLUDES) $(INCLUDES) $*.cloci -o $*.lcu~
+	$(LPP) $(LPP_FLAGS) $(LOCI_INCLUDES) $(INCLUDES) $*.cloci -o $*.lcu~
 
 %_lo.o : %.c
 	$(CC) $(PIC_FLAGS) $(C_OPT) $(DEFINES) $(LOCI_INCLUDES) $(INCLUDES) -o $*_lo.o -c $*.c

--- a/src/include/Loci
+++ b/src/include/Loci
@@ -66,6 +66,10 @@
 #include <LociGridReaders.h>
 #include <pnn.h>
 
+#ifdef USE_CUDA_RT
+#include <nvtx3/nvtx3.hpp>
+#endif
+
 #define HAS_MODULE_SEARCH_DIR
 namespace Loci {
   extern void AddModuleSearchDir(std::string dirname);

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -1956,7 +1956,8 @@ std::vector<list<variable> > expand_mapping(std::vector<variableSet> vset) {
 }
 
 
-void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment) {
+void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
+                               const parseSharedInfo &parseInfo) {
   killsp() ;
   string rule_type ;
   if(is_name(is)) {
@@ -2643,6 +2644,33 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment) 
   syncFile(outputFile) ;
   outputFile << "    const int nblks = (stop-start+NTHREADS)/NTHREADS ;" << endl ;
   syncFile(outputFile) ;
+
+  if(parseInfo.debug_info > 0) {
+    ostringstream oss ;
+    for(auto i=targets.begin();i!=targets.end();) {
+      for(size_t j=0;j<i->mapping.size();++j)
+        oss << i->mapping[j] << "->" ;
+      // Output target variables, adding inplace notation if needed
+      if(i->var.size() > 1)
+        oss << '(' ;
+      for(auto vi=i->var.begin();vi!=i->var.end();++vi) {
+        if(vi != i->var.begin())
+          oss << ',' ;
+        oss << *vi ;
+      }
+      if(i->var.size() > 1)
+        oss << ')' ;
+      ++i;
+      if(i != targets.end())
+        oss << "," ;
+    }
+    oss << "<-" ;
+    oss << bodys ;
+    if(constraint!="")
+      oss << ",constraint(" << constraint<<")" ;
+    outputFile << "nvtxRangePush(\"" << oss.str() << "\");" << endl ;
+    syncFile(outputFile) ;
+  }
   outputFile <<"    " <<class_name << "_kernel<<<nblks,NTHREADS,0,Loci::getGPUStream()>>>(";
   for(auto i=writevars.begin();i!=writevars.end();) {
     outputFile << vnames[*i] << ".ptr()";
@@ -2658,7 +2686,12 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment) 
     if(i!=readvars.end())
       outputFile << "," ;
   }
-  outputFile << ",start, stop, NTHREADS) ;" << endl ;
+  outputFile << ",start, stop, NTHREADS) ;"  ;
+  if(parseInfo.debug_info > 0) {
+    outputFile << "nvtxRangePop();" ;
+  }
+  outputFile<<endl ;
+  syncFile(outputFile) ;
   syncFile(outputFile) ;
   outputFile << "}" << endl; // end of for loop
   syncFile(outputFile) ;
@@ -3469,7 +3502,7 @@ void parseFile::processFile(string file, ostream &outputFile,
 	    if(parseInfo.no_cuda)
 	      setup_Rule(outputFile,comment,parseInfo) ;
 	    else
-	      setup_cudaRule(outputFile,comment) ;
+	      setup_cudaRule(outputFile,comment,parseInfo) ;
           } else if(key == "include") {
             killsp() ;
             if(!is_string(is)) {

--- a/src/lpp/lpp.h
+++ b/src/lpp/lpp.h
@@ -45,7 +45,9 @@ struct parseSharedInfo {
   bool no_cuda ;
   bool test_parse ;
   int diag_level ;
-  parseSharedInfo() { no_cuda = true ; test_parse= false;  diag_level = 0 ; }
+  int debug_info ;
+  parseSharedInfo() { no_cuda = true ; test_parse= false;  diag_level = 0 ;
+    debug_info = 0 ;}
   
 } ;
   
@@ -155,7 +157,8 @@ class parseFile {
   void setup_Untype(std::ostream &outputFile) ;
   void setup_Rule(std::ostream &outputFile,const std::string &comment,
                   const parseSharedInfo &parseInfo) ;
-  void setup_cudaRule(std::ostream &outputFile,const std::string &comment) ;
+  void setup_cudaRule(std::ostream &outputFile,const std::string &comment,
+                      const parseSharedInfo &parseInfo) ;
 
   void skip_lpp_conditional(std::ostream &outputFile) ;
   void setup_Test(std::ostream &outputFile) ;

--- a/src/lpp/main.cc
+++ b/src/lpp/main.cc
@@ -115,6 +115,7 @@ int main(int argc, char *argv[]) {
   string outfile ;
   bool test_parse = false ;
   int diag_level = 0 ;
+  int debug_info = 0 ;
   for(int i=1;i<argc;++i) {
     if(argv[i][0] == '-') {
       if(argv[i][1] == 'I') {
@@ -131,6 +132,11 @@ int main(int argc, char *argv[]) {
           diag_level = argv[i][2] - '0' ;
         if(argv[i][2] == '\0')
           diag_level = 10 ;
+      } else if(argv[i][1] == 'g') {
+        if(argv[i][2] >= '0' && argv[i][2] <= '9') 
+          debug_info = argv[i][2] - '0' ;
+        if(argv[i][2] == '\0')
+          debug_info = 10 ;
       } else if(argv[i][1] == 'o') {
         if(i+1>argc || out_given)
           Usage(argc,argv) ;
@@ -179,6 +185,7 @@ int main(int argc, char *argv[]) {
   parseInfo.no_cuda = no_cuda ;
   parseInfo.test_parse = test_parse ;
   parseInfo.diag_level = diag_level ;
+  parseInfo.debug_info = debug_info ;
   
   parseFile parser ;
   try {


### PR DESCRIPTION
This adds a -g flag to lpp that will add nvtx calls to before gpu kernel calls that labels the rule signature.  To enable this debugging add LPP_FLAGS=-g to the sys.conf file.