### PR TITLE
Define LOCI_RPATH macro in Loci.conf so that install path is searched during runtime

### DIFF
--- a/src/conf/Loci.conf
+++ b/src/conf/Loci.conf
@@ -18,6 +18,11 @@ endif
 
 LOCI_RPATH= $(LOCI_INSTALL_PATH)/lib
 
+# Export LOCI_RPATH as a C/C++ macro so that it can be used as part of the Loci
+# module search path at runtime. 
+SPECIAL_DEFINES += -DLOCI_RPATH=\"$(LOCI_RPATH)\"
+
+
 export LD_LIBRARY_PATH:=$(LOCI_BASE)/lib:$(LD_LIBRARY_PATH)
 export DYLD_LIBRARY_PATH:=$(LOCI_BASE)/lib:$(DYLD_LIBRARY_PATH)
 

--- a/src/conf/Loci.conf
+++ b/src/conf/Loci.conf
@@ -19,8 +19,7 @@ endif
 LOCI_RPATH= $(LOCI_INSTALL_PATH)/lib
 
 # Export LOCI_RPATH as a C/C++ macro so that it can be used as part of the Loci
-# module search path at runtime. 
-SPECIAL_DEFINES += -DLOCI_RPATH=\"$(LOCI_RPATH)\"
+# module search path at runtime.
 
 
 export LD_LIBRARY_PATH:=$(LOCI_BASE)/lib:$(LD_LIBRARY_PATH)
@@ -41,6 +40,7 @@ DEFINES =    $(SYSTEM_DEFINES) \
              $(DEBUG_DEFINES) \
              -DLOCI_SYS_$(SYS_TYPE) \
              -DLOCI_ARCH_$(ARCH_TYPE) \
+             -DLOCI_RPATH=\"$(LOCI_RPATH)\" \
              $(SPECIAL_DEFINES)
 
 LOCI_INCLUDES  = -I$(LOCI_BASE)/include


### PR DESCRIPTION
I noticed that after installing Loci, when I tried to run Stream, I'd see an error about a failure to load fvm_m.so for example. The LDD on the .so files were all nicely defined. It was inside` Initialize.cc:`

```
#ifdef LOCI_RPATH
      { string rpath = LOCI_RPATH ; AddModuleSearchDir(rpath) ; }
#endif

```

In the `Loci.con`f there was the definition of the `LOCI_RPATH`, used in the makefiles during compilation. But that was never set as  a c++ macro variable, and so that segment wasn't getting activated at runtime and the installation path wasn't being searched.  I know generally if you just slap the path into the `LD_LIBRARY_PATH` or defined that` LOCI_MODULE_PATH`, it would work fine. From a simplicity standpoint, I figured that the minimal amount of work required from a user is a good target, and utilizing the information that was already provided during compilation time to set the paths so that everything works is preferable to requiring environment variables to be set.

This branch just add that `LOCI_RPATH` macro to the `SPECIAL_DEFINES`. I tested it in Stream and it works without needing any paths set after this change.