### PR TITLE
lpp AST unary precedence fix

### DIFF
--- a/quickTest/FVM/IOplot.loci
+++ b/quickTest/FVM/IOplot.loci
@@ -139,7 +139,7 @@ namespace flowPsi {
 
 $type cell2nodeD(X) store<double> ;
   $rule pointwise(cell2nodeD(X)<-c2nD_scalar_sum(X),nodalw_sumD),constraint(pos) {
-    double rsum = 1./(double($nodalw_sumD)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sumD)+1e-20) ;
     $cell2nodeD(X) = $c2nD_scalar_sum(X)*rsum ;
   }
 
@@ -176,7 +176,7 @@ $type cell2nodeD(X) store<double> ;
   $type boundary_node param<bool> ;
 
 $rule pointwise(boundary::cell2nodeD(X)<-boundary_scalar_sumD(X),boundary_nodalw_sumD),constraint(boundary_node) {
-      double rsum = 1./(double($boundary_nodalw_sumD)+1e-20) ;
+      double rsum = 1./(static_cast<double>($boundary_nodalw_sumD)+1e-20) ;
       $cell2nodeD(X) = $boundary_scalar_sumD(X)*rsum ;
   }
 
@@ -228,7 +228,7 @@ $rule pointwise(boundary::cell2nodeD(X)<-boundary_scalar_sumD(X),boundary_nodalw
 
   $type cell2nodeD_v3d(V) store<vector3d<double> > ;
   $rule pointwise(cell2nodeD_v3d(V)<-c2nD_v3d_sum(V),nodalw_sumD) {
-    double rsum = 1./(double($nodalw_sumD)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sumD)+1e-20) ;
     $cell2nodeD_v3d(V) = $c2nD_v3d_sum(V)*rsum ;
   }
   $type boundary_v3d_sumD(V) store<vector3d<double> > ;
@@ -253,7 +253,7 @@ $rule pointwise(boundary::cell2nodeD(X)<-boundary_scalar_sumD(X),boundary_nodalw
   $rule pointwise(boundary::cell2nodeD_v3d(V)<-
 		  boundary_v3d_sumD(V),boundary_nodalw_sumD),
     constraint(boundary_node) {
-      double rsum = 1./(double($boundary_nodalw_sumD)+1e-20) ;
+      double rsum = 1./(static_cast<double>($boundary_nodalw_sumD)+1e-20) ;
       $cell2nodeD_v3d(V) = $boundary_v3d_sumD(V)*rsum ;
   }
 

--- a/src/FVMMod/limiters/nishikawa.loci
+++ b/src/FVMMod/limiters/nishikawa.loci
@@ -117,7 +117,7 @@ namespace Loci {
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1) ;
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
     real limi = ($firstOrderCells != 0)?0.0:1.0 ;
@@ -189,7 +189,7 @@ namespace Loci {
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -268,7 +268,7 @@ namespace Loci {
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -312,7 +312,7 @@ namespace Loci {
       ref += fabs($M[j]) ;
     }
     ref = max(ref,real_t(1e-5)) ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -372,7 +372,7 @@ namespace Loci {
       ref += fabs($M[j]) ;
     }
     ref = max(ref,real_t(1e-5)) ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 

--- a/src/FVMMod/limiters/nishikawa2.loci
+++ b/src/FVMMod/limiters/nishikawa2.loci
@@ -119,7 +119,7 @@ namespace Loci {
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -192,7 +192,7 @@ namespace Loci {
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -270,7 +270,7 @@ namespace Loci {
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -313,7 +313,7 @@ namespace Loci {
     for(int j=0;j<vs;++j)
       ref += fabs($M[j]) ;
     ref = max(ref,real_t(1e-5)) ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0);
     const real epsilon2 = venkaFac*pow(ref,$nisPow);
 
@@ -372,7 +372,7 @@ $rule pointwise(limiterv(M)<-cellcenter, M, gradv(M), firstOrderCells,
     for(int j=0;j<vs;++j)
       ref += fabs($M[j]) ;
     ref = max(ref,real_t(1e-5)) ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0) ;
     const real epsilon2 = venkaFac*pow(ref,$nisPow) ;
 
@@ -461,7 +461,7 @@ $rule pointwise(limiterv(M)<-cellcenter, M, gradv(M), firstOrderCells,
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1 ;
+    const real pp1 = static_cast<real>($nisPow+1) ;
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0) ;
     const real epsilon2 = venkaFac*pow(ref,$nisPow) ;
 
@@ -513,7 +513,7 @@ $rule pointwise(limiterv(M)<-cellcenter, M, gradv(M), firstOrderCells,
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1 ;
+    const real pp1 = static_cast<real>($nisPow+1) ;
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0) ;
     const real epsilon2 = venkaFac*pow(ref,$nisPow) ;
 
@@ -569,7 +569,7 @@ $rule pointwise(limiterv(M)<-cellcenter, M, gradv(M), firstOrderCells,
     }
 
     const real ref = 1e-20+sqrt(refsq)/numrefs ;
-    const real pp1 = (real)$nisPow+1 ;
+    const real pp1 = static_cast<real>($nisPow+1) ;
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0) ;
     const real epsilon2 = venkaFac*pow(ref,$nisPow) ;
 
@@ -601,7 +601,7 @@ $rule pointwise(limiterv(M)<-cellcenter, M, gradv(M), firstOrderCells,
       ref += fabs($M[j]) ;
     }
     ref = max(ref,real_t(1e-5)) ;
-    const real pp1 = (real)$nisPow+1;
+    const real pp1 = static_cast<real>($nisPow+1);
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0) ;
     const real epsilon2 = venkaFac*pow(ref,$nisPow) ;
 
@@ -649,7 +649,7 @@ $rule pointwise(limiterv(M)<-cellcenter, M, gradv(M), firstOrderCells,
       ref += fabs($M[j]) ;
     }
     ref = max(ref,real_t(1e-5)) ;
-    const real pp1 = (real)$nisPow+1 ;
+    const real pp1 = static_cast<real>($nisPow+1) ;
     const real venkaFac = pow($Kl,pp1)*pow(6/(M_PI*$grid_vol)*$vol,pp1/3.0) ;
     const real epsilon2 = venkaFac*pow(ref,$nisPow) ;
 

--- a/src/FVMMod/node_values.loci
+++ b/src/FVMMod/node_values.loci
@@ -176,7 +176,7 @@ namespace Loci {
   prelude {
     $cell2node_v(M).setVecSize($nodal_sum(M).vecSize()) ;
   } compute {
-    double rsum = 1./(double($nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sum)+1e-20) ;
     for(int i=0;i<$*nodal_sum(M).vecSize();++i) {
       $cell2node_v(M)[i] = $nodal_sum(M)[i]*rsum ;
     }
@@ -241,7 +241,7 @@ namespace Loci {
   prelude {
     $cell2node_v(M).setVecSize($boundary_nodal_sum(M).vecSize()) ;
   } compute {
-      double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
+      double rsum = 1./(static_cast<double>($boundary_nodalw_sum)+1e-20) ;
       for(int i=0;i<$*boundary_nodal_sum(M).vecSize();++i) {
         $cell2node_v(M)[i] = $boundary_nodal_sum(M)[i]*rsum ;
       }
@@ -305,7 +305,7 @@ namespace Loci {
   /// nodes
   $rule pointwise(cell2node(X)<-c2n_scalar_sum(X), nodalw_sum),
   constraint(pos, hasCellValues(X)) {
-    double rsum = 1./(double($nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sum)+1e-20) ;
     $cell2node(X) = $c2n_scalar_sum(X)*rsum ;
   }
 
@@ -330,7 +330,7 @@ namespace Loci {
   $rule pointwise(boundary::cell2node(X)<-boundary_scalar_sum(X),
     boundary_nodalw_sum),
   constraint(boundary_node,hasCellValues(X)) {
-    double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($boundary_nodalw_sum)+1e-20) ;
     $cell2node(X) = $boundary_scalar_sum(X)*rsum ;
   }
 
@@ -393,7 +393,7 @@ namespace Loci {
   /// compute interior node interpolated values
   $rule pointwise(cell2node_v3d(V)<-c2n_v3d_sum(V), nodalw_sum),
   constraint(pos, hasCellValues(V)) {
-    double rsum = 1./(double($nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sum)+1e-20) ;
     $cell2node_v3d(V) = $c2n_v3d_sum(V)*rsum ;
   }
 
@@ -423,7 +423,7 @@ namespace Loci {
   $rule pointwise(boundary::cell2node_v3d(V)<-boundary_v3d_sum(V),
     boundary_nodalw_sum),
   constraint(boundary_node, hasCellValues(V)) {
-    double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($boundary_nodalw_sum)+1e-20) ;
     $cell2node_v3d(V) = $boundary_v3d_sum(V)*rsum ;
   }
 
@@ -512,7 +512,7 @@ namespace Loci {
 
   $rule pointwise(cell2nodep(XF)<-c2n_scalar_sump(XF), nodalw_sum),
   constraint(pos, hasCellValues(XF)) {
-    double rsum = 1./(double($nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sum)+1e-20) ;
     $cell2nodep(XF) = $c2n_scalar_sump(XF)*rsum ;
   }
 
@@ -544,7 +544,7 @@ namespace Loci {
   $rule pointwise(boundary::cell2nodep(XF)<-boundary_scalar_sump(XF),
     boundary_nodalw_sum),
   constraint(boundary_node, hasCellValues(XF)) {
-    double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($boundary_nodalw_sum)+1e-20) ;
     $cell2nodep(XF) = $boundary_scalar_sump(XF)*rsum ;
   }
 
@@ -617,7 +617,7 @@ namespace Loci {
   $type cell2nodep_v3d(VF) store<vector3d<FADPLOT> > ;
   $rule pointwise(cell2nodep_v3d(VF)<-c2n_v3d_sump(VF), nodalw_sum),
   constraint(pos, hasCellValues(VF)) {
-    double rsum = 1./(double($nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($nodalw_sum)+1e-20) ;
     $cell2nodep_v3d(VF) = $c2n_v3d_sump(VF)*rsum ;
   }
 
@@ -654,7 +654,7 @@ namespace Loci {
   $rule pointwise(boundary::cell2nodep_v3d(VF)<-boundary_v3d_sump(VF),
     boundary_nodalw_sum),
   constraint(boundary_node, hasCellValues(VF)) {
-    double rsum = 1./(double($boundary_nodalw_sum)+1e-20) ;
+    double rsum = 1./(static_cast<double>($boundary_nodalw_sum)+1e-20) ;
     $cell2nodep_v3d(VF) = $boundary_v3d_sump(VF)*rsum ;
   }
 

--- a/src/FVMOverset/holeCutting.loci
+++ b/src/FVMOverset/holeCutting.loci
@@ -884,7 +884,7 @@ namespace Loci {
   $type nblankf store<float> ;
   /// This is available for plotting functions
   $rule pointwise(nblankf<-nblank) {
-    $nblankf = float($nblank) ;
+    $nblankf = static_cast<float>($nblank) ;
     if($nblank == 0)
       $nblankf = 0.0 ;
   }

--- a/src/include/FVM.lh
+++ b/src/include/FVM.lh
@@ -41,7 +41,7 @@ $type ref Map ;
 $type pmap Map ;
 
 /** The transformation that maps periodic faces */
-$type periodicTransform store<rigid_transform> ;
+$type periodicTransform store<Loci::rigid_transform> ;
 
 /** Mapping from face to nodes that define the face */
 $type face2node multiMap ;

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -1564,13 +1564,6 @@ void AST_printTree::visit(AST_exprOper &s) {
       out << '?' ;
       if(*ii != 0)
 	(*ii)->accept(*this) ;
-      out << ':' ;
-      if(ii==s.terms.end()) {
-	cerr << "internal error on tertiary operator" << endl ;
-      } else
-	++ii ;
-      if(*ii != 0)
-	(*ii)->accept(*this) ;
       popindent() ;
     }
     break ;

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -1472,6 +1472,7 @@ void AST_printTree::visit(AST_exprOper &s) {
 	(*ii)->accept(*this) ;
     }
     popindent() ;
+    break ;
   case OP_BRACEBLOCK:
     {
       pushindent(s) ;

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -1465,6 +1465,13 @@ void AST_printTree::visit(AST_exprOper &s) {
       popindent() ;
     }
     break ;
+  case OP_TEMPLATE_CAST:
+    pushindent(s) ;
+    for(AST_type::ASTList::iterator ii=s.terms.begin();ii!=s.terms.end();++ii) {
+      if(*ii != 0)
+	(*ii)->accept(*this) ;
+    }
+    popindent() ;
   case OP_BRACEBLOCK:
     {
       pushindent(s) ;

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -1709,8 +1709,8 @@ public:
   AST_type::ASTP convertLociVar(AST_type::ASTP var) {
     CPTR<AST_Token> p = CPTR<AST_Token>(var) ;
     variable v(p->text) ;
-    while(v.get_info().priority.size() != 0)
-      v = v.drop_priority() ;
+    //    while(v.get_info().priority.size() != 0)
+    //      v = v.drop_priority() ;
     
     auto vmi = vnames.find(v) ;
     if(vmi == vnames.end()) {

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -501,6 +501,8 @@ AST_type::elementType tokenToOperator(AST_type::elementType nodeType) {
     return OP_COMMA ;
   case TK_QUESTION:
     return OP_TERNARY ;
+  case TK_COLON:
+    return OP_COLON ; // works with OP_TERNARY
   case TK_DOT:
     return OP_DOT ;
   default:
@@ -973,6 +975,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
        << endl ;
 #endif
 
+#ifdef C_STYLE_CAST
   // Check for a type cast
   if(ASTEqual(openToken,TK_DOUBLE) ||
      ASTEqual(openToken,TK_FLOAT) ||
@@ -989,12 +992,13 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
                                                            fileName,
                                                            typemap,prec)) ;
       return AST_type::ASTP(AST_data) ;
-    } 
+    }
   }
+#endif
   // Check for a parenthesized group or C-style cast ( type ) expr
   if(ASTEqual(openToken,TK_OPENPAREN)) {
     pushToken(openToken) ;
-    if(scanForCStyleCast(is, linecount,typemap)) {
+    if(false && scanForCStyleCast(is, linecount,typemap)) {
       // Cast has unary-level precedence: parse operand with parseExpressionPartial.
       (void)getToken(is, linecount) ; // '('
       AST_type::ASTP maybeType =
@@ -1033,6 +1037,16 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 #endif
     // parse expression contained within parenthesized group
     AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap) ;
+#ifdef VERBOSE
+    cerr << "parseExpressionPartial: creating group"
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
+    {
+      AST_simplePrint printer(cerr,-2) ;
+      exp->accept(printer) ;
+      cerr << endl ;
+    }
+#endif
     
     CPTR<AST_Token> closeToken = getToken(is,linecount) ;
     CPTR<AST_exprOper> group = new AST_exprOper ;
@@ -1094,8 +1108,8 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     cast->terms.push_back(AST_type::ASTP(openToken)) ;
     openToken=getToken(is,linecount) ;
     if(!ASTEqual(openToken,TK_OPENPAREN)) {
-      cerr << "expecting ')'" << endl ;
-      cast->terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting '>'",openToken->lineno,fileName))) ;
+      cerr << "expecting '('" << endl ;
+      cast->terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting '('",openToken->lineno,fileName))) ;
       return AST_type::ASTP(cast) ;
     }
     cast->terms.push_back(AST_type::ASTP(openToken)) ;
@@ -1288,6 +1302,11 @@ inline AST_type::operatorPrecedence getPrecedence(CPTR<AST_exprOper> op) {
   return getPrecedence(op->nodeType) ;
 }
 
+inline bool rightToLeftAssociativePrecedence(AST_type::operatorPrecedence op) {
+  return (op == AST_type::operatorPrecedence::PREC_ASSIGNMENT ||
+          op == AST_type::operatorPrecedence::PREC_UNARY_PREFIX) ;
+}
+
 inline bool precedenceCompare(AST_type::ASTP &op,
                               CPTR<AST_exprOper> &opStack) {
 
@@ -1295,12 +1314,22 @@ inline bool precedenceCompare(AST_type::ASTP &op,
   AST_type::operatorPrecedence prec_opStack = getPrecedence(opStack) ;
   //  if(prec_op == prec_opStack && op->nodeType == OP_TERNARY)
   //    return false ;
-  if(prec_op == prec_opStack &&
-     (prec_op == AST_type::operatorPrecedence::PREC_ASSIGNMENT ||
-      prec_op == AST_type::operatorPrecedence::PREC_UNARY_PREFIX))
-    return true ;
-  return prec_op > prec_opStack ;
+  return ((prec_op == prec_opStack &&
+           rightToLeftAssociativePrecedence(prec_op)) ||
+          prec_op > prec_opStack) ;
 }
+
+void printStack(vector<CPTR<AST_exprOper> > &exprStack,
+                ostream &out) {
+  out << "Stack:" << endl ;
+  for(size_t i=0;i<exprStack.size();++i) {
+    out << i << " - " ;
+    AST_simplePrint printer(out,-2) ;
+    exprStack[i]->accept(printer) ;
+    out << endl ;
+  }
+}
+
 AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                                        std::istream &is, int &linecount,
                                        const string &fileName,
@@ -1311,7 +1340,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
   // create stack and push sentinel on the stack
 
   // Note that if we have repeated operators that have default left
-  // associativity (e.g. a+b+c+d = (a+(b+(c+d))) then this will be structured
+  // associativity (e.g. a+b+c+d = (((a+b)+c)+d) then this will be structured
   // as a single plus node in the tree, e.g. (+:a b c d)
 
 #ifdef VERBOSE
@@ -1337,6 +1366,11 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
   }
   // After getting the first term we are in a loop of searching for operators
   do {
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
     // Check if we detect a terminating token
     CPTR<AST_Token> openToken = getToken(is,linecount) ;
     AST_type::elementType opcode = tokenToOperator(openToken->nodeType) ;
@@ -1344,12 +1378,22 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
     if(opprec <= prec) {
       // We found it, restore token and break out of loop
       pushToken(openToken) ;
+#ifdef VERBOSE
+      cerr << "exiting expression parsing due to precedence for token"
+           << OPtoName(openToken->nodeType) << endl ;
+#endif
       break ;
     }
     // restore token for parseOperator
     pushToken(openToken) ;
     // binary operator check
     AST_type::ASTP op = parseOperator(is, linecount) ;
+#ifdef VERBOSE
+    if(op == 0) {
+      cerr << "exiting expression parsing due to token"
+           << OPtoName(openToken->nodeType) << endl ;
+    }
+#endif
     if(op == 0)
       break ;
 
@@ -1379,6 +1423,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
            << OPtoName(exprStack.back()->nodeType)
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
 #endif
       // ?: must read ':' and the false branch here as well; the lower
       // branches only handle colon when exprStack.back() is not OP_NIL.
@@ -1386,13 +1433,20 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
         CPTR<AST_Token> op2 = getToken(is,linecount) ;
         if(ASTEqual(op2,TK_COLON)) {
           AST_type::ASTP expr3 =
-              parseExpressionPartial(is,linecount,fileName,typemap) ;
+            parseExpression(is,linecount,fileName,typemap,
+                            AST_type::operatorPrecedence::PREC_ASSIGNMENT) ;
+            //              parseExpressionPartial(is,linecount,fileName,typemap) ;
           if(expr3 == 0) {
             return AST_type::ASTP(new AST_syntaxError(
                 "Expecting expression after ':' in ?: operator", linecount,
                 fileName)) ;
           }
           exprStack.back()->terms.push_back(expr3) ;
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
         } else {
           pushToken(op2) ;
           return AST_type::ASTP(new AST_syntaxError(
@@ -1422,6 +1476,11 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
          << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
 #endif
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
         
       }
       
@@ -1434,6 +1493,11 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << " stack size=" << exprStack.size() 
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
+#endif
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
 #endif
       } else if(precedenceCompare(op,exprStack.back())) {
         // if operator is lower precedence than top of stack, then we need
@@ -1456,6 +1520,11 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
         if(ASTEqual(op,OP_TERNARY)) {
           CPTR<AST_Token> op2 = getToken(is,linecount) ;
 #ifdef VERBOSE
@@ -1464,7 +1533,15 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                << endl ;
 #endif
           if(ASTEqual(op2,TK_COLON)) {
-            expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+            //            expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+            expr = parseExpression(is,linecount,fileName,typemap,
+                                   AST_type::operatorPrecedence::PREC_COMMA) ;
+#ifdef VERBOSE
+            cerr << "after colon parsed expression:" << endl ;
+            AST_simplePrint printer(cerr,-2) ;
+            expr->accept(printer) ;
+#endif
+              
             np->terms.push_back(expr) ;
           } else {
             pushToken(op2) ;
@@ -1477,6 +1554,11 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << " stack size=" << exprStack.size()
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
+#endif
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
 #endif
       } else {
 	CPTR<AST_exprOper> np = new AST_exprOper ;
@@ -1511,9 +1593,22 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
+#ifdef VERBOSE
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
       }
     }
   } while(true) ;
+
+
+#ifdef VERBOSE
+  cerr << "parseExpressionOperator exit loop stack" << endl ;
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
 
   AST_type::ASTP e = CPTR<AST_type>(exprStack.front()) ;
   if(ASTEqual(exprStack.front(),OP_NIL)) 
@@ -2695,7 +2790,7 @@ void AST_simplePrint::visit(AST_exprOper &s) {
 }
 
 void AST_simplePrint::visit(AST_Token &s) {
-  if(s.lineno >0 && lineno != s.lineno) {
+  if(lineno != -2 && s.lineno >0 && lineno != s.lineno) {
     out << endl ;
     if(!prettyPrint)
       if(lineno < 0 || lineno+1 != s.lineno)

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -411,128 +411,100 @@ AST_type::ASTP parseTerm(std::istream &is, int &linecount) {
 }
 
 
-
-
+AST_type::elementType tokenToOperator(AST_type::elementType nodeType) {
+  switch(nodeType) {
+  case TK_SCOPE:
+    return OP_SCOPE ;
+    //-----------------------------------
+    // For using @ to separate namespaces
+  case TK_AT:
+    return OP_AT ;
+    //-----------------------------------
+    // Traditional C operators
+  case TK_ARROW:
+    return OP_ARROW ;
+  case TK_TIMES:
+    return OP_TIMES ;
+  case TK_DIVIDE:
+    return OP_DIVIDE ;
+  case TK_MODULUS:
+    return OP_MODULUS ;
+  case TK_PLUS:
+    return OP_PLUS ;
+  case TK_MINUS:
+    return OP_MINUS ;
+  case TK_SHIFT_RIGHT:
+    return OP_SHIFT_RIGHT ;
+  case TK_SHIFT_LEFT:
+    return OP_SHIFT_LEFT ;
+  case TK_LT:
+    return OP_LT ;
+  case TK_GT:
+    return OP_GT ;
+  case TK_GE:
+    return OP_GE ;
+  case TK_LE:
+    return OP_LE ;
+  case TK_EQUAL:
+    return OP_EQUAL ;
+  case TK_NOT_EQUAL:
+    return OP_NOT_EQUAL ;
+  case TK_AND:
+    return OP_AND ;
+  case TK_EXOR:
+    return OP_EXOR ;
+  case TK_OR:
+    return OP_OR ;
+  case TK_LOGICAL_AND:
+    return OP_LOGICAL_AND;
+  case TK_LOGICAL_OR:
+    return OP_LOGICAL_OR ;
+  case TK_ASSIGN:
+    return OP_ASSIGN ;
+  case TK_TIMES_ASSIGN:
+    return OP_TIMES_ASSIGN ;
+  case TK_DIVIDE_ASSIGN:
+    return OP_DIVIDE_ASSIGN ;
+  case TK_MODULUS_ASSIGN:
+    return OP_MODULUS_ASSIGN ;
+  case TK_PLUS_ASSIGN:
+    return OP_PLUS_ASSIGN ;
+  case TK_MINUS_ASSIGN:
+    return OP_MINUS_ASSIGN ;
+  case TK_SHIFT_LEFT_ASSIGN:
+    return OP_SHIFT_LEFT_ASSIGN ;
+  case TK_SHIFT_RIGHT_ASSIGN:
+    return OP_SHIFT_RIGHT_ASSIGN ;
+  case TK_AND_ASSIGN:
+    return OP_AND_ASSIGN ;
+  case TK_OR_ASSIGN:
+    return OP_OR_ASSIGN ;
+  case TK_EXOR_ASSIGN:
+    return OP_EXOR_ASSIGN ;
+  case TK_COMMA:
+    return OP_COMMA ;
+  case TK_QUESTION:
+    return OP_TERNARY ;
+  case TK_DOT:
+    return OP_DOT ;
+  default:
+    return OP_ERROR ;
+  }
+  return OP_ERROR ;
+}
 /// Parse operator token, convert from TK_* node type to OP_* nodetype
 AST_type::ASTP parseOperator(std::istream &is, int &linecount) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
   cerr << "in parseOperator, token = " << openToken->text << endl ;
 #endif
-  switch(openToken->nodeType) {
-  case TK_SCOPE:
-    openToken->nodeType = OP_SCOPE ;
-    return AST_type::ASTP(openToken) ;
-    //-----------------------------------
-    // For using @ to separate namespaces
-  case TK_AT:
-    openToken->nodeType = OP_AT ;
-    return AST_type::ASTP(openToken) ;
-    //-----------------------------------
-    // Traditional C operators
-  case TK_ARROW:
-    openToken->nodeType = OP_ARROW ;
-    return AST_type::ASTP(openToken) ;
-  case TK_TIMES:
-    openToken->nodeType = OP_TIMES ;
-    return AST_type::ASTP(openToken) ;
-  case TK_DIVIDE:
-    openToken->nodeType = OP_DIVIDE ;
-    return AST_type::ASTP(openToken) ;
-  case TK_MODULUS:
-    openToken->nodeType = OP_MODULUS ;
-    return AST_type::ASTP(openToken) ;
-  case TK_PLUS:
-    openToken->nodeType = OP_PLUS ;
-    return AST_type::ASTP(openToken) ;
-  case TK_MINUS:
-    openToken->nodeType = OP_MINUS ;
-    return AST_type::ASTP(openToken) ;
-  case TK_SHIFT_RIGHT:
-    openToken->nodeType = OP_SHIFT_RIGHT ;
-    return AST_type::ASTP(openToken) ;
-  case TK_SHIFT_LEFT:
-    openToken->nodeType = OP_SHIFT_LEFT ;
-    return AST_type::ASTP(openToken) ;
-  case TK_LT:
-    openToken->nodeType = OP_LT ;
-    return AST_type::ASTP(openToken) ;
-  case TK_GT:
-    openToken->nodeType = OP_GT ;
-    return AST_type::ASTP(openToken) ;
-  case TK_GE:
-    openToken->nodeType = OP_GE ;
-    return AST_type::ASTP(openToken) ;
-  case TK_LE:
-    openToken->nodeType = OP_LE ;
-    return AST_type::ASTP(openToken) ;
-  case TK_EQUAL:
-    openToken->nodeType = OP_EQUAL ;
-    return AST_type::ASTP(openToken) ;
-  case TK_NOT_EQUAL:
-    openToken->nodeType = OP_NOT_EQUAL ;
-    return AST_type::ASTP(openToken) ;
-  case TK_AND:
-    openToken->nodeType = OP_AND ;
-    return AST_type::ASTP(openToken) ;
-  case TK_EXOR:
-    openToken->nodeType = OP_EXOR ;
-    return AST_type::ASTP(openToken) ;
-  case TK_OR:
-    openToken->nodeType = OP_OR ;
-    return AST_type::ASTP(openToken) ;
-  case TK_LOGICAL_AND:
-    openToken->nodeType = OP_LOGICAL_AND;
-    return AST_type::ASTP(openToken) ;
-  case TK_LOGICAL_OR:
-    openToken->nodeType = OP_LOGICAL_OR ;
-    return AST_type::ASTP(openToken) ;
-  case TK_ASSIGN:
-    openToken->nodeType = OP_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_TIMES_ASSIGN:
-    openToken->nodeType = OP_TIMES_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_DIVIDE_ASSIGN:
-    openToken->nodeType = OP_DIVIDE_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_MODULUS_ASSIGN:
-    openToken->nodeType = OP_MODULUS_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_PLUS_ASSIGN:
-    openToken->nodeType = OP_PLUS_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_MINUS_ASSIGN:
-    openToken->nodeType = OP_MINUS_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_SHIFT_LEFT_ASSIGN:
-    openToken->nodeType = OP_SHIFT_LEFT_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_SHIFT_RIGHT_ASSIGN:
-    openToken->nodeType = OP_SHIFT_RIGHT_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_AND_ASSIGN:
-    openToken->nodeType = OP_AND_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_OR_ASSIGN:
-    openToken->nodeType = OP_OR_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_EXOR_ASSIGN:
-    openToken->nodeType = OP_EXOR_ASSIGN ;
-    return AST_type::ASTP(openToken) ;
-  case TK_COMMA:
-    openToken->nodeType = OP_COMMA ;
-    return AST_type::ASTP(openToken) ;
-  case TK_QUESTION:
-    openToken->nodeType = OP_TERNARY ;
-    return AST_type::ASTP(openToken) ;
-  case TK_DOT:
-    openToken->nodeType = OP_DOT ;
-    return AST_type::ASTP(openToken) ;
-  default:
+  AST_type::elementType op = tokenToOperator(openToken->nodeType) ;
+  if(op == OP_ERROR) {
     pushToken(openToken) ;
     return AST_type::ASTP(0) ;
   }
+  openToken->nodeType = op ;
+  return AST_type::ASTP(openToken) ;
 }
 
 /// Check for input token that is a unary operator
@@ -960,7 +932,8 @@ bool scanForCStyleCast(std::istream &is, int &linecount,varmap &typemap) {
 /// Parse the part of an expression that is not a binary or ternary operator
 AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 				      const string &fileName,
-				      varmap &typemap) {
+				      varmap &typemap,
+                                      AST_type::operatorPrecedence prec) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
   cerr << "in parseExpressionPartial, token = " << openToken->text << endl ;
@@ -980,7 +953,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       AST_data->type_decl.push_back(AST_type::ASTP(openToken)) ;
       AST_data->type_decl.push_back(parseExpressionPartial(is,linecount,
                                                            fileName,
-                                                           typemap)) ;
+                                                           typemap,prec)) ;
       return AST_type::ASTP(AST_data) ;
     } 
   }
@@ -1006,7 +979,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
             "invalid type in cast", closeTok->lineno, fileName)) ;
       }
       AST_type::ASTP operand =
-          parseExpressionPartial(is, linecount, fileName, typemap) ;
+        parseExpressionPartial(is, linecount, fileName, typemap,prec) ;
       if(operand == 0) {
         return AST_type::ASTP(new AST_syntaxError(
             "expecting expression after cast", closeTok->lineno, fileName)) ;
@@ -1020,9 +993,9 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     }
     openToken = getToken(is, linecount) ;
 #ifdef VERBOSE
-  cerr << "parseExpressionPartial: Found '(' parsing new expression" << endl ;
+    cerr << "parseExpressionPartial: Found '(' parsing new expression" << endl ;
 #endif    
-    AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap) ;
+    AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap,prec) ;
     CPTR<AST_Token> closeToken = getToken(is,linecount) ;
     CPTR<AST_exprOper> group = new AST_exprOper ;
     group->nodeType = OP_GROUP ;
@@ -1047,7 +1020,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     }
     pushToken(afterBrace) ;
     AST_type::ASTP inner =
-        parseExpression(is,linecount,fileName,typemap) ;
+      parseExpression(is,linecount,fileName,typemap,prec) ;
     CPTR<AST_Token> closeTok = getToken(is,linecount) ;
     if(closeTok->nodeType != TK_CLOSEBRACE) {
       pushToken(closeTok) ;
@@ -1069,7 +1042,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 #endif    
     //check for unary operators
     AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,
-						 typemap) ;
+						 typemap,prec) ;
     if(expr!= 0) {
       CPTR<AST_exprOper> unary = new AST_exprOper ;
       unary->nodeType = unaryOperator(openToken->nodeType) ;
@@ -1128,9 +1101,8 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 
 /// get precedence of operator code (larger = tighter binding).
 inline AST_type::operatorPrecedence getPrecedence(AST_type::elementType op) {
+  // Note going from highest precedence to lowest
   switch(op) {
-  case OP_NIL:
-    return AST_type::operatorPrecedence::PREC_ERROR ;
   case OP_SCOPE:
   case OP_AT:
     return AST_type::operatorPrecedence::PREC_SCOPE ;
@@ -1150,6 +1122,7 @@ inline AST_type::operatorPrecedence getPrecedence(AST_type::elementType op) {
   case OP_AMPERSAND:
   case OP_DOLLAR:
     return AST_type::operatorPrecedence::PREC_UNARY_PREFIX ;
+    // Not implementing member access right now
     //        return AST_type::operatorPrecedence::PREC_MEMBER_ACCESS ;
   case OP_TIMES:
   case OP_DIVIDE:
@@ -1194,6 +1167,8 @@ inline AST_type::operatorPrecedence getPrecedence(AST_type::elementType op) {
     return AST_type::operatorPrecedence::PREC_ASSIGNMENT ;
   case OP_COMMA:
     return AST_type::operatorPrecedence::PREC_COMMA ;
+  case OP_NIL:
+    return AST_type::operatorPrecedence::PREC_ERROR ;
   default:
     return AST_type::operatorPrecedence::PREC_ERROR ;
   }
@@ -1212,20 +1187,28 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                                        std::istream &is, int &linecount,
                                        const string &fileName,
                                        varmap &typemap,
-                                       AST_type::elementType
-                                       term) {
+                                       AST_type::operatorPrecedence
+                                       prec) {
   // exprStack holds already processed binary operators
   // create stack and push sentinel on the stack
 
   // Note that if we have repeated operators that have default left
   // associativity (e.g. a+b+c+d = (a+(b+(c+d))) then this will be structured
   // as a single plus node in the tree, e.g. (+:a b c d)
-  
+
+#ifdef VERBOSE
+  cerr << "in parseExpressionOperator" ;
+  if(expr == 0)
+    cerr << " with nil expr" ;
+  cerr << endl ;
+#endif
   vector<CPTR<AST_exprOper> > exprStack ;
   {
     CPTR<AST_exprOper> tmp = new AST_exprOper ;
     tmp->nodeType = OP_NIL ;
-    tmp->terms.push_back(expr) ;
+    if(expr!=0)
+      tmp->terms.push_back(expr) ;
+
     exprStack.push_back(tmp) ;
 #ifdef VERBOSE
     cerr << "push op = " << OPtoName(exprStack.back()->nodeType)  << endl ;
@@ -1235,7 +1218,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
   do {
     // Check if we detect a terminating token
     CPTR<AST_Token> openToken = getToken(is,linecount) ;
-    if(openToken->nodeType == term) {
+    AST_type::elementType opcode = tokenToOperator(openToken->nodeType) ;
+    AST_type::operatorPrecedence opprec = getPrecedence(opcode) ;
+    if(opprec <= prec) {
       // We found it, restore token and break out of loop
       pushToken(openToken) ;
       break ;
@@ -1401,14 +1386,17 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 /// parseExpressionPartial
 AST_type::ASTP parseExpression(std::istream &is, int &linecount,
 			       const string &fileName,
-			       varmap &typemap) {
+			       varmap &typemap,
+                               AST_type::operatorPrecedence prec) {
 #ifdef VERBOSE
   cerr << "in parseExpression"<< endl ;
 #endif
-  AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+
+  AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap,prec) ;
   if(expr == 0) // If no valid expression then return null
     return expr ;
-  return parseExpressionOperator(expr,is,linecount,fileName,typemap) ;
+  
+  return parseExpressionOperator(expr,is,linecount,fileName,typemap,prec) ;
   
 }
 
@@ -1794,6 +1782,16 @@ AST_type::ASTP parseDeclarationOrSimpleStatement(std::istream &is,
 #ifdef VERBOSE
   cerr << "in parseDeclarationOrSimpleStatement"<< endl;
 #endif
+  // If starts with a unary operator or '(' then it is a simple statement
+  CPTR<AST_Token> openToken = getToken(is,linecount) ;
+  pushToken(openToken) ;
+  if(checkUnaryToken(openToken) || ASTEqual(openToken,TK_OPENPAREN)) {
+#ifdef VERBOSE
+    cerr << "Starts with operator or grouping so call parseSimpleStatement"
+         << endl ;
+#endif
+    return parseSimpleStatement(is,linecount,fileName,typemap) ;
+  }
   bool isFunc = false ;
   string ident = getIdentifierName(is,linecount,fileName,isFunc) ;
 #ifdef VERBOASE
@@ -1945,7 +1943,7 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
 #endif
       if(expr != 0) { // If no valid expression then return null
         expr = parseExpressionOperator(expr,is,linecount,fileName,typemap,
-                                       TK_COMMA) ;
+                                       AST_type::operatorPrecedence::PREC_COMMA) ;
       } else {
 #ifdef VERBOSE
   cerr << "in parseDeclaration, parseExpressionPartial returned nil " <<  endl ;
@@ -1960,6 +1958,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
       token = getToken(is,linecount) ;
     }
     if(ASTEqual(token,TK_COMMA)) {
+#ifdef VERBOSE
+      cerr << "pushing TK_COMMA onto decls"<< endl ;
+#endif
       AST_data->decls.push_back(AST_type::ASTP(token)) ;
       token = getToken(is,linecount) ;
     }

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -191,19 +191,25 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
   CPTR<AST_Token> token = getToken(is,linecount) ;
   do {
 #ifdef VERBOSE
-    cerr << "in parseTypeSpecifier, token = " << token->text << endl ;
+    cerr << "in parseTypeSpecifier, token = " << token->text 
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     switch(token->nodeType) {
     case TK_CONST:
       type_spec.push_back(AST_type::ASTP(token)) ;
 #ifdef VERBOSE
-      cerr << "in parseTypeSpecifier const variable" << endl ;
+      cerr << "in parseTypeSpecifier const variable"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       break ;
     case TK_EXTERN:
       type_spec.push_back(AST_type::ASTP(token)) ;
 #ifdef VERBOSE
-      cerr << "in parseTypeSpecifier extern variable" << endl ;
+      cerr << "in parseTypeSpecifier extern variable"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       break ;
     case TK_CHAR:
@@ -218,7 +224,9 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
     case TK_UNSIGNED:
     case TK_AUTO:
 #ifdef VERBOSE
-      cerr << "in parseTypeSpecifier, builtin type" << endl ;
+      cerr << "in parseTypeSpecifier, builtin type"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       builtin_type = true ;
       if(defined_type) { // This is a syntax error
@@ -233,7 +241,9 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
     case TK_SCOPE:
     case TK_NAME:
 #ifdef VERBOSE
-      cerr << "in parseTypeSpecifier, named type" << endl ;
+      cerr << "in parseTypeSpecifier, named type"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       if(builtin_type || defined_type ) {
         istype = false ;
@@ -258,7 +268,9 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
       break ;
     default:
 #ifdef VERBOSE
-      cerr << "in parseTypeSpecifier, finished type parsing" << endl ;
+      cerr << "in parseTypeSpecifier, finished type parsing"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       istype = false ;
       break ;
@@ -399,7 +411,9 @@ inline bool isTerm(const CPTR<AST_Token> &p) {
 AST_type::ASTP parseTerm(std::istream &is, int &linecount) {
   CPTR<AST_Token> token = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseTerm, token = " << token->text << endl ;
+  cerr << "in parseTerm, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   if(isTerm(token))
     return AST_type::ASTP(token) ;
@@ -496,7 +510,9 @@ AST_type::elementType tokenToOperator(AST_type::elementType nodeType) {
 AST_type::ASTP parseOperator(std::istream &is, int &linecount) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseOperator, token = " << openToken->text << endl ;
+  cerr << "in parseOperator, token = " << openToken->text
+         << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   AST_type::elementType op = tokenToOperator(openToken->nodeType) ;
   if(op == OP_ERROR) {
@@ -576,7 +592,9 @@ AST_type::ASTP applyPostFixOperator(AST_type::ASTP expr,
 				    varmap &typemap) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in applyPostFixOperator, token = " << openToken->text << endl ;
+  cerr << "in applyPostFixOperator, token = " << openToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   if(checkPostFixToken(openToken->nodeType)) {
     CPTR<AST_exprOper> post = new AST_exprOper ;
@@ -626,7 +644,8 @@ AST_type::ASTP parseScopedObject(std::istream &is, int &linecount,
        << OPtoName(openToken->nodeType) ;
     if(ASTEqual(openToken,TK_NAME))
       cerr << " name=" << openToken->text ;
-    cerr << endl ;
+    cerr << ", file: " << __FILE__ << ":" << __LINE__ 
+         << endl ;
 #endif
   AST_type::ASTList terms ;
   // Special case for global scope (eg ::name)
@@ -648,7 +667,9 @@ AST_type::ASTP parseScopedObject(std::istream &is, int &linecount,
   openToken = getToken(is,linecount) ;
 
 #ifdef VERBOSE
-  cerr << "searching token = " << openToken->text << endl ;
+  cerr << "searching token = " << openToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   while(ASTEqual(openToken,TK_SCOPE)) {
     openToken = getToken(is,linecount) ;
@@ -679,7 +700,8 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
   // Template Arguments
 #ifdef VERBOSE
   cerr << "parseTemplateArguments: found term template open '<'" 
-           << endl ;
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   CPTR<AST_Token> token = getToken(is,linecount) ;
   AST_type::ASTP arg = AST_type::ASTP(token) ;
@@ -690,12 +712,14 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
   
 #ifdef VERBOSE
   cerr << "parseTemplateArguments: parsed type specification " 
+       << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif    
   CPTR<AST_Token> closeToken = getToken(is,linecount) ;
   if(ASTEqual(closeToken,TK_CLOSETEMPLATE)) {
 #ifdef VERBOSE
   cerr << "parseTemplateArguments: only single argument " 
+       << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif    
     // only a single type in template parameters
@@ -709,6 +733,7 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
 
 #ifdef VERBOSE
   cerr << "parseTemplateArguments: parsing comma separated list of types " 
+       << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif    
     
@@ -716,7 +741,9 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
     tlist->nodeType = OP_COMMA ;    tlist->terms.push_back(arg) ;
     while(ASTEqual(closeToken,TK_COMMA)) {
 #ifdef VERBOSE
-      cerr << "parseTemplateArgument, got " << closeToken->text<< endl ;
+      cerr << "parseTemplateArgument, got " << closeToken->text
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       CPTR<AST_Token> token = getToken(is,linecount) ;
       AST_type::ASTP arg = AST_type::ASTP(token) ;
@@ -750,6 +777,7 @@ AST_type::ASTP parseFunctionArguments(AST_type::ASTP objname,
                                       varmap &typemap) {
 #ifdef VERBOSE
   cerr << "parseFunctionArguments: found term template open '('" 
+       << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif    
   AST_type::ASTP args = parseExpression(is,linecount,fileName,typemap) ;
@@ -773,7 +801,9 @@ AST_type::ASTP parseIdentifier(std::istream &is, int &linecount,
 				      const string &fileName,
 				      varmap &typemap) {
 #ifdef VERBOSE
-  cerr << "in parseIdentifier" << endl ;
+  cerr << "in parseIdentifier"
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif 
 
   AST_type::ASTP objname = parseScopedObject(is,linecount,fileName,typemap) ;
@@ -936,7 +966,9 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
                                       AST_type::operatorPrecedence prec) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseExpressionPartial, token = " << openToken->text << endl ;
+  cerr << "in parseExpressionPartial, token = " << openToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
 
   // Check for a type cast
@@ -971,15 +1003,14 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
         return AST_type::ASTP(new AST_syntaxError(
             "expecting ')' in cast", closeTok->lineno, fileName)) ;
       }
-      AST_typeSpec *tsp =
-          dynamic_cast<AST_typeSpec *>(maybeType.operator->()) ;
+      CPTR<AST_typeSpec> ts = CPTR<AST_typeSpec>(maybeType) ;
       if(maybeType == 0 || maybeType->nodeType != ND_TYPE_SPEC ||
-         tsp == 0 || tsp->type_spec.empty()) {
+         ts == 0 || ts->type_spec.empty()) {
         return AST_type::ASTP(new AST_syntaxError(
             "invalid type in cast", closeTok->lineno, fileName)) ;
       }
       AST_type::ASTP operand =
-        parseExpressionPartial(is, linecount, fileName, typemap,prec) ;
+        parseExpressionPartial(is, linecount, fileName, typemap) ;
       if(operand == 0) {
         return AST_type::ASTP(new AST_syntaxError(
             "expecting expression after cast", closeTok->lineno, fileName)) ;
@@ -991,11 +1022,16 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       return applyPostFixOperator(AST_type::ASTP(castNode), is, linecount,
                                   fileName, typemap) ;
     }
+    // Grab '('
     openToken = getToken(is, linecount) ;
 #ifdef VERBOSE
-    cerr << "parseExpressionPartial: Found '(' parsing new expression" << endl ;
-#endif    
-    AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap,prec) ;
+    cerr << "parseExpressionPartial: Found '(' parsing new expression"
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
+#endif
+    // parse expression contained within parenthesized group
+    AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap) ;
+    
     CPTR<AST_Token> closeToken = getToken(is,linecount) ;
     CPTR<AST_exprOper> group = new AST_exprOper ;
     group->nodeType = OP_GROUP ;
@@ -1020,7 +1056,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     }
     pushToken(afterBrace) ;
     AST_type::ASTP inner =
-      parseExpression(is,linecount,fileName,typemap,prec) ;
+      parseExpression(is,linecount,fileName,typemap) ;
     CPTR<AST_Token> closeTok = getToken(is,linecount) ;
     if(closeTok->nodeType != TK_CLOSEBRACE) {
       pushToken(closeTok) ;
@@ -1038,11 +1074,13 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 #ifdef VERBOSE
     cerr << "parseExpressionPartial: found unary operator '"
          << openToken->text << " parsing unary target." 
+         << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
 #endif    
     //check for unary operators
-    AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,
-						 typemap,prec) ;
+    AST_type::ASTP expr =
+      parseExpression(is,linecount,fileName,typemap,
+                      AST_type::operatorPrecedence::PREC_UNARY_PREFIX) ;
     if(expr!= 0) {
       CPTR<AST_exprOper> unary = new AST_exprOper ;
       unary->nodeType = unaryOperator(openToken->nodeType) ;
@@ -1050,6 +1088,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 #ifdef VERBOSE
       cerr << "parseExpressionPartial: creating unary operator, "
            << "search for postfix operators ++,--, or []" 
+           << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
 #endif    
       return applyPostFixOperator(AST_type::ASTP(unary),is,linecount,fileName,
@@ -1086,6 +1125,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 #ifdef VERBOSE
     cerr << "parseExpressionPartial: found term '" 
          << openToken->text << "', checking for following parenthesis"
+         << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
 #endif    
     pushToken(openToken) ;
@@ -1200,7 +1240,8 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
   cerr << "in parseExpressionOperator" ;
   if(expr == 0)
     cerr << " with nil expr" ;
-  cerr << endl ;
+  cerr << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   vector<CPTR<AST_exprOper> > exprStack ;
   {
@@ -1211,7 +1252,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 
     exprStack.push_back(tmp) ;
 #ifdef VERBOSE
-    cerr << "push op = " << OPtoName(exprStack.back()->nodeType)  << endl ;
+    cerr << "push op = " << OPtoName(exprStack.back()->nodeType)
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
   }
   // After getting the first term we are in a loop of searching for operators
@@ -1233,11 +1276,14 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
       break ;
 
 #ifdef VERBOSE
-    cerr << "parseExpression operator op = " << OPtoString(op->nodeType) << endl ;
+    cerr << "parseExpression operator op = " << OPtoString(op->nodeType)
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     // Special case for ?: operator or array
     if(ASTEqual(op,OP_TERNARY)) 
-      expr = parseExpression(is,linecount,fileName,typemap) ;
+      expr = parseExpression(is,linecount,fileName,typemap,
+                             AST_type::operatorPrecedence::PREC_ASSIGNMENT) ;
     else 
       expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
     
@@ -1253,7 +1299,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 #ifdef VERBOSE
       cerr << "replacing OP_NIL on exprStack with "
            << OPtoName(exprStack.back()->nodeType)
-           << " line " << __LINE__
+           << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
 #endif
       // ?: must read ':' and the false branch here as well; the lower
@@ -1281,16 +1327,22 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
             getPrecedence(op) <= getPrecedence(exprStack.back())) {
 #ifdef VERBOSE
 	if(ASTEqual(op,OP_TERNARY)) {
-	  cerr << "pop stack when OP_TERNARY" << endl ;
+	  cerr << "pop stack when OP_TERNARY"
+               << ", file: " << __FILE__ << ":" << __LINE__
+               << endl ;
 	}
 #endif
 #ifdef VERBOSE
-    cerr << "pop off exprStack:" << OPtoName(exprStack.back()->nodeType)  << endl ;
+    cerr << "pop off exprStack:" << OPtoName(exprStack.back()->nodeType)
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
 	exprStack.pop_back() ;
 #ifdef VERBOSE
     cerr << "after pop top of stack is:" << OPtoName(exprStack.back()->nodeType)
-         << ", size=" << exprStack.size() << endl ;
+         << ", size=" << exprStack.size()
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
         
       }
@@ -1302,6 +1354,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
         cerr << "adding term to operator: "
              << OPtoName(exprStack.back()->nodeType)
              << " stack size=" << exprStack.size() 
+             << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
       } else if(getPrecedence(op) > getPrecedence(exprStack.back())) {
@@ -1313,6 +1366,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
         cerr << "top of stack is" << OPtoName(exprStack.back()->nodeType)
              << endl ;
         cerr << "editing rightmost term: " << OPtoName(exprStack.back()->terms.back()->nodeType)
+             << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
         np->terms.push_back(exprStack.back()->terms.back()) ;
@@ -1321,12 +1375,15 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 #ifdef VERBOSE
         cerr << "pushing " << OPtoName(exprStack.back()->nodeType)
              << "to stack,  line " << __LINE__
+             << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
         if(ASTEqual(op,OP_TERNARY)) {
           CPTR<AST_Token> op2 = getToken(is,linecount) ;
 #ifdef VERBOSE
-          cerr << " detected OP_TERNARY, op2 =" << op2->text << endl ;
+          cerr << " detected OP_TERNARY, op2 =" << op2->text
+               << ", file: " << __FILE__ << ":" << __LINE__
+               << endl ;
 #endif
           if(ASTEqual(op2,TK_COLON)) {
             expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
@@ -1339,14 +1396,18 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
         exprStack.push_back(np) ;
 #ifdef VERBOSE
         cerr << "pushing on exprStack:" << OPtoName(exprStack.back()->nodeType)
-             << " stack size=" << exprStack.size() << endl ;
+             << " stack size=" << exprStack.size()
+             << ", file: " << __FILE__ << ":" << __LINE__
+             << endl ;
 #endif
       } else {
 	CPTR<AST_exprOper> np = new AST_exprOper ;
 	np->nodeType = op->nodeType ;
 #ifdef VERBOSE
         cerr << "creating lower precidence op="
-             << OPtoName(np->nodeType)  << endl ;
+             << OPtoName(np->nodeType)
+             << ", file: " << __FILE__ << ":" << __LINE__
+             << endl ;
 #endif        
 	np->terms.push_back(AST_type::ASTP(exprStack.back())) ;
 	np->terms.push_back(expr) ;
@@ -1360,14 +1421,16 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 	  }
 	  np->terms.push_back(expr) ;
 #ifdef VERBOSE
-	  cerr << " processed OP_TERNARY" << endl ;
+	  cerr << " processed OP_TERNARY"
+               << ", file: " << __FILE__ << ":" << __LINE__
+               << endl ;
 #endif
 	  
 	} 
 	exprStack.back() = np ;
 #ifdef VERBOSE
         cerr << "changing exprStack to" << OPtoName(exprStack.back()->nodeType)
-             << " line " << __LINE__
+             << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
       }
@@ -1389,7 +1452,9 @@ AST_type::ASTP parseExpression(std::istream &is, int &linecount,
 			       varmap &typemap,
                                AST_type::operatorPrecedence prec) {
 #ifdef VERBOSE
-  cerr << "in parseExpression"<< endl ;
+  cerr << "in parseExpression"
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
 
   AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap,prec) ;
@@ -1406,7 +1471,9 @@ AST_type::ASTP parseCaseStatement(std::istream &is, int &linecount,
 				  varmap &typemap) {
   CPTR<AST_Token> token = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseCaseStatement, token = " << token->text << endl ;
+  cerr << "in parseCaseStatement, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   if(!ASTEqual(token,TK_CASE) &&
      !ASTEqual(token,TK_DEFAULT)) {
@@ -1438,7 +1505,9 @@ AST_type::ASTP parseSwitchStatement(std::istream &is, int &linecount,
 				    varmap &typemap)  {
   CPTR<AST_Token> token = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseSwitchStatement, token = " << token->text << endl ;
+  cerr << "in parseSwitchStatement, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   AST_type::ASTP switchtok(token) ;
   CPTR<AST_controlStatement> ctrl = new AST_controlStatement ;
@@ -1491,7 +1560,9 @@ AST_type::ASTP parseIfStatement(std::istream &is, int &linecount,
 				varmap &typemap)  {
   CPTR<AST_Token> token = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseIfStatement, token = " << token->text << endl ;
+  cerr << "in parseIfStatement, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   if(!ASTEqual(token,TK_IF)) {
     pushToken(token) ;
@@ -1532,7 +1603,9 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
 				  varmap &typemap) {
   CPTR<AST_Token> token = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseLoopStatement, token = " << token->text << endl ;
+  cerr << "in parseLoopStatement, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   AST_type::ASTP loop = AST_type::ASTP(token) ;
   CPTR<AST_controlStatement> ctrl = new AST_controlStatement ;
@@ -1564,7 +1637,9 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
       ctrl->parts.push_back(AST_type::ASTP(token)) ;
       token = getToken(is,linecount) ;
 #ifdef VERBOSE
-      cerr << "for loop parsed TK_OPEN_PAREN, next token = " << OPtoName(token->nodeType) << endl ;
+      cerr << "for loop parsed TK_OPEN_PAREN, next token = " << OPtoName(token->nodeType)
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       
       AST_type::ASTP initializer = 0 ;
@@ -1592,18 +1667,24 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
             parseSimpleStatement(is,linecount,fileName,ctrl->identifiers) ;
       }
 #ifdef VERBOSE
-      cerr << "initializer = " << OPtoName(initializer->nodeType) << endl ;
+      cerr << "initializer = " << OPtoName(initializer->nodeType)
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif      
       ctrl->parts.push_back(initializer) ;
 	
 #ifdef VERBOSE
-      cerr << "for: parsing conditional expression" << endl;
+      cerr << "for: parsing conditional expression"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl;
 #endif
       AST_type::ASTP conditional = parseExpression(is,linecount,fileName,
 						   ctrl->identifiers) ;
       
 #ifdef VERBOSE
-      cerr << "conditional = " << OPtoName(conditional->nodeType) << endl ;
+      cerr << "conditional = " << OPtoName(conditional->nodeType)
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif      
       ctrl->parts.push_back(conditional) ;
       token = getToken(is,linecount) ;
@@ -1708,7 +1789,9 @@ string getIdentifierName(std::istream &is,
                          const string &fileName,
                          bool &isFunc) {
 #ifdef VERBOSE
-  cerr << "in getIdentifierName" << endl ;
+  cerr << "in getIdentifierName"
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   vector<CPTR<AST_Token>>  token_stack ;
   isFunc = false ;
@@ -1732,12 +1815,16 @@ string getIdentifierName(std::istream &is,
       break ;
   }
 #ifdef VERBOSE
-  cerr << "ident name = " << name << endl ;
+  cerr << "ident name = " << name
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   // if template, parse template arguments
   if(ASTEqual(token,TK_OPENTEMPLATE)) {
 #ifdef VERBOSE
-    cerr << "identifier is template" << endl ;
+    cerr << "identifier is template"
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     int count = 1 ;
     name += "<" ;
@@ -1765,7 +1852,9 @@ string getIdentifierName(std::istream &is,
   for(auto ii = token_stack.rbegin();ii!=token_stack.rend();++ii)
     pushToken(*ii) ;
 #ifdef VERBOSE
-  cerr << "return ident name = " << name << endl ;
+  cerr << "return ident name = " << name
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   return name ;
 }
@@ -1780,7 +1869,9 @@ AST_type::ASTP parseDeclarationOrSimpleStatement(std::istream &is,
                                                  const string &fileName,
                                                  varmap &typemap) {
 #ifdef VERBOSE
-  cerr << "in parseDeclarationOrSimpleStatement"<< endl;
+  cerr << "in parseDeclarationOrSimpleStatement"
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl;
 #endif
   // If starts with a unary operator or '(' then it is a simple statement
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
@@ -1788,6 +1879,7 @@ AST_type::ASTP parseDeclarationOrSimpleStatement(std::istream &is,
   if(checkUnaryToken(openToken) || ASTEqual(openToken,TK_OPENPAREN)) {
 #ifdef VERBOSE
     cerr << "Starts with operator or grouping so call parseSimpleStatement"
+         << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
 #endif
     return parseSimpleStatement(is,linecount,fileName,typemap) ;
@@ -1803,7 +1895,9 @@ AST_type::ASTP parseDeclarationOrSimpleStatement(std::istream &is,
   auto ii = typemap.find(ident) ;
 #ifdef VERBOSE
   if( ii != typemap.end()) {
-    cerr << "typemap defines " << ident << endl ;
+    cerr << "typemap defines " << ident
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
   }
 #endif
   if(ii != typemap.end() && ii->second.isLocalIdentifier()) {
@@ -1827,20 +1921,26 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
 
   do {
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, token = " << token->text << endl ;
+  cerr << "in parseDeclaration, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
     switch(token->nodeType) {
     case TK_CONST:
       // TK_REGISTER,TK_VOLATILE,TK_MUTABLE add later
       AST_data->type_decl.push_back(AST_type::ASTP(token)) ;
 #ifdef VERBOSE
-      cerr << "in parseDeclaration, const variable" << endl ;
+      cerr << "in parseDeclaration, const variable"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       break ;
     case TK_EXTERN:
       AST_data->type_decl.push_back(AST_type::ASTP(token)) ;
 #ifdef VERBOSE
-      cerr << "in parseDeclaration, extern variable" << endl ;
+      cerr << "in parseDeclaration, extern variable"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       break ;
     case TK_CHAR:
@@ -1855,7 +1955,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
     case TK_UNSIGNED:
     case TK_AUTO:
 #ifdef VERBOSE
-      cerr << "in parseDeclaration, builtin type" << endl ;
+      cerr << "in parseDeclaration, builtin type"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       builtin_type = true ;
       if(defined_type) { // This is a syntax error
@@ -1870,7 +1972,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
     case TK_SCOPE:
     case TK_NAME:
 #ifdef VERBOSE
-      cerr << "in parseDeclaration, named type" << endl ;
+      cerr << "in parseDeclaration, named type"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       if(builtin_type || defined_type ) {
         istype = false ;
@@ -1896,7 +2000,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
     default:
 #ifdef VERBOSE
       cerr << "in parseDeclaration, finished type parsing" << endl ;
-      cerr << "parsed token " << OPtoName(token->nodeType) << endl ;
+      cerr << "parsed token " << OPtoName(token->nodeType)
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       istype = false ;
       break ;
@@ -1907,13 +2013,17 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
 
 #ifdef VERBOSE
   cerr << "in parseDeclaration, processing declarations: " << token->text
-       << " " << OPtoName(token->nodeType) << endl;
+       << " " << OPtoName(token->nodeType)
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl;
 #endif
   while(ASTEqual(token,TK_NAME) ||
         ASTEqual(token,TK_TIMES) ||
         ASTEqual(token,TK_AND)) {
 #ifdef VERBOSE
-    cerr << "in parseDeclaration, found name, * or & " << endl ;
+    cerr << "in parseDeclaration, found name, * or & "
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
 
     if(ASTEqual(token,TK_TIMES)) {
@@ -1930,7 +2040,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
     }
     
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, processed pointer or reference: " << token->text << endl ;
+  cerr << "in parseDeclaration, processed pointer or reference: " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
     if(ASTEqual(token,TK_NAME)) {
       typemap[token->text] = localIdentifier() ;
@@ -1939,14 +2051,18 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
       
       AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, parsing expression " <<  endl ;
+  cerr << "in parseDeclaration, parsing expression "
+       << ", file: " << __FILE__ << ":" << __LINE__
+       <<  endl ;
 #endif
       if(expr != 0) { // If no valid expression then return null
         expr = parseExpressionOperator(expr,is,linecount,fileName,typemap,
                                        AST_type::operatorPrecedence::PREC_COMMA) ;
       } else {
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, parseExpressionPartial returned nil " <<  endl ;
+  cerr << "in parseDeclaration, parseExpressionPartial returned nil "
+       << ", file: " << __FILE__ << ":" << __LINE__
+       <<  endl ;
 #endif
         
         AST_type::ASTP p =
@@ -1959,7 +2075,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
     }
     if(ASTEqual(token,TK_COMMA)) {
 #ifdef VERBOSE
-      cerr << "pushing TK_COMMA onto decls"<< endl ;
+      cerr << "pushing TK_COMMA onto decls"
+           << ", file: " << __FILE__ << ":" << __LINE__
+           << endl ;
 #endif
       AST_data->decls.push_back(AST_type::ASTP(token)) ;
       token = getToken(is,linecount) ;
@@ -1988,7 +2106,9 @@ AST_type::ASTP parseSpecialControlStatement(std::istream &is, int &linecount,
   AST_data->nodeType = OP_SPECIAL ;
   CPTR<AST_Token> token = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseSpecialControlStatement, token = " << token->text << endl ;
+  cerr << "in parseSpecialControlStatement, token = " << token->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   AST_data->elements.push_back(AST_type::ASTP(token)) ;
   token = getToken(is,linecount) ;
@@ -2017,7 +2137,9 @@ AST_type::ASTP parseSimpleStatement(std::istream &is, int &linecount,
                                     const string &fileName,
                                     varmap &typemap) {
 #ifdef VERBOSE
-  cerr << "in parseSimpleStatement" << endl ;
+  cerr << "in parseSimpleStatement"
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap) ;
   
@@ -2025,6 +2147,7 @@ AST_type::ASTP parseSimpleStatement(std::istream &is, int &linecount,
   AST_type::ASTP term = AST_type::ASTP(termToken) ;
 #ifdef VERBOSE
   cerr << "terminal token for simpleStatement is " << OPtoName(term->nodeType)
+       << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif
   if(!ASTEqual(term,TK_SEMICOLON)) {
@@ -2050,7 +2173,9 @@ AST_type::ASTP parseStatement(std::istream &is, int &linecount,
   CPTR<AST_Token> firstToken = getToken(is,linecount) ;
 
 #ifdef VERBOSE
-  cerr << "in parseStatement, token = " << firstToken->text << endl ;
+  cerr << "in parseStatement, token = " << firstToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   pushToken(firstToken) ;
   switch(firstToken->nodeType) {
@@ -2150,7 +2275,9 @@ AST_type::ASTP parseBlock(std::istream &is, int &linecount,
 			  varmap &typemap) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
-  cerr << "in parseBlock, token = " << openToken->text << endl ;
+  cerr << "in parseBlock, token = " << openToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
 
   AST_type::elementType closeType = TK_CLOSEBRACE ;

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -1288,6 +1288,19 @@ inline AST_type::operatorPrecedence getPrecedence(CPTR<AST_exprOper> op) {
   return getPrecedence(op->nodeType) ;
 }
 
+inline bool precedenceCompare(AST_type::ASTP &op,
+                              CPTR<AST_exprOper> &opStack) {
+
+  AST_type::operatorPrecedence prec_op = getPrecedence(op);
+  AST_type::operatorPrecedence prec_opStack = getPrecedence(opStack) ;
+  //  if(prec_op == prec_opStack && op->nodeType == OP_TERNARY)
+  //    return false ;
+  if(prec_op == prec_opStack &&
+     (prec_op == AST_type::operatorPrecedence::PREC_ASSIGNMENT ||
+      prec_op == AST_type::operatorPrecedence::PREC_UNARY_PREFIX))
+    return true ;
+  return prec_op > prec_opStack ;
+}
 AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                                        std::istream &is, int &linecount,
                                        const string &fileName,
@@ -1389,7 +1402,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
     } else {
       // Now we reorder the tree based on operator precedence
       while(exprStack.size() > 1 &&
-            getPrecedence(op) <= getPrecedence(exprStack.back())) {
+            !precedenceCompare(op,exprStack.back())) {
 #ifdef VERBOSE
 	if(ASTEqual(op,OP_TERNARY)) {
 	  cerr << "pop stack when OP_TERNARY"
@@ -1422,7 +1435,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
-      } else if(getPrecedence(op) > getPrecedence(exprStack.back())) {
+      } else if(precedenceCompare(op,exprStack.back())) {
         // if operator is lower precedence than top of stack, then we need
         // to put this operator on the rightmost term
         CPTR<AST_exprOper> np = new AST_exprOper ;
@@ -1949,6 +1962,9 @@ AST_type::ASTP parseDeclarationOrSimpleStatement(std::istream &is,
 #endif
     return parseSimpleStatement(is,linecount,fileName,typemap) ;
   }
+  if(ASTEqual(openToken,TK_STRUCT) || ASTEqual(openToken,TK_CLASS))
+    return parseDeclaration(is,linecount,fileName,typemap) ;
+  
   bool isFunc = false ;
   string ident = getIdentifierName(is,linecount,fileName,isFunc) ;
 #ifdef VERBOASE
@@ -2019,6 +2035,8 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
     case TK_SIGNED:
     case TK_UNSIGNED:
     case TK_AUTO:
+    case TK_STRUCT:
+    case TK_CLASS:
 #ifdef VERBOSE
       cerr << "in parseDeclaration, builtin type"
            << ", file: " << __FILE__ << ":" << __LINE__
@@ -2259,6 +2277,8 @@ AST_type::ASTP parseStatement(std::istream &is, int &linecount,
   case TK_CONST:
   case TK_EXTERN:
   case TK_AUTO:
+  case TK_STRUCT:
+  case TK_CLASS:
     return parseDeclaration(is,linecount,fileName,typemap) ;
   case TK_FOR:
   case TK_WHILE:

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -1332,6 +1332,79 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
          << endl ;
 #endif
     expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+    openToken = getToken(is,linecount) ;
+    pushToken(openToken) ;
+    if((ASTEqual(op,OP_ARROW) || ASTEqual(op,OP_DOT)) &&
+       checkPostFixToken(openToken->nodeType)) {
+      // Here we have a special case where the postfix ++ or -- operator
+      // needs to happen after we close the existing arrow operator
+      if(ASTEqual(exprStack.back(),OP_NIL)) {
+        // If no operator on the stack, add this to the node
+        exprStack.back()->nodeType = op->nodeType ;
+        exprStack.back()->terms.push_back(expr) ;
+      } else {
+        // Put arrow or dot operator on stack
+        if(ASTEqual(op,exprStack.back())) {      
+          // If operator is the same, just chain the terms
+          exprStack.back()->terms.push_back(expr) ;
+#ifdef VERBOSE
+          cerr << "adding term to operator: "
+               << OPtoName(exprStack.back()->nodeType)
+               << " stack size=" << exprStack.size()
+               << ", file: " << __FILE__ << ":" << __LINE__
+               << endl ;
+#endif
+#ifdef VERBOSE
+          if(exprStack.size() > 0) {
+            printStack(exprStack,cerr) ;
+          }
+#endif
+        } else {
+          CPTR<AST_exprOper> np = new AST_exprOper ;
+          np->nodeType = op->nodeType ;
+#ifdef VERBOSE
+          cerr << "top of stack is" << OPtoName(exprStack.back()->nodeType)
+               << endl ;
+          cerr << "editing rightmost term: " << OPtoName(exprStack.back()->terms.back()->nodeType)
+               << ", file: " << __FILE__ << ":" << __LINE__
+               << endl ;
+#endif
+          np->terms.push_back(exprStack.back()->terms.back()) ;
+          np->terms.push_back(expr) ;
+          exprStack.back()->terms.back() = AST_type::ASTP(np) ;
+#ifdef VERBOSE
+          cerr << "pushing " << OPtoName(exprStack.back()->nodeType)
+               << "to stack,  line " << __LINE__
+               << ", file: " << __FILE__ << ":" << __LINE__
+               << endl ;
+#endif
+#ifdef VERBOSE
+          if(exprStack.size() > 0) {
+            printStack(exprStack,cerr) ;
+          }
+#endif
+          exprStack.push_back(np) ;
+        }
+      }
+      // Now parse post increment/decrement
+      expr = AST_type::ASTP(exprStack.back()),
+      exprStack.back() =
+        CPTR<AST_exprOper>(applyPostFixOperator(expr,
+                                                is,linecount,
+                                                fileName,typemap)) ;
+      if(exprStack.size() > 1)
+        exprStack[exprStack.size()-2]->terms.back()=
+          AST_type::ASTP(exprStack.back()) ;
+      continue ;
+    }
+      
+
+#ifdef VERBOSE
+    cerr << "before applyPostFixOperator" << endl ;
+    if(exprStack.size() > 0) {
+      printStack(exprStack,cerr) ;
+    }
+#endif
     expr = applyPostFixOperator(expr,is,linecount,fileName,typemap) ;
     
     if(expr == 0) {
@@ -1374,8 +1447,8 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
           printStack(exprStack,cerr) ;
         }
 #endif
-
       }
+
 
       if(ASTEqual(op,OP_COLON)) {
 #ifdef VERBOSE

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -971,27 +971,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
        << endl ;
 #endif
 
-#ifdef C_STYLE_CAST
-  // Check for a type cast
-  if(ASTEqual(openToken,TK_DOUBLE) ||
-     ASTEqual(openToken,TK_FLOAT) ||
-     ASTEqual(openToken,TK_INT) ||
-     ASTEqual(openToken,TK_SHORT) ||
-     ASTEqual(openToken,TK_CHAR) ||
-     ASTEqual(openToken,TK_LONG)) {
-    CPTR<AST_Token> nextToken = getToken(is,linecount) ;
-    pushToken(nextToken) ;
-    if(ASTEqual(nextToken,TK_OPENPAREN)) {
-      CPTR<AST_declaration> AST_data = new AST_declaration ;
-      AST_data->type_decl.push_back(AST_type::ASTP(openToken)) ;
-      AST_data->type_decl.push_back(parseExpressionPartial(is,linecount,
-                                                           fileName,
-                                                           typemap,prec)) ;
-      return AST_type::ASTP(AST_data) ;
-    }
-  }
-#endif
-  // Check for a parenthesized group or C-style cast ( type ) expr
+  // Check for a parenthesized group 
   if(ASTEqual(openToken,TK_OPENPAREN)) {
     pushToken(openToken) ;
     // Grab '('
@@ -1023,8 +1003,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       return AST_type::ASTP(new AST_syntaxError("expecting ')'",closeToken->lineno,fileName)) ;
 
     }
-    return applyPostFixOperator(AST_type::ASTP(group),is,linecount,fileName,
-				typemap) ;
+    return AST_type::ASTP(group) ;
   }
   if(ASTEqual(openToken,TK_CONST_CAST) ||
      ASTEqual(openToken,TK_DYNAMIC_CAST) ||
@@ -1096,8 +1075,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     if(ASTEqual(afterBrace,TK_CLOSEBRACE)) {
       CPTR<AST_exprOper> br = new AST_exprOper ;
       br->nodeType = OP_BRACEBLOCK ;
-      return applyPostFixOperator(AST_type::ASTP(br),is,linecount,fileName,
-				  typemap) ;
+      return AST_type::ASTP(br) ;
     }
     pushToken(afterBrace) ;
     AST_type::ASTP inner =
@@ -1111,8 +1089,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     CPTR<AST_exprOper> br = new AST_exprOper ;
     br->nodeType = OP_BRACEBLOCK ;
     br->terms.push_back(inner) ;
-    return applyPostFixOperator(AST_type::ASTP(br),is,linecount,fileName,
-				typemap) ;
+    return AST_type::ASTP(br) ;
   }
   // Check for unary operators
   if(checkUnaryToken(openToken)) {
@@ -1136,8 +1113,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
 #endif
-      return applyPostFixOperator(AST_type::ASTP(unary),is,linecount,fileName,
-				  typemap) ;
+      return AST_type::ASTP(unary) ;
     }
   }
   // Check if we are parsing a scoped name
@@ -1145,25 +1121,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
      ASTEqual(openToken,TK_SCOPE)) {
     pushToken(openToken) ;
     AST_type::ASTP objname = parseIdentifier(is,linecount,fileName,typemap) ;
-    return applyPostFixOperator(objname,is,linecount,fileName, typemap) ;
-
-    //    AST_type::ASTP objname = parseScopedObject(is,linecount,fileName,typemap) ;
-
-    openToken = getToken(is,linecount) ;
-    if(ASTEqual(openToken,TK_OPENTEMPLATE)) {
-      objname = parseTemplateArguments(objname,is,linecount,fileName,typemap) ;
-    } else
-      pushToken(openToken) ;
-
-    openToken = getToken(is,linecount) ;
-    if(ASTEqual(openToken,TK_OPENPAREN)) {
-      objname = parseFunctionArguments(objname,is,linecount,fileName,typemap) ;
-    } else
-      pushToken(openToken) ;
-
-    return applyPostFixOperator(AST_type::ASTP(objname),is,linecount,fileName,
-                                typemap) ;
-
+    return objname ;
   }
 
   if(isTerm(openToken)) {
@@ -1177,8 +1135,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     AST_type::ASTP exp = parseTerm(is,linecount);
 
 
-    return applyPostFixOperator(exp,is,linecount,fileName,typemap) ;
-    //    return exp ;
+    return exp ;
   }
   pushToken(openToken) ;
   return 0 ;
@@ -1372,7 +1329,8 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
          << endl ;
 #endif
     expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
-
+    expr = applyPostFixOperator(expr,is,linecount,fileName,typemap) ;
+    
     if(expr == 0) {
       return AST_type::ASTP(new AST_syntaxError("Expecting expression after binary operator",linecount,fileName)) ;
     }
@@ -1417,10 +1375,12 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
       }
 
       if(ASTEqual(op,OP_COLON)) {
-        //        cerr << "FOUND COLON" << endl ;
+#ifdef VERBOSE
+        cerr << "FOUND COLON" << endl ;
         printStack(exprStack,cerr) ;
+#endif
         if(exprStack.back()->nodeType != OP_TERNARY) {
-          cerr << "expected to be working with TERNARY operator" << endl ;
+          cerr << "expected ':' to be working with '?' in TERNARY operator" << endl ;
           CPTR<AST_Token> optoken = CPTR<AST_Token>(op) ;
           AST_type::ASTP err =
             AST_type::ASTP(new AST_syntaxError("expecting ':' to be paired with '?'",
@@ -1536,6 +1496,7 @@ AST_type::ASTP parseExpression(std::istream &is, int &linecount,
 #endif
 
   AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap,prec) ;
+  expr = applyPostFixOperator(expr,is,linecount,fileName,typemap) ;
   if(expr == 0) // If no valid expression then return null
     return expr ;
 
@@ -2134,6 +2095,7 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
       pushToken(token) ;
 
       AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+      expr = applyPostFixOperator(expr,is,linecount,fileName,typemap) ;
 #ifdef VERBOSE
       cerr << "in parseDeclaration, parsing expression "
            << ", file: " << __FILE__ << ":" << __LINE__

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -279,7 +279,7 @@ AST_type::AST_type() {
   id = parseIDctr++ ;
 }
 
-/// Acceptor method AST node, passes node to visitor object for AST_tolen
+/// Acceptor method AST node, passes node to visitor object for AST_token
 void AST_Token::accept(AST_visitor &v) {  v.visit(*this) ; }
 
 /// Code to clone an AST_Token
@@ -994,36 +994,6 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
   // Check for a parenthesized group or C-style cast ( type ) expr
   if(ASTEqual(openToken,TK_OPENPAREN)) {
     pushToken(openToken) ;
-    if(false && scanForCStyleCast(is, linecount,typemap)) {
-      // Cast has unary-level precedence: parse operand with parseExpressionPartial.
-      (void)getToken(is, linecount) ; // '('
-      AST_type::ASTP maybeType =
-        parseTypeSpecifier(is, linecount, fileName, typemap) ;
-      CPTR<AST_Token> closeTok = getToken(is, linecount) ;
-      if(closeTok->nodeType != TK_CLOSEPAREN) {
-        pushToken(closeTok) ;
-        return AST_type::ASTP(new AST_syntaxError(
-                                                  "expecting ')' in cast", closeTok->lineno, fileName)) ;
-      }
-      CPTR<AST_typeSpec> ts = CPTR<AST_typeSpec>(maybeType) ;
-      if(maybeType == 0 || maybeType->nodeType != ND_TYPE_SPEC ||
-         ts == 0 || ts->type_spec.empty()) {
-        return AST_type::ASTP(new AST_syntaxError(
-                                                  "invalid type in cast", closeTok->lineno, fileName)) ;
-      }
-      AST_type::ASTP operand =
-        parseExpressionPartial(is, linecount, fileName, typemap) ;
-      if(operand == 0) {
-        return AST_type::ASTP(new AST_syntaxError(
-                                                  "expecting expression after cast", closeTok->lineno, fileName)) ;
-      }
-      CPTR<AST_exprOper> castNode = new AST_exprOper ;
-      castNode->nodeType = OP_CAST ;
-      castNode->terms.push_back(maybeType) ;
-      castNode->terms.push_back(operand) ;
-      return applyPostFixOperator(AST_type::ASTP(castNode), is, linecount,
-                                  fileName, typemap) ;
-    }
     // Grab '('
     openToken = getToken(is, linecount) ;
 #ifdef VERBOSE
@@ -1268,6 +1238,7 @@ inline AST_type::operatorPrecedence getPrecedence(AST_type::elementType op) {
   case OP_LOGICAL_OR:
     return AST_type::operatorPrecedence::PREC_LOGICAL_OR ;
   case OP_TERNARY:
+  case OP_COLON:
   case OP_ASSIGN:
   case OP_TIMES_ASSIGN:
   case OP_DIVIDE_ASSIGN:
@@ -1400,21 +1371,8 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
          << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
 #endif
-    // Special case for ?: operator or array
-    if(ASTEqual(op,OP_TERNARY)) {
-#ifdef VERBOSE
-      cerr << "parsing expression for first term of TERNARY operator" << endl ;
-#endif
-      expr = parseExpression(is,linecount,fileName,typemap,
-                             AST_type::operatorPrecedence::PREC_ASSIGNMENT) ;
-#ifdef VERBOSE
-      cerr << "expr parsed = " << endl ;
-      AST_simplePrint printer(cerr,-2) ;
-      expr->accept(printer) ;
-#endif
-    } else {
-      expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
-    }
+    expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+
     if(expr == 0) {
       return AST_type::ASTP(new AST_syntaxError("Expecting expression after binary operator",linecount,fileName)) ;
     }
@@ -1433,50 +1391,11 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
         printStack(exprStack,cerr) ;
       }
 #endif
-      // ?: must read ':' and the false branch here as well; the lower
-      // branches only handle colon when exprStack.back() is not OP_NIL.
-      if(ASTEqual(op,OP_TERNARY)) {
-        CPTR<AST_Token> op2 = getToken(is,linecount) ;
-#ifdef VERBOSE
-        cerr << "op2 = " << OPtoName(op2->nodeType) << endl ;
-#endif
-        if(ASTEqual(op2,TK_COLON)) {
-#ifdef VERBOSE
-          cerr << "Found ':' of '?' operator" << endl ;
-#endif
-          
-          AST_type::ASTP expr3 =
-            parseExpression(is,linecount,fileName,typemap,
-                            AST_type::operatorPrecedence::PREC_COMMA) ;
-          //              parseExpressionPartial(is,linecount,fileName,typemap) ;
-          if(expr3 == 0) {
-            return AST_type::ASTP(new AST_syntaxError(
-                                                      "Expecting expression after ':' in ?: operator", linecount,
-                                                      fileName)) ;
-          }
-          exprStack.back()->terms.push_back(expr3) ;
-#ifdef VERBOSE
-          if(exprStack.size() > 0) {
-            printStack(exprStack,cerr) ;
-          }
-#endif
-        } else {
-          pushToken(op2) ;
-          return AST_type::ASTP(new AST_syntaxError(
-                                                    "expecting ':' in tertiary operator", op2->lineno, fileName)) ;
-        }
-      }
+
     } else {
       // Now we reorder the tree based on operator precedence
       while(exprStack.size() > 1 &&
             !precedenceCompare(op,exprStack.back())) {
-#ifdef VERBOSE
-	if(ASTEqual(op,OP_TERNARY)) {
-	  cerr << "pop stack when OP_TERNARY"
-               << ", file: " << __FILE__ << ":" << __LINE__
-               << endl ;
-	}
-#endif
 #ifdef VERBOSE
         cerr << "pop off exprStack:" << OPtoName(exprStack.back()->nodeType)
              << ", file: " << __FILE__ << ":" << __LINE__
@@ -1497,7 +1416,19 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 
       }
 
-      if(ASTEqual(op,exprStack.back())) {
+      if(ASTEqual(op,OP_COLON)) {
+        //        cerr << "FOUND COLON" << endl ;
+        printStack(exprStack,cerr) ;
+        if(exprStack.back()->nodeType != OP_TERNARY) {
+          cerr << "expected to be working with TERNARY operator" << endl ;
+          CPTR<AST_Token> optoken = CPTR<AST_Token>(op) ;
+          AST_type::ASTP err =
+            AST_type::ASTP(new AST_syntaxError("expecting ':' to be paired with '?'",
+                                               optoken->lineno,fileName)) ;
+          exprStack.back()->terms.push_back(err) ;
+        }
+      }
+      if(!ASTEqual(op,OP_TERNARY) && ASTEqual(op,exprStack.back())) {
 	// If operator is the same, just chain the terms
 	exprStack.back()->terms.push_back(expr) ;
 #ifdef VERBOSE
@@ -1538,32 +1469,6 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
           printStack(exprStack,cerr) ;
         }
 #endif
-        if(ASTEqual(op,OP_TERNARY)) {
-          CPTR<AST_Token> op2 = getToken(is,linecount) ;
-#ifdef VERBOSE
-          cerr << " detected OP_TERNARY, op2 =" << op2->text
-               << ", file: " << __FILE__ << ":" << __LINE__
-               << endl ;
-#endif
-          if(ASTEqual(op2,TK_COLON)) {
-#ifdef VERBOSE
-            cerr << "detected TK_COLON, parsing expression" << endl ;
-#endif
-            //            expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
-            expr = parseExpression(is,linecount,fileName,typemap,
-                                   AST_type::operatorPrecedence::PREC_COMMA) ;
-#ifdef VERBOSE
-            cerr << "after colon parsed expression:" << endl ;
-            AST_simplePrint printer(cerr,-2) ;
-            expr->accept(printer) ;
-#endif
-
-            np->terms.push_back(expr) ;
-          } else {
-            pushToken(op2) ;
-            return AST_type::ASTP(new AST_syntaxError("expecting ':' in tertiary operator",op2->lineno,fileName)) ;
-          }
-        }
         exprStack.push_back(np) ;
 #ifdef VERBOSE
         cerr << "pushing on exprStack:" << OPtoName(exprStack.back()->nodeType)
@@ -1587,22 +1492,6 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 #endif
 	np->terms.push_back(AST_type::ASTP(exprStack.back())) ;
 	np->terms.push_back(expr) ;
-	if(ASTEqual(op,OP_TERNARY)) {
-	  CPTR<AST_Token> op2 = getToken(is,linecount) ;
-	  if(!ASTEqual(op2,TK_COLON)) {
-	    pushToken(op2) ;
-	    expr = AST_type::ASTP(new AST_syntaxError("unexpected ':' in tertiary operator",linecount,fileName)) ;
-	  } else {
-            expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
-	  }
-	  np->terms.push_back(expr) ;
-#ifdef VERBOSE
-	  cerr << " processed OP_TERNARY"
-               << ", file: " << __FILE__ << ":" << __LINE__
-               << endl ;
-#endif
-
-	}
 	exprStack.back() = np ;
 #ifdef VERBOSE
         cerr << "changing exprStack to" << OPtoName(exprStack.back()->nodeType)
@@ -1675,7 +1564,8 @@ AST_type::ASTP parseCaseStatement(std::istream &is, int &linecount,
   AST_data->elements.push_back(AST_type::ASTP(token)) ;
   if(ASTEqual(token,TK_CASE)) {
     AST_type::ASTP expr =
-      parseExpression(is,linecount,fileName,AST_data->identifiers) ;
+      parseExpression(is,linecount,fileName,AST_data->identifiers,
+                      AST_type::operatorPrecedence::PREC_ASSIGNMENT) ;
     AST_data->elements.push_back(expr) ;
   }
 
@@ -2755,13 +2645,6 @@ void AST_simplePrint::visit(AST_exprOper &s) {
       if(ii!=s.terms.end()) 
         ++ii ;
       out << '?' ;
-      if(ii!=s.terms.end() && *ii != 0)
-	(*ii)->accept(*this) ;
-      out << ':' ;
-      if(ii==s.terms.end()) {
-	cerr << "internal error on tertiary operator" << endl ;
-      } else
-	++ii ;
       if(ii!=s.terms.end() && *ii != 0)
 	(*ii)->accept(*this) ;
     }

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -152,6 +152,8 @@ string OPtoString(AST_type::elementType val) {
     return string("*") ;
   case OP_CAST:
     return string(" ") ;
+  case OP_TEMPLATE_CAST:
+    return string(" ") ;
   case OP_BRACEBLOCK:
     return string(" ") ;
   default:
@@ -1043,6 +1045,69 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     }
     return applyPostFixOperator(AST_type::ASTP(group),is,linecount,fileName,
 				typemap) ;
+  }
+  if(ASTEqual(openToken,TK_CONST_CAST) ||
+     ASTEqual(openToken,TK_DYNAMIC_CAST) ||
+     ASTEqual(openToken,TK_REINTERPRET_CAST) ||
+     ASTEqual(openToken,TK_STATIC_CAST)) {
+#ifdef VERBOSE
+    cerr << "in template cast, token = " << openToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
+#endif
+    // parse templated cast
+    CPTR<AST_exprOper> cast = new AST_exprOper ;
+    cast->nodeType = OP_TEMPLATE_CAST ;
+    cast->terms.push_back(AST_type::ASTP(openToken)) ;
+    // how scan for template brace
+    openToken=getToken(is,linecount) ;
+#ifdef VERBOSE
+    cerr << "in template cast parser, token = " << openToken->text
+       << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
+#endif
+    if(!ASTEqual(openToken,TK_OPENTEMPLATE)) {
+      cerr << "expecting '<'" << endl ;
+      cast->terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting '<'",openToken->lineno,fileName))) ;
+      return AST_type::ASTP(cast) ;
+    }
+    cast->terms.push_back(AST_type::ASTP(openToken)) ;
+    AST_type::ASTP objname =
+      parseTypeSpecifier(is,linecount,fileName,typemap) ;
+#ifdef VERBOSE
+    cerr << "in template cast parser, got template arguments"
+         << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
+#endif
+    cast->terms.push_back(objname) ;
+    openToken=getToken(is,linecount) ;
+    if(ASTEqual(openToken,TK_TIMES) ||
+       ASTEqual(openToken,TK_AMPERSAND)) {
+      cast->terms.push_back(AST_type::ASTP(openToken)) ;
+      openToken = getToken(is,linecount) ;
+    }
+    if(!ASTEqual(openToken,TK_CLOSETEMPLATE)) {
+      cerr << "expecting '>'" << endl ;
+      cast->terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting '>'",openToken->lineno,fileName))) ;
+      return AST_type::ASTP(cast) ;
+    }
+    cast->terms.push_back(AST_type::ASTP(openToken)) ;
+    openToken=getToken(is,linecount) ;
+    if(!ASTEqual(openToken,TK_OPENPAREN)) {
+      cerr << "expecting ')'" << endl ;
+      cast->terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting '>'",openToken->lineno,fileName))) ;
+      return AST_type::ASTP(cast) ;
+    }
+    cast->terms.push_back(AST_type::ASTP(openToken)) ;
+    cast->terms.push_back(AST_type::ASTP(parseExpression(is,linecount,fileName,typemap))) ;
+    openToken=getToken(is,linecount) ;
+    if(!ASTEqual(openToken,TK_CLOSEPAREN)) {
+      cerr << "expecting ')'" << endl ;
+      cast->terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting ')'",openToken->lineno,fileName))) ;
+      return AST_type::ASTP(cast) ;
+    }
+    cast->terms.push_back(AST_type::ASTP(openToken)) ;
+    return AST_type::ASTP(cast) ;
   }
   // Brace-enclosed initializer list: { expr, ... }  (commas inside do not end
   // the outer declaration; parseExpression stops before '}').
@@ -2216,7 +2281,13 @@ AST_type::ASTP parseStatement(std::istream &is, int &linecount,
       firstToken = getToken(is,linecount) ;
       CPTR<AST_declaration> AST_data = new AST_declaration ;
       AST_data->type_decl.push_back(AST_type::ASTP(firstToken)) ;
-      
+
+      firstToken = getToken(is,linecount) ;
+      if(ASTEqual(firstToken,TK_NAMESPACE)) {
+        AST_data->type_decl.push_back(AST_type::ASTP(firstToken)) ;
+      } else {
+        pushToken(firstToken) ;
+      }
       bool isFunc = false ;
       string s = getIdentifierName(is,linecount,fileName,isFunc) ;
       if(!isFunc) {
@@ -2477,6 +2548,11 @@ void AST_simplePrint::visit(AST_exprOper &s) {
     out << ')' ;
     if(s.terms.size() >= 2 && s.terms[1] != 0)
       s.terms[1]->accept(*this) ;
+    break ;
+  case OP_TEMPLATE_CAST:
+    for(auto ii=s.terms.begin();ii!=s.terms.end();++ii)
+      if(*ii != 0)
+	(*ii)->accept(*this) ;
     break ;
   case OP_BRACEBLOCK:
     out << '{' ;

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -51,6 +51,7 @@ using std::vector ;
 using Loci::vmap_info ;
 using Loci::variableSet ;
 using namespace nodeTypes ;
+
 /// Convert operator code to corresponding string for printing
 string OPtoString(AST_type::elementType val) {
   switch(val) {
@@ -162,26 +163,8 @@ string OPtoString(AST_type::elementType val) {
   return string("/*error*/") ;
 }
 
-bool isTypeDecl(CPTR<AST_Token> p, varmap &typemap) {
-  switch(p->nodeType) {
-  case TK_CHAR:
-  case TK_FLOAT:
-  case TK_DOUBLE:
-  case TK_INT:
-  case TK_BOOL:
-  case TK_SHORT:
-  case TK_LONG:
-  case TK_SIGNED:
-  case TK_UNSIGNED:
-  case TK_CONST:
-  case TK_AUTO:
-  case TK_VOID:
-    return true ;
-  default:
-    return false ;
-  }
-}
-
+// Parse a type specification used in either a type declaration statement
+// or a template argument.
 AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
                                   const string &fileName,
                                   varmap &typemap) {
@@ -193,7 +176,7 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
   CPTR<AST_Token> token = getToken(is,linecount) ;
   do {
 #ifdef VERBOSE
-    cerr << "in parseTypeSpecifier, token = " << token->text 
+    cerr << "in parseTypeSpecifier, token = " << token->text
          << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
 #endif
@@ -251,7 +234,7 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
         istype = false ;
       } else {
         pushToken(token) ;
-        
+
         AST_type::ASTP typedec =
           parseIdentifier(is,linecount,fileName,typemap) ;
         if(typedec->nodeType == OP_FUNC) {
@@ -288,15 +271,18 @@ AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
   return AST_type::ASTP(p) ;
 }
 
+// AST_type constructor enumerates all AST_type objects to give them a unique
+// identifier (id)
 static int parseIDctr = 0 ;
 AST_type::AST_type() {
   nodeType = OP_ERROR ;
   id = parseIDctr++ ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object for AST_tolen
 void AST_Token::accept(AST_visitor &v) {  v.visit(*this) ; }
 
+/// Code to clone an AST_Token
 AST_type::ASTP AST_Token::clone() const {
   CPTR<AST_Token> tok = new AST_Token ;
   tok->nodeType = nodeType ;
@@ -305,18 +291,22 @@ AST_type::ASTP AST_Token::clone() const {
   return ASTP(tok) ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object of
+/// AST_syntaxError.
 void AST_syntaxError::accept(AST_visitor &v) {  v.visit(*this) ; }
 
+/// Code to clone an AST_syntaxError
 AST_type::ASTP AST_syntaxError::clone() const {
   CPTR<AST_syntaxError> p = new AST_syntaxError(error,lineno,fileName) ;
   p->nodeType = nodeType ;
   return ASTP(p) ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object for
+/// AST_simpleStatement
 void AST_SimpleStatement::accept(AST_visitor &v) {  v.visit(*this) ; }
 
+/// Code to clone an AST_simpleStatement
 AST_type::ASTP AST_SimpleStatement::clone() const {
   CPTR<AST_SimpleStatement> p = new AST_SimpleStatement(exp->clone(),
                                                         Terminal->clone()) ;
@@ -324,9 +314,10 @@ AST_type::ASTP AST_SimpleStatement::clone() const {
   return ASTP(p) ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object for AST_Block
 void AST_Block::accept(AST_visitor &v) {  v.visit(*this) ; }
 
+/// General helper code to clone an ASTList
 inline void cloneList(AST_type::ASTList &l, const AST_type::ASTList &in) {
   AST_type::ASTList tmp(in.size()) ;
   for(size_t i=0;i<in.size();++i)
@@ -334,6 +325,7 @@ inline void cloneList(AST_type::ASTList &l, const AST_type::ASTList &in) {
   l.swap(tmp) ;
 }
 
+// Code to clone the codeblock AST_Block
 AST_type::ASTP AST_Block::clone() const {
   CPTR<AST_Block> p = new AST_Block ;
   p->nodeType = nodeType ;
@@ -342,10 +334,11 @@ AST_type::ASTP AST_Block::clone() const {
   return ASTP(p) ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object for
+/// AST_typeSpec node.
 void AST_typeSpec::accept(AST_visitor &v) {  v.visit(*this) ; }
 
-
+/// Code to clone AST_typeSpec node.
 AST_type::ASTP AST_typeSpec::clone() const {
   CPTR<AST_typeSpec> p = new AST_typeSpec ;
   p->nodeType = nodeType ;
@@ -353,10 +346,11 @@ AST_type::ASTP AST_typeSpec::clone() const {
   return ASTP(p) ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object for
+/// AST_declaration node
 void AST_declaration::accept(AST_visitor &v) {  v.visit(*this) ; }
 
-
+/// Code to clone AST_declaration node
 AST_type::ASTP AST_declaration::clone() const {
   CPTR<AST_declaration> p = new AST_declaration ;
   p->nodeType = nodeType ;
@@ -368,6 +362,7 @@ AST_type::ASTP AST_declaration::clone() const {
 /// Acceptor method AST node, passes node to visitor object
 void AST_exprOper::accept(AST_visitor &v) {  v.visit(*this) ; }
 
+///Code to clone an expression operator node.  (AST_exprOper)
 AST_type::ASTP AST_exprOper::clone() const {
   CPTR<AST_exprOper> p = new AST_exprOper ;
   p->nodeType = nodeType ;
@@ -375,7 +370,8 @@ AST_type::ASTP AST_exprOper::clone() const {
   return ASTP(p) ;
 }
 
-/// Acceptor method AST node, passes node to visitor object
+/// Acceptor method AST node, passes node to visitor object for
+/// AST_controlStatement
 void AST_controlStatement::accept(AST_visitor &v) {  v.visit(*this) ; }
 
 AST_type::ASTP AST_controlStatement::clone() const {
@@ -421,7 +417,7 @@ AST_type::ASTP parseTerm(std::istream &is, int &linecount) {
     return AST_type::ASTP(token) ;
   else {
     pushToken(token) ;
-    AST_type::ASTP(new AST_syntaxError("expecting token",token->lineno,"")) ;    
+    AST_type::ASTP(new AST_syntaxError("expecting token",token->lineno,"")) ;
     return AST_type::ASTP(0) ;
   }
 }
@@ -515,7 +511,7 @@ AST_type::ASTP parseOperator(std::istream &is, int &linecount) {
   CPTR<AST_Token> openToken = getToken(is,linecount) ;
 #ifdef VERBOSE
   cerr << "in parseOperator, token = " << openToken->text
-         << ", file: " << __FILE__ << ":" << __LINE__
+       << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif
   AST_type::elementType op = tokenToOperator(openToken->nodeType) ;
@@ -570,13 +566,13 @@ AST_type::elementType unaryOperator(AST_type::elementType e) {
   }
 }
 
-/// Check for postfix token '++' or '--' 
+/// Check for postfix token '++' or '--'
 bool checkPostFixToken(AST_type::elementType e) {
   return (e == TK_INCREMENT ||
 	  e == TK_DECREMENT) ;
 }
 
-/// Pares postfix operator convert node type from TK_* to appropriate OP_* 
+/// Pares postfix operator convert node type from TK_* to appropriate OP_*
 AST_type::elementType postFixOperator(AST_type::elementType e) {
   switch(e) {
   case TK_INCREMENT:
@@ -624,7 +620,7 @@ AST_type::ASTP applyPostFixOperator(AST_type::ASTP expr,
     array->nodeType = OP_ARRAY ;
     array->terms.push_back(expr) ;
     array->terms.push_back(index) ;
-    
+
     openToken = getToken(is,linecount) ;
     pushToken(openToken) ;
     if(checkPostFixToken(openToken->nodeType) ||
@@ -635,7 +631,7 @@ AST_type::ASTP applyPostFixOperator(AST_type::ASTP expr,
       return AST_type::ASTP(array) ;
   }
   pushToken(openToken) ;
-    
+
   return expr ;
 }
 
@@ -646,10 +642,10 @@ AST_type::ASTP parseScopedObject(std::istream &is, int &linecount,
 #ifdef VERBOSE
   cerr << "parseScopedObject, parsing named object with scope, "
        << OPtoName(openToken->nodeType) ;
-    if(ASTEqual(openToken,TK_NAME))
-      cerr << " name=" << openToken->text ;
-    cerr << ", file: " << __FILE__ << ":" << __LINE__ 
-         << endl ;
+  if(ASTEqual(openToken,TK_NAME))
+    cerr << " name=" << openToken->text ;
+  cerr << ", file: " << __FILE__ << ":" << __LINE__
+       << endl ;
 #endif
   AST_type::ASTList terms ;
   // Special case for global scope (eg ::name)
@@ -664,7 +660,7 @@ AST_type::ASTP parseScopedObject(std::istream &is, int &linecount,
   // Now openToken should be a name, so push it onto the terms list
   if(!ASTEqual(openToken,TK_NAME)) {
     terms.push_back(AST_type::ASTP(new AST_syntaxError("expecting name following '::'",openToken->lineno,fileName))) ;
-  } else 
+  } else
     terms.push_back(AST_type::ASTP(openToken)) ;
 
   // Now get more terms as long as we have a scope operator
@@ -687,13 +683,13 @@ AST_type::ASTP parseScopedObject(std::istream &is, int &linecount,
   }
   // We are done parsing, so return this to the token input
   pushToken(openToken) ;
-      
+
   if(terms.size() > 1) {
     CPTR<AST_exprOper> tmp = new AST_exprOper ;
     tmp->nodeType = OP_SCOPE ;
     tmp->terms = terms ;
     return AST_type::ASTP(tmp) ;
-  } 
+  }
   return AST_type::ASTP(terms.back()) ;
 }
 
@@ -703,7 +699,7 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
                                       varmap &typemap) {
   // Template Arguments
 #ifdef VERBOSE
-  cerr << "parseTemplateArguments: found term template open '<'" 
+  cerr << "parseTemplateArguments: found term template open '<'"
        << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
 #endif
@@ -713,19 +709,19 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
     pushToken(token) ;
     arg = parseTypeSpecifier(is,linecount,fileName,typemap) ;
   }
-  
+
 #ifdef VERBOSE
-  cerr << "parseTemplateArguments: parsed type specification " 
+  cerr << "parseTemplateArguments: parsed type specification "
        << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
-#endif    
+#endif
   CPTR<AST_Token> closeToken = getToken(is,linecount) ;
   if(ASTEqual(closeToken,TK_CLOSETEMPLATE)) {
 #ifdef VERBOSE
-  cerr << "parseTemplateArguments: only single argument " 
-       << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
-#endif    
+    cerr << "parseTemplateArguments: only single argument "
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
+#endif
     // only a single type in template parameters
     CPTR<AST_exprOper> func = new AST_exprOper ;
     func->nodeType = OP_TEMPLATE ;
@@ -736,11 +732,11 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
   if(ASTEqual(closeToken,TK_COMMA)) {
 
 #ifdef VERBOSE
-  cerr << "parseTemplateArguments: parsing comma separated list of types " 
-       << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
-#endif    
-    
+    cerr << "parseTemplateArguments: parsing comma separated list of types "
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
+#endif
+
     CPTR<AST_exprOper> tlist = new AST_exprOper ;
     tlist->nodeType = OP_COMMA ;    tlist->terms.push_back(arg) ;
     while(ASTEqual(closeToken,TK_COMMA)) {
@@ -755,7 +751,7 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
         pushToken(token) ;
         arg = parseTypeSpecifier(is,linecount,fileName,typemap) ;
       }
-      
+
       tlist->terms.push_back(arg) ;
       closeToken = getToken(is,linecount) ;
     }
@@ -768,7 +764,7 @@ AST_type::ASTP parseTemplateArguments(AST_type::ASTP objname,
     func->terms.push_back(AST_type::ASTP(tlist)) ;
     return AST_type::ASTP(func) ;
   }
-  
+
   AST_type::ASTP p =
     AST_type::ASTP(new AST_syntaxError("Syntax error parsing template arguments",
                                        closeToken->lineno,fileName)) ;
@@ -780,10 +776,10 @@ AST_type::ASTP parseFunctionArguments(AST_type::ASTP objname,
                                       const string &fileName,
                                       varmap &typemap) {
 #ifdef VERBOSE
-  cerr << "parseFunctionArguments: found term template open '('" 
+  cerr << "parseFunctionArguments: found term template open '('"
        << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
-#endif    
+#endif
   AST_type::ASTP args = parseExpression(is,linecount,fileName,typemap) ;
   CPTR<AST_Token> closeToken = getToken(is,linecount) ;
   CPTR<AST_exprOper> func = new AST_exprOper ;
@@ -802,13 +798,13 @@ AST_type::ASTP parseFunctionArguments(AST_type::ASTP objname,
 }
 /// Parse identifier or function call
 AST_type::ASTP parseIdentifier(std::istream &is, int &linecount,
-				      const string &fileName,
-				      varmap &typemap) {
+                               const string &fileName,
+                               varmap &typemap) {
 #ifdef VERBOSE
   cerr << "in parseIdentifier"
        << ", file: " << __FILE__ << ":" << __LINE__
        << endl ;
-#endif 
+#endif
 
   AST_type::ASTP objname = parseScopedObject(is,linecount,fileName,typemap) ;
 
@@ -834,7 +830,7 @@ AST_type::ASTP parseIdentifier(std::istream &is, int &linecount,
     openToken = getToken(is,linecount) ;
   }
   pushToken(openToken) ;
-    
+
   openToken = getToken(is,linecount) ;
   if(ASTEqual(openToken,TK_OPENPAREN)) {
     objname = parseFunctionArguments(objname,is,linecount,fileName,typemap) ;
@@ -861,13 +857,13 @@ bool scanForCStyleCast(std::istream &is, int &linecount,varmap &typemap) {
     tokenStack.push_back(openToken) ;
     openToken = getToken(is,linecount) ;
     // If we find a close paren, then break out of loop
-    // to check for 
+    // to check for
     if(ASTEqual(openToken,TK_CLOSEPAREN) &&
        tokenStack.size() > 1)
       break ;
     bool builtintype = false ;
     bool usertype = false ;
-    switch(openToken->nodeType) { 
+    switch(openToken->nodeType) {
     case TK_CHAR:
     case TK_FLOAT:
     case TK_DOUBLE:
@@ -919,7 +915,7 @@ bool scanForCStyleCast(std::istream &is, int &linecount,varmap &typemap) {
         tokenStack.pop_back() ;
       }
       return ASTEqual(openToken,TK_CLOSEPAREN) ;
-        
+
     default:
       pushToken(openToken) ;
       while(tokenStack.size() > 0) {
@@ -927,7 +923,7 @@ bool scanForCStyleCast(std::istream &is, int &linecount,varmap &typemap) {
         tokenStack.pop_back() ;
       }
       return false ;
-    }        
+    }
   } while(true) ;
   // found closing paren, search what follows to determine if this is a
   // C style cast.
@@ -954,7 +950,7 @@ bool scanForCStyleCast(std::istream &is, int &linecount,varmap &typemap) {
   default:
     break ;
   }
-      
+
   pushToken(openToken) ;
   while(tokenStack.size() > 0) {
     pushToken(tokenStack.back()) ;
@@ -1002,24 +998,24 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       // Cast has unary-level precedence: parse operand with parseExpressionPartial.
       (void)getToken(is, linecount) ; // '('
       AST_type::ASTP maybeType =
-          parseTypeSpecifier(is, linecount, fileName, typemap) ;
+        parseTypeSpecifier(is, linecount, fileName, typemap) ;
       CPTR<AST_Token> closeTok = getToken(is, linecount) ;
       if(closeTok->nodeType != TK_CLOSEPAREN) {
         pushToken(closeTok) ;
         return AST_type::ASTP(new AST_syntaxError(
-            "expecting ')' in cast", closeTok->lineno, fileName)) ;
+                                                  "expecting ')' in cast", closeTok->lineno, fileName)) ;
       }
       CPTR<AST_typeSpec> ts = CPTR<AST_typeSpec>(maybeType) ;
       if(maybeType == 0 || maybeType->nodeType != ND_TYPE_SPEC ||
          ts == 0 || ts->type_spec.empty()) {
         return AST_type::ASTP(new AST_syntaxError(
-            "invalid type in cast", closeTok->lineno, fileName)) ;
+                                                  "invalid type in cast", closeTok->lineno, fileName)) ;
       }
       AST_type::ASTP operand =
         parseExpressionPartial(is, linecount, fileName, typemap) ;
       if(operand == 0) {
         return AST_type::ASTP(new AST_syntaxError(
-            "expecting expression after cast", closeTok->lineno, fileName)) ;
+                                                  "expecting expression after cast", closeTok->lineno, fileName)) ;
       }
       CPTR<AST_exprOper> castNode = new AST_exprOper ;
       castNode->nodeType = OP_CAST ;
@@ -1047,7 +1043,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       cerr << endl ;
     }
 #endif
-    
+
     CPTR<AST_Token> closeToken = getToken(is,linecount) ;
     CPTR<AST_exprOper> group = new AST_exprOper ;
     group->nodeType = OP_GROUP ;
@@ -1055,7 +1051,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     if(closeToken->nodeType != TK_CLOSEPAREN) {
       pushToken(closeToken) ;
       return AST_type::ASTP(new AST_syntaxError("expecting ')'",closeToken->lineno,fileName)) ;
-      
+
     }
     return applyPostFixOperator(AST_type::ASTP(group),is,linecount,fileName,
 				typemap) ;
@@ -1066,8 +1062,8 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
      ASTEqual(openToken,TK_STATIC_CAST)) {
 #ifdef VERBOSE
     cerr << "in template cast, token = " << openToken->text
-       << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     // parse templated cast
     CPTR<AST_exprOper> cast = new AST_exprOper ;
@@ -1077,8 +1073,8 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     openToken=getToken(is,linecount) ;
 #ifdef VERBOSE
     cerr << "in template cast parser, token = " << openToken->text
-       << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     if(!ASTEqual(openToken,TK_OPENTEMPLATE)) {
       cerr << "expecting '<'" << endl ;
@@ -1091,7 +1087,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 #ifdef VERBOSE
     cerr << "in template cast parser, got template arguments"
          << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
+         << endl ;
 #endif
     cast->terms.push_back(objname) ;
     openToken=getToken(is,linecount) ;
@@ -1140,7 +1136,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     if(closeTok->nodeType != TK_CLOSEBRACE) {
       pushToken(closeTok) ;
       return AST_type::ASTP(new AST_syntaxError(
-          "expecting '}' in brace initializer", closeTok->lineno,fileName)) ;
+                                                "expecting '}' in brace initializer", closeTok->lineno,fileName)) ;
     }
     CPTR<AST_exprOper> br = new AST_exprOper ;
     br->nodeType = OP_BRACEBLOCK ;
@@ -1152,10 +1148,10 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
   if(checkUnaryToken(openToken)) {
 #ifdef VERBOSE
     cerr << "parseExpressionPartial: found unary operator '"
-         << openToken->text << " parsing unary target." 
+         << openToken->text << " parsing unary target."
          << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
-#endif    
+#endif
     //check for unary operators
     AST_type::ASTP expr =
       parseExpression(is,linecount,fileName,typemap,
@@ -1166,10 +1162,10 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       unary->terms.push_back(expr) ;
 #ifdef VERBOSE
       cerr << "parseExpressionPartial: creating unary operator, "
-           << "search for postfix operators ++,--, or []" 
+           << "search for postfix operators ++,--, or []"
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
-#endif    
+#endif
       return applyPostFixOperator(AST_type::ASTP(unary),is,linecount,fileName,
 				  typemap) ;
     }
@@ -1180,7 +1176,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
     pushToken(openToken) ;
     AST_type::ASTP objname = parseIdentifier(is,linecount,fileName,typemap) ;
     return applyPostFixOperator(objname,is,linecount,fileName, typemap) ;
-    
+
     //    AST_type::ASTP objname = parseScopedObject(is,linecount,fileName,typemap) ;
 
     openToken = getToken(is,linecount) ;
@@ -1188,7 +1184,7 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       objname = parseTemplateArguments(objname,is,linecount,fileName,typemap) ;
     } else
       pushToken(openToken) ;
-    
+
     openToken = getToken(is,linecount) ;
     if(ASTEqual(openToken,TK_OPENPAREN)) {
       objname = parseFunctionArguments(objname,is,linecount,fileName,typemap) ;
@@ -1196,17 +1192,17 @@ AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
       pushToken(openToken) ;
 
     return applyPostFixOperator(AST_type::ASTP(objname),is,linecount,fileName,
-				  typemap) ;
-    
+                                typemap) ;
+
   }
-      
+
   if(isTerm(openToken)) {
 #ifdef VERBOSE
-    cerr << "parseExpressionPartial: found term '" 
+    cerr << "parseExpressionPartial: found term '"
          << openToken->text << "', checking for following parenthesis"
          << ", file: " << __FILE__ << ":" << __LINE__
          << endl ;
-#endif    
+#endif
     pushToken(openToken) ;
     AST_type::ASTP exp = parseTerm(is,linecount);
 
@@ -1230,7 +1226,7 @@ inline AST_type::operatorPrecedence getPrecedence(AST_type::elementType op) {
   case OP_ARRAY:
   case OP_DOT:
   case OP_ARROW:
-   return AST_type::operatorPrecedence::PREC_UNARY_POSTFIX ;
+    return AST_type::operatorPrecedence::PREC_UNARY_POSTFIX ;
   case OP_INCREMENT:
   case OP_DECREMENT:
   case OP_UNARY_PLUS:
@@ -1306,17 +1302,19 @@ inline bool rightToLeftAssociativePrecedence(AST_type::operatorPrecedence op) {
   return (op == AST_type::operatorPrecedence::PREC_ASSIGNMENT ||
           op == AST_type::operatorPrecedence::PREC_UNARY_PREFIX) ;
 }
+inline bool precedenceCompare(AST_type::operatorPrecedence prec_op,
+                              AST_type::operatorPrecedence prec_opStack) {
+  return ((prec_op == prec_opStack &&
+           rightToLeftAssociativePrecedence(prec_op)) ||
+          prec_op > prec_opStack) ;
+}  
 
 inline bool precedenceCompare(AST_type::ASTP &op,
                               CPTR<AST_exprOper> &opStack) {
 
   AST_type::operatorPrecedence prec_op = getPrecedence(op);
   AST_type::operatorPrecedence prec_opStack = getPrecedence(opStack) ;
-  //  if(prec_op == prec_opStack && op->nodeType == OP_TERNARY)
-  //    return false ;
-  return ((prec_op == prec_opStack &&
-           rightToLeftAssociativePrecedence(prec_op)) ||
-          prec_op > prec_opStack) ;
+  return precedenceCompare(prec_op,prec_opStack) ;
 }
 
 void printStack(vector<CPTR<AST_exprOper> > &exprStack,
@@ -1403,16 +1401,24 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
          << endl ;
 #endif
     // Special case for ?: operator or array
-    if(ASTEqual(op,OP_TERNARY)) 
+    if(ASTEqual(op,OP_TERNARY)) {
+#ifdef VERBOSE
+      cerr << "parsing expression for first term of TERNARY operator" << endl ;
+#endif
       expr = parseExpression(is,linecount,fileName,typemap,
                              AST_type::operatorPrecedence::PREC_ASSIGNMENT) ;
-    else 
+#ifdef VERBOSE
+      cerr << "expr parsed = " << endl ;
+      AST_simplePrint printer(cerr,-2) ;
+      expr->accept(printer) ;
+#endif
+    } else {
       expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
-    
+    }
     if(expr == 0) {
       return AST_type::ASTP(new AST_syntaxError("Expecting expression after binary operator",linecount,fileName)) ;
     }
-    
+
     if(ASTEqual(exprStack.back(),OP_NIL)) {
       // If no operator is parsed yet, we just get started and initilize
       // the left branch
@@ -1423,34 +1429,41 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
            << OPtoName(exprStack.back()->nodeType)
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+      if(exprStack.size() > 0) {
+        printStack(exprStack,cerr) ;
+      }
 #endif
       // ?: must read ':' and the false branch here as well; the lower
       // branches only handle colon when exprStack.back() is not OP_NIL.
       if(ASTEqual(op,OP_TERNARY)) {
         CPTR<AST_Token> op2 = getToken(is,linecount) ;
+#ifdef VERBOSE
+        cerr << "op2 = " << OPtoName(op2->nodeType) << endl ;
+#endif
         if(ASTEqual(op2,TK_COLON)) {
+#ifdef VERBOSE
+          cerr << "Found ':' of '?' operator" << endl ;
+#endif
+          
           AST_type::ASTP expr3 =
             parseExpression(is,linecount,fileName,typemap,
-                            AST_type::operatorPrecedence::PREC_ASSIGNMENT) ;
-            //              parseExpressionPartial(is,linecount,fileName,typemap) ;
+                            AST_type::operatorPrecedence::PREC_COMMA) ;
+          //              parseExpressionPartial(is,linecount,fileName,typemap) ;
           if(expr3 == 0) {
             return AST_type::ASTP(new AST_syntaxError(
-                "Expecting expression after ':' in ?: operator", linecount,
-                fileName)) ;
+                                                      "Expecting expression after ':' in ?: operator", linecount,
+                                                      fileName)) ;
           }
           exprStack.back()->terms.push_back(expr3) ;
 #ifdef VERBOSE
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+          if(exprStack.size() > 0) {
+            printStack(exprStack,cerr) ;
+          }
 #endif
         } else {
           pushToken(op2) ;
           return AST_type::ASTP(new AST_syntaxError(
-              "expecting ':' in tertiary operator", op2->lineno, fileName)) ;
+                                                    "expecting ':' in tertiary operator", op2->lineno, fileName)) ;
         }
       }
     } else {
@@ -1465,39 +1478,39 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 	}
 #endif
 #ifdef VERBOSE
-    cerr << "pop off exprStack:" << OPtoName(exprStack.back()->nodeType)
-         << ", file: " << __FILE__ << ":" << __LINE__
-         << endl ;
+        cerr << "pop off exprStack:" << OPtoName(exprStack.back()->nodeType)
+             << ", file: " << __FILE__ << ":" << __LINE__
+             << endl ;
 #endif
 	exprStack.pop_back() ;
 #ifdef VERBOSE
-    cerr << "after pop top of stack is:" << OPtoName(exprStack.back()->nodeType)
-         << ", size=" << exprStack.size()
-         << ", file: " << __FILE__ << ":" << __LINE__
-         << endl ;
+        cerr << "after pop top of stack is:" << OPtoName(exprStack.back()->nodeType)
+             << ", size=" << exprStack.size()
+             << ", file: " << __FILE__ << ":" << __LINE__
+             << endl ;
 #endif
 #ifdef VERBOSE
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+        if(exprStack.size() > 0) {
+          printStack(exprStack,cerr) ;
+        }
 #endif
-        
+
       }
-      
+
       if(ASTEqual(op,exprStack.back())) {
 	// If operator is the same, just chain the terms
 	exprStack.back()->terms.push_back(expr) ;
 #ifdef VERBOSE
         cerr << "adding term to operator: "
              << OPtoName(exprStack.back()->nodeType)
-             << " stack size=" << exprStack.size() 
+             << " stack size=" << exprStack.size()
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
 #endif
 #ifdef VERBOSE
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+        if(exprStack.size() > 0) {
+          printStack(exprStack,cerr) ;
+        }
 #endif
       } else if(precedenceCompare(op,exprStack.back())) {
         // if operator is lower precedence than top of stack, then we need
@@ -1521,9 +1534,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << endl ;
 #endif
 #ifdef VERBOSE
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+        if(exprStack.size() > 0) {
+          printStack(exprStack,cerr) ;
+        }
 #endif
         if(ASTEqual(op,OP_TERNARY)) {
           CPTR<AST_Token> op2 = getToken(is,linecount) ;
@@ -1533,6 +1546,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                << endl ;
 #endif
           if(ASTEqual(op2,TK_COLON)) {
+#ifdef VERBOSE
+            cerr << "detected TK_COLON, parsing expression" << endl ;
+#endif
             //            expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
             expr = parseExpression(is,linecount,fileName,typemap,
                                    AST_type::operatorPrecedence::PREC_COMMA) ;
@@ -1541,7 +1557,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
             AST_simplePrint printer(cerr,-2) ;
             expr->accept(printer) ;
 #endif
-              
+
             np->terms.push_back(expr) ;
           } else {
             pushToken(op2) ;
@@ -1556,9 +1572,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << endl ;
 #endif
 #ifdef VERBOSE
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+        if(exprStack.size() > 0) {
+          printStack(exprStack,cerr) ;
+        }
 #endif
       } else {
 	CPTR<AST_exprOper> np = new AST_exprOper ;
@@ -1568,7 +1584,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << OPtoName(np->nodeType)
              << ", file: " << __FILE__ << ":" << __LINE__
              << endl ;
-#endif        
+#endif
 	np->terms.push_back(AST_type::ASTP(exprStack.back())) ;
 	np->terms.push_back(expr) ;
 	if(ASTEqual(op,OP_TERNARY)) {
@@ -1577,7 +1593,7 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 	    pushToken(op2) ;
 	    expr = AST_type::ASTP(new AST_syntaxError("unexpected ':' in tertiary operator",linecount,fileName)) ;
 	  } else {
-	      expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
+            expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
 	  }
 	  np->terms.push_back(expr) ;
 #ifdef VERBOSE
@@ -1585,8 +1601,8 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                << ", file: " << __FILE__ << ":" << __LINE__
                << endl ;
 #endif
-	  
-	} 
+
+	}
 	exprStack.back() = np ;
 #ifdef VERBOSE
         cerr << "changing exprStack to" << OPtoName(exprStack.back()->nodeType)
@@ -1594,9 +1610,9 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
              << endl ;
 #endif
 #ifdef VERBOSE
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+        if(exprStack.size() > 0) {
+          printStack(exprStack,cerr) ;
+        }
 #endif
       }
     }
@@ -1605,13 +1621,13 @@ AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
 
 #ifdef VERBOSE
   cerr << "parseExpressionOperator exit loop stack" << endl ;
-    if(exprStack.size() > 0) {
-      printStack(exprStack,cerr) ;
-    }
+  if(exprStack.size() > 0) {
+    printStack(exprStack,cerr) ;
+  }
 #endif
 
   AST_type::ASTP e = CPTR<AST_type>(exprStack.front()) ;
-  if(ASTEqual(exprStack.front(),OP_NIL)) 
+  if(ASTEqual(exprStack.front(),OP_NIL))
     e = CPTR<AST_type>(exprStack.front()->terms.front()) ;
 
   return applyPostFixOperator(AST_type::ASTP(e),is,linecount,fileName,typemap) ;
@@ -1633,9 +1649,9 @@ AST_type::ASTP parseExpression(std::istream &is, int &linecount,
   AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap,prec) ;
   if(expr == 0) // If no valid expression then return null
     return expr ;
-  
+
   return parseExpressionOperator(expr,is,linecount,fileName,typemap,prec) ;
-  
+
 }
 
 
@@ -1662,13 +1678,13 @@ AST_type::ASTP parseCaseStatement(std::istream &is, int &linecount,
       parseExpression(is,linecount,fileName,AST_data->identifiers) ;
     AST_data->elements.push_back(expr) ;
   }
-  
+
   token = getToken(is,linecount) ;
   if(!ASTEqual(token,TK_COLON)) {
-    pushToken(token) ; 
+    pushToken(token) ;
     return AST_type::ASTP(new AST_syntaxError("expecting ':' in case statement",token->lineno,fileName)) ;
   }
-  
+
   AST_data->elements.push_back(AST_type::ASTP(token)) ;
   return AST_type::ASTP(AST_data) ;
 }
@@ -1719,8 +1735,8 @@ AST_type::ASTP parseSwitchStatement(std::istream &is, int &linecount,
     }
     token = getToken(is,linecount) ;
   }
-			
-  if(ASTEqual(token,TK_ERROR)) 
+
+  if(ASTEqual(token,TK_ERROR))
     return AST_type::ASTP(new AST_syntaxError("failed to find closing brace in swithc statement",linecount,fileName)) ;
 
   ctrl->parts.push_back(AST_type::ASTP(token)) ;
@@ -1742,7 +1758,7 @@ AST_type::ASTP parseIfStatement(std::istream &is, int &linecount,
     return AST_type::ASTP(new AST_syntaxError("confused in if statement",token->lineno,fileName)) ;
   }
   AST_type::ASTP iftok = AST_type::ASTP(token) ;
-  
+
   token = getToken(is,linecount) ;
   if(!ASTEqual(token,TK_OPENPAREN)) {
     pushToken(token) ;
@@ -1750,7 +1766,7 @@ AST_type::ASTP parseIfStatement(std::istream &is, int &linecount,
   }
   pushToken(token) ;
   AST_type::ASTP conditional = parseExpression(is,linecount,fileName,typemap) ;
-  if(conditional == 0) 
+  if(conditional == 0)
     return AST_type::ASTP(new AST_syntaxError("malformed if conditional",token->lineno,fileName)) ;
 
   AST_type::ASTP body = parseStatement(is,linecount,fileName,typemap) ;
@@ -1758,7 +1774,7 @@ AST_type::ASTP parseIfStatement(std::istream &is, int &linecount,
   AST_type::ASTP elsetok = 0 ;
   AST_type::ASTP ebody = 0 ;
   token = getToken(is,linecount) ;
-  
+
   if(ASTEqual(token,TK_ELSE)) {
     elsetok = AST_type::ASTP(token) ;
     ebody = parseStatement(is,linecount,fileName,typemap) ;
@@ -1769,7 +1785,7 @@ AST_type::ASTP parseIfStatement(std::istream &is, int &linecount,
   ctrl->identifiers = typemap ;
   ctrl->constructIf(iftok,conditional,body,elsetok,ebody) ;
   return AST_type::ASTP(ctrl) ;
-}			 
+}
 
 AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
 				  const string &fileName,
@@ -1799,14 +1815,14 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
       // advance
       // TK_CLOSEPAREN
       // for body
-      
+
       ctrl->nodeType = ND_CTRL_FOR ;
-      
+
       token = getToken(is,linecount) ;
       if(!ASTEqual(token,TK_OPENPAREN)) {
 	pushToken(token) ;
 	return AST_type::ASTP(new AST_syntaxError("for expecting '('",token->lineno,fileName)) ;
-     } 
+      }
       ctrl->parts.push_back(AST_type::ASTP(token)) ;
       token = getToken(is,linecount) ;
 #ifdef VERBOSE
@@ -1814,7 +1830,7 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
 #endif
-      
+
       AST_type::ASTP initializer = 0 ;
       if(ASTEqual(token,TK_SEMICOLON)) {
         initializer = AST_type::ASTP(token) ;
@@ -1843,9 +1859,9 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
       cerr << "initializer = " << OPtoName(initializer->nodeType)
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
-#endif      
+#endif
       ctrl->parts.push_back(initializer) ;
-	
+
 #ifdef VERBOSE
       cerr << "for: parsing conditional expression"
            << ", file: " << __FILE__ << ":" << __LINE__
@@ -1853,12 +1869,12 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
 #endif
       AST_type::ASTP conditional = parseExpression(is,linecount,fileName,
 						   ctrl->identifiers) ;
-      
+
 #ifdef VERBOSE
       cerr << "conditional = " << OPtoName(conditional->nodeType)
            << ", file: " << __FILE__ << ":" << __LINE__
            << endl ;
-#endif      
+#endif
       ctrl->parts.push_back(conditional) ;
       token = getToken(is,linecount) ;
       if(!ASTEqual(token,TK_SEMICOLON)) {
@@ -1942,7 +1958,7 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
       token = getToken(is,linecount) ;
       if(!ASTEqual(token,TK_SEMICOLON)) {
 	pushToken(token) ;
-	
+
 	ctrl->parts.push_back(AST_type::ASTP(new AST_syntaxError("Expecting ';' in do loop",token->lineno,fileName))) ;
       } else
 	ctrl->parts.push_back(AST_type::ASTP(token)) ;
@@ -1952,7 +1968,7 @@ AST_type::ASTP parseLoopStatement(std::istream &is, int &linecount,
   default:
     return 0 ;
   }
-  
+
   return AST_type::ASTP(getToken(is,linecount)) ;
 }
 
@@ -2031,9 +2047,9 @@ string getIdentifierName(std::istream &is,
 #endif
   return name ;
 }
-    
-      
-    
+
+
+
 /// Determine if statement is a declration or a simple statement by
 /// looking up potential typename in varmap.  We assume that the first
 /// token is either an TK_NAME or TK_SCOPE as a prerequisite
@@ -2059,7 +2075,7 @@ AST_type::ASTP parseDeclarationOrSimpleStatement(std::istream &is,
   }
   if(ASTEqual(openToken,TK_STRUCT) || ASTEqual(openToken,TK_CLASS))
     return parseDeclaration(is,linecount,fileName,typemap) ;
-  
+
   bool isFunc = false ;
   string ident = getIdentifierName(is,linecount,fileName,isFunc) ;
 #ifdef VERBOASE
@@ -2097,9 +2113,9 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
 
   do {
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, token = " << token->text
-       << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
+    cerr << "in parseDeclaration, token = " << token->text
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     switch(token->nodeType) {
     case TK_CONST:
@@ -2158,7 +2174,7 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
         istype = false ;
       } else {
         pushToken(token) ;
-        
+
         AST_type::ASTP typedec =
           parseIdentifier(is,linecount,fileName,typemap) ;
         if(typedec->nodeType == OP_FUNC) {
@@ -2216,36 +2232,36 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
       AST_data->decls.push_back(AST_type::ASTP(token)) ;
       token = getToken(is,linecount) ;
     }
-    
+
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, processed pointer or reference: " << token->text
-       << ", file: " << __FILE__ << ":" << __LINE__
-       << endl ;
+    cerr << "in parseDeclaration, processed pointer or reference: " << token->text
+         << ", file: " << __FILE__ << ":" << __LINE__
+         << endl ;
 #endif
     if(ASTEqual(token,TK_NAME)) {
       typemap[token->text] = localIdentifier() ;
       AST_data->decl_varnames.push_back(token->text) ;
       pushToken(token) ;
-      
+
       AST_type::ASTP expr = parseExpressionPartial(is,linecount,fileName,typemap) ;
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, parsing expression "
-       << ", file: " << __FILE__ << ":" << __LINE__
-       <<  endl ;
+      cerr << "in parseDeclaration, parsing expression "
+           << ", file: " << __FILE__ << ":" << __LINE__
+           <<  endl ;
 #endif
       if(expr != 0) { // If no valid expression then return null
         expr = parseExpressionOperator(expr,is,linecount,fileName,typemap,
                                        AST_type::operatorPrecedence::PREC_COMMA) ;
       } else {
 #ifdef VERBOSE
-  cerr << "in parseDeclaration, parseExpressionPartial returned nil "
-       << ", file: " << __FILE__ << ":" << __LINE__
-       <<  endl ;
+        cerr << "in parseDeclaration, parseExpressionPartial returned nil "
+             << ", file: " << __FILE__ << ":" << __LINE__
+             <<  endl ;
 #endif
-        
+
         AST_type::ASTP p =
           AST_type::ASTP(new AST_syntaxError("Syntax error variable declaration",
-                                         token->lineno,fileName)) ;
+                                             token->lineno,fileName)) ;
         AST_data->decls.push_back(p) ;
       }
       AST_data->decls.push_back(expr) ;
@@ -2278,7 +2294,7 @@ AST_type::ASTP parseDeclaration(std::istream &is, int &linecount,
 AST_type::ASTP parseSpecialControlStatement(std::istream &is, int &linecount,
 					    const string &fileName,
 					    varmap &typemap) {
-  
+
   CPTR<AST_Block> AST_data = new AST_Block ;
   AST_data->identifiers = typemap ;
   AST_data->nodeType = OP_SPECIAL ;
@@ -2320,7 +2336,7 @@ AST_type::ASTP parseSimpleStatement(std::istream &is, int &linecount,
        << endl ;
 #endif
   AST_type::ASTP exp = parseExpression(is,linecount,fileName,typemap) ;
-  
+
   CPTR<AST_Token> termToken = getToken(is,linecount) ;
   AST_type::ASTP term = AST_type::ASTP(termToken) ;
 #ifdef VERBOSE
@@ -2424,7 +2440,7 @@ AST_type::ASTP parseStatement(std::istream &is, int &linecount,
       return AST_type::ASTP(AST_data) ;
     }
     break ;
-    
+
   case TK_OPENPAREN:
   case TK_PLUS:
   case TK_MINUS:
@@ -2437,8 +2453,8 @@ AST_type::ASTP parseStatement(std::istream &is, int &linecount,
   case TK_LOCI_CONTAINER:
     {
       return parseSimpleStatement(is,linecount,fileName,typemap) ;
-    } 
-    
+    }
+
   case TK_MACRO:
     firstToken = getToken(is,linecount) ;
     return AST_type::ASTP(firstToken) ;
@@ -2448,7 +2464,7 @@ AST_type::ASTP parseStatement(std::istream &is, int &linecount,
   default:
     break ;
   }
-  
+
   firstToken = getToken(is,linecount) ;
   return AST_type::ASTP(new AST_syntaxError("Expecting statement or ';' ",
 					    firstToken->lineno,
@@ -2486,7 +2502,7 @@ AST_type::ASTP parseBlock(std::istream &is, int &linecount,
       parseStatement(is,linecount,fileName,AST_data->identifiers) ;
     AST_data->elements.push_back(statement) ;
     token = getToken(is,linecount) ;
-    if(is.fail() || is.eof()) 
+    if(is.fail() || is.eof())
       break ;
   }
   AST_data->elements.push_back(AST_type::ASTP(token)) ;
@@ -2496,7 +2512,7 @@ AST_type::ASTP parseBlock(std::istream &is, int &linecount,
 void AST_visitor::visit(AST_SimpleStatement &s) {
   if(s.exp!=0)
     s.exp->accept(*this) ;
-  if(s.Terminal!=0) 
+  if(s.Terminal!=0)
     s.Terminal->accept(*this) ;
 }
 void AST_visitor::visit(AST_Block &s) {
@@ -2537,7 +2553,7 @@ void AST_visitor::visit(AST_controlStatement &s) {
 void AST_errorCheck::visit(AST_syntaxError &s) {
   cerr << s.fileName << ":" << s.lineno << ": syntax, " <<s.error << endl ;
   error_count++ ;
-}  
+}
 
 void AST_collectAccessInfo::visit(AST_Token &s) {
   if(ASTEqual(s,TK_LOCI_VARIABLE)) {
@@ -2557,11 +2573,11 @@ AST_type::ASTP getArrayVar(AST_type::ASTP expr) {
 }
 bool isExprLociVariable(AST_type::ASTP expr) {
   expr = getArrayVar(expr) ;
-  
+
   return ASTEqual(expr,TK_LOCI_VARIABLE) ;
 }
 
-  
+
 void AST_collectAccessInfo::visit(AST_exprOper &s) {
   switch(s.nodeType) {
   case OP_ASSIGN:
@@ -2587,7 +2603,7 @@ void AST_collectAccessInfo::visit(AST_exprOper &s) {
       for(auto mi=first.id2vmap.begin();mi!=first.id2vmap.end();++mi)
 	id2vmap[mi->first] = mi->second ;
       for(++ii;ii!=s.terms.end();++ii)
-	if(*ii != 0) 
+	if(*ii != 0)
           (*ii)->accept(*this) ;
     }
     break ;
@@ -2596,11 +2612,11 @@ void AST_collectAccessInfo::visit(AST_exprOper &s) {
       // Work on this to fill in the maps
       bool allLociVars = true ;
       for(auto ii=s.terms.begin();ii!=s.terms.end();++ii)
-	if(*ii != 0) 
+	if(*ii != 0)
 	  allLociVars = allLociVars && isExprLociVariable(*ii) ;
       if(allLociVars) {
 	Loci::vmap_info vm ;
-	
+
 	for(auto ii=s.terms.begin();ii!=s.terms.end();++ii)
 	  if(*ii != 0) {
 	    AST_type::ASTP vp = getArrayVar(*ii) ;
@@ -2641,7 +2657,7 @@ void AST_collectAccessInfo::visit(AST_exprOper &s) {
     break ;
   }
 }
-  
+
 void AST_simplePrint::visit(AST_exprOper &s) {
   auto t = id2rename.find(s.id) ;
   if(t != id2rename.end()) {
@@ -2732,23 +2748,25 @@ void AST_simplePrint::visit(AST_exprOper &s) {
   case OP_TERNARY:
     {
       AST_type::ASTList::iterator ii=s.terms.begin() ;
-      if(*ii != 0)
+      
+      if(ii!=s.terms.end() && *ii != 0) {
 	(*ii)->accept(*this) ;
-      ++ii ;
+      }
+      if(ii!=s.terms.end()) 
+        ++ii ;
       out << '?' ;
-      if(*ii != 0)
+      if(ii!=s.terms.end() && *ii != 0)
 	(*ii)->accept(*this) ;
       out << ':' ;
       if(ii==s.terms.end()) {
 	cerr << "internal error on tertiary operator" << endl ;
       } else
 	++ii ;
-      if(*ii != 0)
+      if(ii!=s.terms.end() && *ii != 0)
 	(*ii)->accept(*this) ;
-
     }
     break ;
-      
+
   case OP_UNARY_PLUS:
   case OP_UNARY_MINUS:
   case OP_NOT:
@@ -2810,7 +2828,7 @@ void AST_simplePrint::visit(AST_Token &s) {
       out << "$" << s.text ;
     } else if(ASTEqual(s,TK_MACRO)) {
       out << endl << '#' << s.text << endl ;
-    } else 
+    } else
       out <<s.text << ' ' ;
   }
 }
@@ -2827,7 +2845,7 @@ bool condenseOp(AST_type::elementType et) {
     return false ;
   }
 }
-    
+
 void AST_condenseLeftAssociative::visit(AST_exprOper &e) {
   AST_type::elementType op = e.nodeType ;
 

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -609,6 +609,9 @@ AST_type::ASTP applyPostFixOperator(AST_type::ASTP expr,
     else
       return AST_type::ASTP(post) ;
   }
+  if(ASTEqual(openToken,TK_OPENPAREN)) {
+    return parseFunctionArguments(expr,is,linecount,fileName,typemap) ;
+  }
   if(ASTEqual(openToken,TK_OPENBRACKET)) {
     AST_type::ASTP index = parseExpression(is,linecount,fileName,typemap) ;
     openToken = getToken(is,linecount) ;

--- a/src/lpp/parseAST.h
+++ b/src/lpp/parseAST.h
@@ -73,7 +73,7 @@ struct varinfo {
   bool isLocalIdentifier() { return statusLocal ; }
 } ;
 
-/// create varinfo type for local variable 
+/// create varinfo type for local variable
 inline varinfo localIdentifier() {
   varinfo v ;
   v.statusType=false ;
@@ -118,9 +118,12 @@ public:
   AST_type() ;
   typedef CPTR<AST_type> ASTP ;
   typedef std::vector<ASTP> ASTList ;
-  // Operator precedence orderd from lowest to hightest
+  // Operator precedence ordered from lowest to highest
+  // Look at getPrecedence() in parseAST.cc to see what operators are
+  // associated with each precedence level.
   enum class operatorPrecedence {
-    PREC_ERROR = 0,
+    PREC_ERROR = 0, // reserved for error value
+    PREC_NIL,       // lowest precedence
     PREC_COMMA,
     PREC_ASSIGNMENT,
     PREC_LOGICAL_OR,
@@ -138,23 +141,26 @@ public:
     PREC_UNARY_POSTFIX,
     PREC_SCOPE
   } ;
-  
+
+  // potential node types for the AST_tree nodes.
+  // Note, if changing this enum, remember to make the changes to the
+  // convenience namespace, nodeTypes, below.
   enum class elementType {
-    OP_SCOPE=0x000,
-    OP_AT=0x080, // For using @ to separate namespaces
+    OP_SCOPE,
+    OP_AT, // For using @ to separate namespaces
     // Traditional C operators
-    OP_DOT=0x100,
+    OP_DOT,
     OP_ARROW,
     OP_ARRAY,
-    OP_TIMES = 0x300, OP_DIVIDE, OP_MODULUS,
-    OP_PLUS  = 0x400, OP_MINUS, 
-    OP_SHIFT_RIGHT = 0x500, OP_SHIFT_LEFT,
-    OP_LT = 0x600, OP_GT, OP_GE, OP_LE,
-    OP_EQUAL = 0x700, OP_NOT_EQUAL, 
-    OP_AND=0x800, OP_EXOR=0x900, OP_OR=0xa00,
-    OP_LOGICAL_AND=0xb00, OP_LOGICAL_OR=0xc00,
+    OP_TIMES, OP_DIVIDE, OP_MODULUS,
+    OP_PLUS, OP_MINUS,
+    OP_SHIFT_RIGHT, OP_SHIFT_LEFT,
+    OP_LT, OP_GT, OP_GE, OP_LE,
+    OP_EQUAL, OP_NOT_EQUAL,
+    OP_AND, OP_EXOR, OP_OR,
+    OP_LOGICAL_AND, OP_LOGICAL_OR,
     OP_TERNARY,
-    OP_ASSIGN=0xd00,
+    OP_ASSIGN,
     OP_TIMES_ASSIGN,
     OP_DIVIDE_ASSIGN,
     OP_MODULUS_ASSIGN,
@@ -165,11 +171,11 @@ public:
     OP_AND_ASSIGN,
     OP_OR_ASSIGN,
     OP_EXOR_ASSIGN,
-    OP_COMMA=0xe00, 
-    OP_COLON=0xf00,
+    OP_COMMA,
+    OP_COLON,
     OP_SEMICOLON,
     // terminal for empty statement
-    OP_NIL=0x1000,
+    OP_NIL,
     // terminals for variable name, function, array or name{args}
     OP_INCREMENT,OP_DECREMENT,
     OP_POSTINCREMENT, OP_POSTDECREMENT,
@@ -188,18 +194,18 @@ public:
     OP_OPENBRACE,OP_CLOSEBRACE,
     OP_LOCI_DIRECTIVE,OP_LOCI_VARIABLE,OP_LOCI_CONTAINER,
     OP_TERM, OP_SPECIAL,
-    TK_BRACEBLOCK=0x2000,
+    TK_BRACEBLOCK,
     TK_SCOPE,
     TK_AT, // For using @ to separate namespaces
     // Traditional C operators
-    TK_ARROW, 
+    TK_ARROW,
     TK_TIMES, TK_DIVIDE, TK_MODULUS,
-    TK_PLUS, TK_MINUS, 
+    TK_PLUS, TK_MINUS,
     TK_SHIFT_RIGHT, TK_SHIFT_LEFT,
     TK_LT, TK_GT, TK_GE, TK_LE,
-    TK_EQUAL, TK_NOT_EQUAL, 
+    TK_EQUAL, TK_NOT_EQUAL,
     TK_AND, TK_EXOR, TK_OR,
-    TK_LOGICAL_AND, TK_LOGICAL_OR, 
+    TK_LOGICAL_AND, TK_LOGICAL_OR,
     TK_ASSIGN,
     TK_TIMES_ASSIGN,
     TK_DIVIDE_ASSIGN,
@@ -218,7 +224,7 @@ public:
     TK_NIL,
     // terminals for variable name, function, array or name{args}
     TK_INCREMENT,TK_DECREMENT,TK_COMMENT,TK_MACRO,
-    TK_NAME, 
+    TK_NAME,
     // terminal for string, integer, or unspecified error condition
     TK_STRING, TK_NUMBER, TK_ERROR,
     // Unary operations
@@ -229,7 +235,7 @@ public:
     TK_OPENTEMPLATE,TK_CLOSETEMPLATE,
     TK_LOCI_DIRECTIVE,TK_LOCI_VARIABLE,TK_LOCI_CONTAINER,
     // Now the keywords
-    TK_ALIGNAS, TK_ALIGNOF, TK_ASM, 
+    TK_ALIGNAS, TK_ALIGNOF, TK_ASM,
     TK_BOOL,TK_FALSE,TK_TRUE,TK_CHAR,TK_INT,TK_LONG,
     TK_SHORT,TK_SIGNED,TK_UNSIGNED,TK_DOUBLE,TK_FLOAT,TK_ENUM,
     TK_MUTABLE,TK_CONST,TK_STATIC,TK_VOLATILE,TK_AUTO,
@@ -248,235 +254,451 @@ public:
     ND_CTRL_IF,ND_CTRL_FOR,ND_CTRL_WHILE, ND_CTRL_DO,
     ND_CTRL_SWITCH, ND_SIMPLE_STATEMENT,ND_BLOCK,
     ND_DECL,ND_TYPE_SPEC,ND_TERMINAL,
-    TK_SENTINEL 
-		    
+    TK_SENTINEL
+
   } ;
   int id ;
   elementType nodeType ;
   virtual void accept(AST_visitor &v) = 0 ;
   virtual ASTP clone() const = 0 ;
-  
+
 } ;
 
 namespace nodeTypes {
-  
-  constexpr AST_type::elementType OP_SCOPE = AST_type::elementType::OP_SCOPE ;
-  constexpr AST_type::elementType OP_AT = AST_type::elementType::OP_AT ;
-  constexpr AST_type::elementType OP_DOT = AST_type::elementType::OP_DOT ;
-  constexpr AST_type::elementType OP_ARROW = AST_type::elementType::OP_ARROW ;
-  constexpr AST_type::elementType OP_ARRAY = AST_type::elementType::OP_ARRAY ;
-  constexpr AST_type::elementType OP_TIMES = AST_type::elementType::OP_TIMES ;
-  constexpr AST_type::elementType OP_DIVIDE = AST_type::elementType::OP_DIVIDE;
-  constexpr AST_type::elementType OP_MODULUS = AST_type::elementType::OP_MODULUS;
-  constexpr AST_type::elementType OP_PLUS = AST_type::elementType::OP_PLUS;
-  constexpr AST_type::elementType OP_MINUS = AST_type::elementType::OP_MINUS; 
-  constexpr AST_type::elementType OP_SHIFT_RIGHT = AST_type::elementType::OP_SHIFT_RIGHT;
-  constexpr AST_type::elementType OP_SHIFT_LEFT = AST_type::elementType::OP_SHIFT_LEFT;
-  constexpr AST_type::elementType OP_LT = AST_type::elementType::OP_LT;
-  constexpr AST_type::elementType OP_GT = AST_type::elementType::OP_GT;
-  constexpr AST_type::elementType OP_GE = AST_type::elementType::OP_GE;
-  constexpr AST_type::elementType OP_LE = AST_type::elementType::OP_LE;
-  constexpr AST_type::elementType OP_EQUAL = AST_type::elementType::OP_EQUAL;
-  constexpr AST_type::elementType OP_NOT_EQUAL = AST_type::elementType::OP_NOT_EQUAL; 
-  constexpr AST_type::elementType OP_AND = AST_type::elementType::OP_AND;
-  constexpr AST_type::elementType OP_EXOR = AST_type::elementType::OP_EXOR;
-  constexpr AST_type::elementType OP_OR = AST_type::elementType::OP_OR;
-  constexpr AST_type::elementType OP_LOGICAL_AND = AST_type::elementType::OP_LOGICAL_AND;
-  constexpr AST_type::elementType OP_LOGICAL_OR = AST_type::elementType::OP_LOGICAL_OR;
-  constexpr AST_type::elementType OP_TERNARY = AST_type::elementType::OP_TERNARY;
-  constexpr AST_type::elementType OP_ASSIGN = AST_type::elementType::OP_ASSIGN;
-  constexpr AST_type::elementType OP_TIMES_ASSIGN = AST_type::elementType::OP_TIMES_ASSIGN;
-  constexpr AST_type::elementType OP_DIVIDE_ASSIGN = AST_type::elementType::OP_DIVIDE_ASSIGN;
-  constexpr AST_type::elementType OP_MODULUS_ASSIGN = AST_type::elementType::OP_MODULUS_ASSIGN;
-  constexpr AST_type::elementType OP_PLUS_ASSIGN = AST_type::elementType::OP_PLUS_ASSIGN;
-  constexpr AST_type::elementType OP_MINUS_ASSIGN = AST_type::elementType::OP_MINUS_ASSIGN;
-  constexpr AST_type::elementType OP_SHIFT_LEFT_ASSIGN = AST_type::elementType::OP_SHIFT_LEFT_ASSIGN;
-  constexpr AST_type::elementType OP_SHIFT_RIGHT_ASSIGN = AST_type::elementType::OP_SHIFT_RIGHT_ASSIGN;
-  constexpr AST_type::elementType OP_AND_ASSIGN = AST_type::elementType::OP_AND_ASSIGN;
-  constexpr AST_type::elementType OP_OR_ASSIGN = AST_type::elementType::OP_OR_ASSIGN;
-  constexpr AST_type::elementType OP_EXOR_ASSIGN = AST_type::elementType::OP_EXOR_ASSIGN;
-  constexpr AST_type::elementType OP_COMMA = AST_type::elementType::OP_COMMA; 
-  constexpr AST_type::elementType OP_COLON = AST_type::elementType::OP_COLON;
-  constexpr AST_type::elementType OP_SEMICOLON = AST_type::elementType::OP_SEMICOLON;
-  constexpr AST_type::elementType OP_NIL = AST_type::elementType::OP_NIL;
-  constexpr AST_type::elementType OP_INCREMENT = AST_type::elementType::OP_INCREMENT;
-  constexpr AST_type::elementType OP_DECREMENT = AST_type::elementType::OP_DECREMENT;
-  constexpr AST_type::elementType OP_POSTINCREMENT = AST_type::elementType::OP_POSTINCREMENT;
-  constexpr AST_type::elementType OP_POSTDECREMENT = AST_type::elementType::OP_POSTDECREMENT;
-  constexpr AST_type::elementType OP_COMMENT = AST_type::elementType::OP_COMMENT;
-  constexpr AST_type::elementType OP_BRACEBLOCK = AST_type::elementType::OP_BRACEBLOCK;
-  constexpr AST_type::elementType OP_NAME = AST_type::elementType::OP_NAME;
-  constexpr AST_type::elementType OP_FUNC = AST_type::elementType::OP_FUNC;
-  constexpr AST_type::elementType OP_NAME_BRACE = AST_type::elementType::OP_NAME_BRACE;
-  constexpr AST_type::elementType OP_FUNC_BRACE = AST_type::elementType::OP_FUNC_BRACE;
-  constexpr AST_type::elementType OP_TEMPLATE = AST_type::elementType::OP_TEMPLATE;
-  constexpr AST_type::elementType OP_TEMPLATE_FUNC = AST_type::elementType::OP_TEMPLATE_FUNC;
-  constexpr AST_type::elementType OP_STRING = AST_type::elementType::OP_STRING;
-  constexpr AST_type::elementType OP_NUMBER = AST_type::elementType::OP_NUMBER;
-  constexpr AST_type::elementType OP_ERROR = AST_type::elementType::OP_ERROR;
-  constexpr AST_type::elementType OP_UNARY_PLUS = AST_type::elementType::OP_UNARY_PLUS;
-  constexpr AST_type::elementType OP_UNARY_MINUS = AST_type::elementType::OP_UNARY_MINUS;
-  constexpr AST_type::elementType OP_NOT = AST_type::elementType::OP_NOT;
-  constexpr AST_type::elementType OP_TILDE = AST_type::elementType::OP_TILDE;
-  constexpr AST_type::elementType OP_AMPERSAND = AST_type::elementType::OP_AMPERSAND;
-  constexpr AST_type::elementType OP_DOLLAR = AST_type::elementType::OP_DOLLAR;
-  constexpr AST_type::elementType OP_STAR = AST_type::elementType::OP_STAR;
-  constexpr AST_type::elementType OP_CAST = AST_type::elementType::OP_CAST;
-  constexpr AST_type::elementType OP_GROUP = AST_type::elementType::OP_GROUP;
-  constexpr AST_type::elementType OP_GROUP_ERROR = AST_type::elementType::OP_GROUP_ERROR;
-  constexpr AST_type::elementType OP_OPENPAREN = AST_type::elementType::OP_OPENPAREN;
-  constexpr AST_type::elementType OP_CLOSEPAREN = AST_type::elementType::OP_CLOSEPAREN;
-  constexpr AST_type::elementType OP_OPENBRACKET = AST_type::elementType::OP_OPENBRACKET;
-  constexpr AST_type::elementType OP_CLOSEBRACKET = AST_type::elementType::OP_CLOSEBRACKET;
-  constexpr AST_type::elementType OP_OPENBRACE = AST_type::elementType::OP_OPENBRACE;
-  constexpr AST_type::elementType OP_CLOSEBRACE = AST_type::elementType::OP_CLOSEBRACE;
-  constexpr AST_type::elementType OP_LOCI_DIRECTIVE = AST_type::elementType::OP_LOCI_DIRECTIVE;
-  constexpr AST_type::elementType OP_LOCI_VARIABLE = AST_type::elementType::OP_LOCI_VARIABLE;
-  constexpr AST_type::elementType OP_LOCI_CONTAINER = AST_type::elementType::OP_LOCI_CONTAINER;
-  constexpr AST_type::elementType OP_TERM = AST_type::elementType::OP_TERM;
-  constexpr AST_type::elementType OP_SPECIAL = AST_type::elementType::OP_SPECIAL;
-  constexpr AST_type::elementType TK_BRACEBLOCK = AST_type::elementType::TK_BRACEBLOCK;
-  constexpr AST_type::elementType TK_SCOPE = AST_type::elementType::TK_SCOPE;
-  constexpr AST_type::elementType TK_AT = AST_type::elementType::TK_AT; 
-  constexpr AST_type::elementType TK_ARROW = AST_type::elementType::TK_ARROW; 
-  constexpr AST_type::elementType TK_TIMES = AST_type::elementType::TK_TIMES;
-  constexpr AST_type::elementType TK_DIVIDE = AST_type::elementType::TK_DIVIDE;
-  constexpr AST_type::elementType TK_MODULUS = AST_type::elementType::TK_MODULUS;
-  constexpr AST_type::elementType TK_PLUS = AST_type::elementType::TK_PLUS;
-  constexpr AST_type::elementType TK_MINUS = AST_type::elementType::TK_MINUS; 
-  constexpr AST_type::elementType TK_SHIFT_RIGHT = AST_type::elementType::TK_SHIFT_RIGHT;
-  constexpr AST_type::elementType TK_SHIFT_LEFT = AST_type::elementType::TK_SHIFT_LEFT;
-  constexpr AST_type::elementType TK_LT = AST_type::elementType::TK_LT;
-  constexpr AST_type::elementType TK_GT = AST_type::elementType::TK_GT;
-  constexpr AST_type::elementType TK_GE = AST_type::elementType::TK_GE;
-  constexpr AST_type::elementType TK_LE = AST_type::elementType::TK_LE;
-  constexpr AST_type::elementType TK_EQUAL = AST_type::elementType::TK_EQUAL;
-  constexpr AST_type::elementType TK_NOT_EQUAL = AST_type::elementType::TK_NOT_EQUAL; 
-  constexpr AST_type::elementType TK_AND = AST_type::elementType::TK_AND;
-  constexpr AST_type::elementType TK_EXOR = AST_type::elementType::TK_EXOR;
-  constexpr AST_type::elementType TK_OR = AST_type::elementType::TK_OR;
-  constexpr AST_type::elementType TK_LOGICAL_AND = AST_type::elementType::TK_LOGICAL_AND;
-  constexpr AST_type::elementType TK_LOGICAL_OR = AST_type::elementType::TK_LOGICAL_OR; 
-  constexpr AST_type::elementType TK_ASSIGN = AST_type::elementType::TK_ASSIGN;
-  constexpr AST_type::elementType TK_TIMES_ASSIGN = AST_type::elementType::TK_TIMES_ASSIGN;
-  constexpr AST_type::elementType TK_DIVIDE_ASSIGN = AST_type::elementType::TK_DIVIDE_ASSIGN;
-  constexpr AST_type::elementType TK_MODULUS_ASSIGN = AST_type::elementType::TK_MODULUS_ASSIGN;
-  constexpr AST_type::elementType TK_PLUS_ASSIGN = AST_type::elementType::TK_PLUS_ASSIGN;
-  constexpr AST_type::elementType TK_MINUS_ASSIGN = AST_type::elementType::TK_MINUS_ASSIGN;
-  constexpr AST_type::elementType TK_SHIFT_LEFT_ASSIGN = AST_type::elementType::TK_SHIFT_LEFT_ASSIGN;
-  constexpr AST_type::elementType TK_SHIFT_RIGHT_ASSIGN = AST_type::elementType::TK_SHIFT_RIGHT_ASSIGN;
-  constexpr AST_type::elementType TK_AND_ASSIGN = AST_type::elementType::TK_AND_ASSIGN;
-  constexpr AST_type::elementType TK_OR_ASSIGN = AST_type::elementType::TK_OR_ASSIGN;
-  constexpr AST_type::elementType TK_EXOR_ASSIGN = AST_type::elementType::TK_EXOR_ASSIGN;
-  constexpr AST_type::elementType TK_COMMA = AST_type::elementType::TK_COMMA;
-  constexpr AST_type::elementType TK_DOT = AST_type::elementType::TK_DOT;
-  constexpr AST_type::elementType TK_COLON = AST_type::elementType::TK_COLON;
-  constexpr AST_type::elementType TK_SEMICOLON = AST_type::elementType::TK_SEMICOLON;
-  constexpr AST_type::elementType TK_NIL = AST_type::elementType::TK_NIL;
 
-  constexpr AST_type::elementType TK_INCREMENT = AST_type::elementType::TK_INCREMENT;
-  constexpr AST_type::elementType TK_DECREMENT = AST_type::elementType::TK_DECREMENT;
-  constexpr AST_type::elementType TK_COMMENT = AST_type::elementType::TK_COMMENT;
-  constexpr AST_type::elementType TK_MACRO = AST_type::elementType::TK_MACRO;
-  constexpr AST_type::elementType TK_NAME = AST_type::elementType::TK_NAME; 
-  constexpr AST_type::elementType TK_STRING = AST_type::elementType::TK_STRING;
-  constexpr AST_type::elementType TK_NUMBER = AST_type::elementType::TK_NUMBER;
-  constexpr AST_type::elementType TK_ERROR = AST_type::elementType::TK_ERROR;
-  constexpr AST_type::elementType TK_UNARY_PLUS = AST_type::elementType::TK_UNARY_PLUS;
-  constexpr AST_type::elementType TK_UNARY_MINUS = AST_type::elementType::TK_UNARY_MINUS;
-  constexpr AST_type::elementType TK_NOT = AST_type::elementType::TK_NOT;
-  constexpr AST_type::elementType TK_TILDE = AST_type::elementType::TK_TILDE;
-  constexpr AST_type::elementType TK_QUESTION = AST_type::elementType::TK_QUESTION;
-  constexpr AST_type::elementType TK_AMPERSAND = AST_type::elementType::TK_AMPERSAND;
-  constexpr AST_type::elementType TK_STAR = AST_type::elementType::TK_STAR;
-  constexpr AST_type::elementType TK_OPENPAREN = AST_type::elementType::TK_OPENPAREN;
-  constexpr AST_type::elementType TK_CLOSEPAREN = AST_type::elementType::TK_CLOSEPAREN;
-  constexpr AST_type::elementType TK_OPENBRACKET = AST_type::elementType::TK_OPENBRACKET;
-  constexpr AST_type::elementType TK_CLOSEBRACKET = AST_type::elementType::TK_CLOSEBRACKET;
-  constexpr AST_type::elementType TK_OPENBRACE = AST_type::elementType::TK_OPENBRACE;
-  constexpr AST_type::elementType TK_CLOSEBRACE = AST_type::elementType::TK_CLOSEBRACE;
-  constexpr AST_type::elementType TK_OPENTEMPLATE = AST_type::elementType::TK_OPENTEMPLATE;
-  constexpr AST_type::elementType TK_CLOSETEMPLATE = AST_type::elementType::TK_CLOSETEMPLATE;
-  constexpr AST_type::elementType TK_LOCI_DIRECTIVE = AST_type::elementType::TK_LOCI_DIRECTIVE;
-  constexpr AST_type::elementType TK_LOCI_VARIABLE = AST_type::elementType::TK_LOCI_VARIABLE;constexpr AST_type::elementType TK_LOCI_CONTAINER = AST_type::elementType::TK_LOCI_CONTAINER;
+  constexpr AST_type::elementType OP_SCOPE =
+    AST_type::elementType::OP_SCOPE ;
+  constexpr AST_type::elementType OP_AT =
+    AST_type::elementType::OP_AT ;
+  constexpr AST_type::elementType OP_DOT =
+    AST_type::elementType::OP_DOT ;
+  constexpr AST_type::elementType OP_ARROW =
+    AST_type::elementType::OP_ARROW ;
+  constexpr AST_type::elementType OP_ARRAY =
+    AST_type::elementType::OP_ARRAY ;
+  constexpr AST_type::elementType OP_TIMES =
+    AST_type::elementType::OP_TIMES ;
+  constexpr AST_type::elementType OP_DIVIDE =
+    AST_type::elementType::OP_DIVIDE;
+  constexpr AST_type::elementType OP_MODULUS =
+    AST_type::elementType::OP_MODULUS;
+  constexpr AST_type::elementType OP_PLUS =
+    AST_type::elementType::OP_PLUS;
+  constexpr AST_type::elementType OP_MINUS =
+    AST_type::elementType::OP_MINUS;
+  constexpr AST_type::elementType OP_SHIFT_RIGHT =
+    AST_type::elementType::OP_SHIFT_RIGHT;
+  constexpr AST_type::elementType OP_SHIFT_LEFT =
+    AST_type::elementType::OP_SHIFT_LEFT;
+  constexpr AST_type::elementType OP_LT =
+    AST_type::elementType::OP_LT;
+  constexpr AST_type::elementType OP_GT =
+    AST_type::elementType::OP_GT;
+  constexpr AST_type::elementType OP_GE =
+    AST_type::elementType::OP_GE;
+  constexpr AST_type::elementType OP_LE =
+    AST_type::elementType::OP_LE;
+  constexpr AST_type::elementType OP_EQUAL =
+    AST_type::elementType::OP_EQUAL;
+  constexpr AST_type::elementType OP_NOT_EQUAL =
+    AST_type::elementType::OP_NOT_EQUAL;
+  constexpr AST_type::elementType OP_AND =
+    AST_type::elementType::OP_AND;
+  constexpr AST_type::elementType OP_EXOR =
+    AST_type::elementType::OP_EXOR;
+  constexpr AST_type::elementType OP_OR =
+    AST_type::elementType::OP_OR;
+  constexpr AST_type::elementType OP_LOGICAL_AND =
+    AST_type::elementType::OP_LOGICAL_AND;
+  constexpr AST_type::elementType OP_LOGICAL_OR =
+    AST_type::elementType::OP_LOGICAL_OR;
+  constexpr AST_type::elementType OP_TERNARY =
+    AST_type::elementType::OP_TERNARY;
+  constexpr AST_type::elementType OP_ASSIGN =
+    AST_type::elementType::OP_ASSIGN;
+  constexpr AST_type::elementType OP_TIMES_ASSIGN =
+    AST_type::elementType::OP_TIMES_ASSIGN;
+  constexpr AST_type::elementType OP_DIVIDE_ASSIGN =
+    AST_type::elementType::OP_DIVIDE_ASSIGN;
+  constexpr AST_type::elementType OP_MODULUS_ASSIGN =
+    AST_type::elementType::OP_MODULUS_ASSIGN;
+  constexpr AST_type::elementType OP_PLUS_ASSIGN =
+    AST_type::elementType::OP_PLUS_ASSIGN;
+  constexpr AST_type::elementType OP_MINUS_ASSIGN =
+    AST_type::elementType::OP_MINUS_ASSIGN;
+  constexpr AST_type::elementType OP_SHIFT_LEFT_ASSIGN =
+    AST_type::elementType::OP_SHIFT_LEFT_ASSIGN;
+  constexpr AST_type::elementType OP_SHIFT_RIGHT_ASSIGN =
+    AST_type::elementType::OP_SHIFT_RIGHT_ASSIGN;
+  constexpr AST_type::elementType OP_AND_ASSIGN =
+    AST_type::elementType::OP_AND_ASSIGN;
+  constexpr AST_type::elementType OP_OR_ASSIGN =
+    AST_type::elementType::OP_OR_ASSIGN;
+  constexpr AST_type::elementType OP_EXOR_ASSIGN =
+    AST_type::elementType::OP_EXOR_ASSIGN;
+  constexpr AST_type::elementType OP_COMMA =
+    AST_type::elementType::OP_COMMA;
+  constexpr AST_type::elementType OP_COLON =
+    AST_type::elementType::OP_COLON;
+  constexpr AST_type::elementType OP_SEMICOLON =
+    AST_type::elementType::OP_SEMICOLON;
+  constexpr AST_type::elementType OP_NIL =
+    AST_type::elementType::OP_NIL;
+  constexpr AST_type::elementType OP_INCREMENT =
+    AST_type::elementType::OP_INCREMENT;
+  constexpr AST_type::elementType OP_DECREMENT =
+    AST_type::elementType::OP_DECREMENT;
+  constexpr AST_type::elementType OP_POSTINCREMENT =
+    AST_type::elementType::OP_POSTINCREMENT;
+  constexpr AST_type::elementType OP_POSTDECREMENT =
+    AST_type::elementType::OP_POSTDECREMENT;
+  constexpr AST_type::elementType OP_COMMENT =
+    AST_type::elementType::OP_COMMENT;
+  constexpr AST_type::elementType OP_BRACEBLOCK =
+    AST_type::elementType::OP_BRACEBLOCK;
+  constexpr AST_type::elementType OP_NAME =
+    AST_type::elementType::OP_NAME;
+  constexpr AST_type::elementType OP_FUNC =
+    AST_type::elementType::OP_FUNC;
+  constexpr AST_type::elementType OP_NAME_BRACE =
+    AST_type::elementType::OP_NAME_BRACE;
+  constexpr AST_type::elementType OP_FUNC_BRACE =
+    AST_type::elementType::OP_FUNC_BRACE;
+  constexpr AST_type::elementType OP_TEMPLATE =
+    AST_type::elementType::OP_TEMPLATE;
+  constexpr AST_type::elementType OP_TEMPLATE_FUNC =
+    AST_type::elementType::OP_TEMPLATE_FUNC;
+  constexpr AST_type::elementType OP_STRING =
+    AST_type::elementType::OP_STRING;
+  constexpr AST_type::elementType OP_NUMBER =
+    AST_type::elementType::OP_NUMBER;
+  constexpr AST_type::elementType OP_ERROR =
+    AST_type::elementType::OP_ERROR;
+  constexpr AST_type::elementType OP_UNARY_PLUS =
+    AST_type::elementType::OP_UNARY_PLUS;
+  constexpr AST_type::elementType OP_UNARY_MINUS =
+    AST_type::elementType::OP_UNARY_MINUS;
+  constexpr AST_type::elementType OP_NOT =
+    AST_type::elementType::OP_NOT;
+  constexpr AST_type::elementType OP_TILDE =
+    AST_type::elementType::OP_TILDE;
+  constexpr AST_type::elementType OP_AMPERSAND =
+    AST_type::elementType::OP_AMPERSAND;
+  constexpr AST_type::elementType OP_DOLLAR =
+    AST_type::elementType::OP_DOLLAR;
+  constexpr AST_type::elementType OP_STAR =
+    AST_type::elementType::OP_STAR;
+  constexpr AST_type::elementType OP_CAST =
+    AST_type::elementType::OP_CAST;
+  constexpr AST_type::elementType OP_GROUP =
+    AST_type::elementType::OP_GROUP;
+  constexpr AST_type::elementType OP_GROUP_ERROR =
+    AST_type::elementType::OP_GROUP_ERROR;
+  constexpr AST_type::elementType OP_OPENPAREN =
+    AST_type::elementType::OP_OPENPAREN;
+  constexpr AST_type::elementType OP_CLOSEPAREN =
+    AST_type::elementType::OP_CLOSEPAREN;
+  constexpr AST_type::elementType OP_OPENBRACKET =
+    AST_type::elementType::OP_OPENBRACKET;
+  constexpr AST_type::elementType OP_CLOSEBRACKET =
+    AST_type::elementType::OP_CLOSEBRACKET;
+  constexpr AST_type::elementType OP_OPENBRACE =
+    AST_type::elementType::OP_OPENBRACE;
+  constexpr AST_type::elementType OP_CLOSEBRACE =
+    AST_type::elementType::OP_CLOSEBRACE;
+  constexpr AST_type::elementType OP_LOCI_DIRECTIVE =
+    AST_type::elementType::OP_LOCI_DIRECTIVE;
+  constexpr AST_type::elementType OP_LOCI_VARIABLE =
+    AST_type::elementType::OP_LOCI_VARIABLE;
+  constexpr AST_type::elementType OP_LOCI_CONTAINER =
+    AST_type::elementType::OP_LOCI_CONTAINER;
+  constexpr AST_type::elementType OP_TERM =
+    AST_type::elementType::OP_TERM;
+  constexpr AST_type::elementType OP_SPECIAL =
+    AST_type::elementType::OP_SPECIAL;
+  constexpr AST_type::elementType TK_BRACEBLOCK =
+    AST_type::elementType::TK_BRACEBLOCK;
+  constexpr AST_type::elementType TK_SCOPE =
+    AST_type::elementType::TK_SCOPE;
+  constexpr AST_type::elementType TK_AT =
+    AST_type::elementType::TK_AT;
+  constexpr AST_type::elementType TK_ARROW =
+    AST_type::elementType::TK_ARROW;
+  constexpr AST_type::elementType TK_TIMES =
+    AST_type::elementType::TK_TIMES;
+  constexpr AST_type::elementType TK_DIVIDE =
+    AST_type::elementType::TK_DIVIDE;
+  constexpr AST_type::elementType TK_MODULUS =
+    AST_type::elementType::TK_MODULUS;
+  constexpr AST_type::elementType TK_PLUS =
+    AST_type::elementType::TK_PLUS;
+  constexpr AST_type::elementType TK_MINUS =
+    AST_type::elementType::TK_MINUS;
+  constexpr AST_type::elementType TK_SHIFT_RIGHT =
+    AST_type::elementType::TK_SHIFT_RIGHT;
+  constexpr AST_type::elementType TK_SHIFT_LEFT =
+    AST_type::elementType::TK_SHIFT_LEFT;
+  constexpr AST_type::elementType TK_LT =
+    AST_type::elementType::TK_LT;
+  constexpr AST_type::elementType TK_GT =
+    AST_type::elementType::TK_GT;
+  constexpr AST_type::elementType TK_GE =
+    AST_type::elementType::TK_GE;
+  constexpr AST_type::elementType TK_LE =
+    AST_type::elementType::TK_LE;
+  constexpr AST_type::elementType TK_EQUAL =
+    AST_type::elementType::TK_EQUAL;
+  constexpr AST_type::elementType TK_NOT_EQUAL =
+    AST_type::elementType::TK_NOT_EQUAL;
+  constexpr AST_type::elementType TK_AND =
+    AST_type::elementType::TK_AND;
+  constexpr AST_type::elementType TK_EXOR =
+    AST_type::elementType::TK_EXOR;
+  constexpr AST_type::elementType TK_OR =
+    AST_type::elementType::TK_OR;
+  constexpr AST_type::elementType TK_LOGICAL_AND =
+    AST_type::elementType::TK_LOGICAL_AND;
+  constexpr AST_type::elementType TK_LOGICAL_OR =
+    AST_type::elementType::TK_LOGICAL_OR;
+  constexpr AST_type::elementType TK_ASSIGN =
+    AST_type::elementType::TK_ASSIGN;
+  constexpr AST_type::elementType TK_TIMES_ASSIGN =
+    AST_type::elementType::TK_TIMES_ASSIGN;
+  constexpr AST_type::elementType TK_DIVIDE_ASSIGN =
+    AST_type::elementType::TK_DIVIDE_ASSIGN;
+  constexpr AST_type::elementType TK_MODULUS_ASSIGN =
+    AST_type::elementType::TK_MODULUS_ASSIGN;
+  constexpr AST_type::elementType TK_PLUS_ASSIGN =
+    AST_type::elementType::TK_PLUS_ASSIGN;
+  constexpr AST_type::elementType TK_MINUS_ASSIGN =
+    AST_type::elementType::TK_MINUS_ASSIGN;
+  constexpr AST_type::elementType TK_SHIFT_LEFT_ASSIGN =
+    AST_type::elementType::TK_SHIFT_LEFT_ASSIGN;
+  constexpr AST_type::elementType TK_SHIFT_RIGHT_ASSIGN =
+    AST_type::elementType::TK_SHIFT_RIGHT_ASSIGN;
+  constexpr AST_type::elementType TK_AND_ASSIGN =
+    AST_type::elementType::TK_AND_ASSIGN;
+  constexpr AST_type::elementType TK_OR_ASSIGN =
+    AST_type::elementType::TK_OR_ASSIGN;
+  constexpr AST_type::elementType TK_EXOR_ASSIGN =
+    AST_type::elementType::TK_EXOR_ASSIGN;
+  constexpr AST_type::elementType TK_COMMA =
+    AST_type::elementType::TK_COMMA;
+  constexpr AST_type::elementType TK_DOT =
+    AST_type::elementType::TK_DOT;
+  constexpr AST_type::elementType TK_COLON =
+    AST_type::elementType::TK_COLON;
+  constexpr AST_type::elementType TK_SEMICOLON =
+    AST_type::elementType::TK_SEMICOLON;
+  constexpr AST_type::elementType TK_NIL =
+    AST_type::elementType::TK_NIL;
 
-  constexpr AST_type::elementType TK_ALIGNAS = AST_type::elementType::TK_ALIGNAS;
-  constexpr AST_type::elementType TK_ALIGNOF = AST_type::elementType::TK_ALIGNOF;
-  constexpr AST_type::elementType TK_ASM = AST_type::elementType::TK_ASM; 
-  constexpr AST_type::elementType TK_BOOL = AST_type::elementType::TK_BOOL;
-  constexpr AST_type::elementType TK_FALSE = AST_type::elementType::TK_FALSE;
-  constexpr AST_type::elementType TK_TRUE = AST_type::elementType::TK_TRUE;
-  constexpr AST_type::elementType TK_CHAR = AST_type::elementType::TK_CHAR;
-  constexpr AST_type::elementType TK_INT = AST_type::elementType::TK_INT;
-  constexpr AST_type::elementType TK_LONG = AST_type::elementType::TK_LONG;
-  constexpr AST_type::elementType TK_SHORT = AST_type::elementType::TK_SHORT;
-  constexpr AST_type::elementType TK_SIGNED = AST_type::elementType::TK_SIGNED;
-  constexpr AST_type::elementType TK_UNSIGNED = AST_type::elementType::TK_UNSIGNED;
-  constexpr AST_type::elementType TK_DOUBLE = AST_type::elementType::TK_DOUBLE;
-  constexpr AST_type::elementType TK_FLOAT = AST_type::elementType::TK_FLOAT;
-  constexpr AST_type::elementType TK_ENUM = AST_type::elementType::TK_ENUM;
-  constexpr AST_type::elementType TK_MUTABLE = AST_type::elementType::TK_MUTABLE;
-  constexpr AST_type::elementType TK_CONST = AST_type::elementType::TK_CONST;
-  constexpr AST_type::elementType TK_STATIC = AST_type::elementType::TK_STATIC;
-  constexpr AST_type::elementType TK_VOLATILE = AST_type::elementType::TK_VOLATILE;
-  constexpr AST_type::elementType TK_AUTO = AST_type::elementType::TK_AUTO;
-  constexpr AST_type::elementType TK_REGISTER = AST_type::elementType::TK_REGISTER;
-  constexpr AST_type::elementType TK_EXPORT = AST_type::elementType::TK_EXPORT;
-  constexpr AST_type::elementType TK_EXTERN = AST_type::elementType::TK_EXTERN;
-  constexpr AST_type::elementType TK_INLINE = AST_type::elementType::TK_INLINE;
-  constexpr AST_type::elementType TK_NAMESPACE = AST_type::elementType::TK_NAMESPACE;
-  constexpr AST_type::elementType TK_USING = AST_type::elementType::TK_USING;
-  constexpr AST_type::elementType TK_EXPLICIT = AST_type::elementType::TK_EXPLICIT;
-  constexpr AST_type::elementType TK_DYNAMIC_CAST = AST_type::elementType::TK_DYNAMIC_CAST;
-  constexpr AST_type::elementType TK_STATIC_CAST = AST_type::elementType::TK_STATIC_CAST;
-  constexpr AST_type::elementType TK_REINTERPRET_CAST = AST_type::elementType::TK_REINTERPRET_CAST;
-  constexpr AST_type::elementType TK_OPERATOR = AST_type::elementType::TK_OPERATOR;
-  constexpr AST_type::elementType TK_PROTECTED = AST_type::elementType::TK_PROTECTED;
-  constexpr AST_type::elementType TK_NOEXCEPT = AST_type::elementType::TK_NOEXCEPT;
-  constexpr AST_type::elementType TK_NULLPTR = AST_type::elementType::TK_NULLPTR;
-  constexpr AST_type::elementType TK_RETURN = AST_type::elementType::TK_RETURN;
-  constexpr AST_type::elementType TK_SIZEOF = AST_type::elementType::TK_SIZEOF;
-  constexpr AST_type::elementType TK_THIS = AST_type::elementType::TK_THIS;
-  constexpr AST_type::elementType TK_TYPEID = AST_type::elementType::TK_TYPEID;
-  constexpr AST_type::elementType TK_SWITCH = AST_type::elementType::TK_SWITCH;
-  constexpr AST_type::elementType TK_CASE = AST_type::elementType::TK_CASE;
-  constexpr AST_type::elementType TK_BREAK = AST_type::elementType::TK_BREAK;
-  constexpr AST_type::elementType TK_DEFAULT = AST_type::elementType::TK_DEFAULT;
-  constexpr AST_type::elementType TK_FOR = AST_type::elementType::TK_FOR;
-  constexpr AST_type::elementType TK_DO = AST_type::elementType::TK_DO;
-  constexpr AST_type::elementType TK_WHILE = AST_type::elementType::TK_WHILE;
-  constexpr AST_type::elementType TK_CONTINUE = AST_type::elementType::TK_CONTINUE;
-  constexpr AST_type::elementType TK_CLASS = AST_type::elementType::TK_CLASS;
-  constexpr AST_type::elementType TK_STRUCT = AST_type::elementType::TK_STRUCT;
-  constexpr AST_type::elementType TK_PUBLIC = AST_type::elementType::TK_PUBLIC;
-  constexpr AST_type::elementType TK_PRIVATE = AST_type::elementType::TK_PRIVATE;
-  constexpr AST_type::elementType TK_FRIEND = AST_type::elementType::TK_FRIEND;
-  constexpr AST_type::elementType TK_UNION = AST_type::elementType::TK_UNION;
-  constexpr AST_type::elementType TK_TYPENAME = AST_type::elementType::TK_TYPENAME;
-  constexpr AST_type::elementType TK_TEMPLATE = AST_type::elementType::TK_TEMPLATE;
-  constexpr AST_type::elementType TK_TYPEDEF = AST_type::elementType::TK_TYPEDEF;
-  constexpr AST_type::elementType TK_VIRTUAL = AST_type::elementType::TK_VIRTUAL;
-  constexpr AST_type::elementType TK_VOID = AST_type::elementType::TK_VOID;
-  constexpr AST_type::elementType TK_TRY = AST_type::elementType::TK_TRY;
-  constexpr AST_type::elementType TK_CATCH = AST_type::elementType::TK_CATCH;
-  constexpr AST_type::elementType TK_THROW = AST_type::elementType::TK_THROW;
-  constexpr AST_type::elementType TK_IF = AST_type::elementType::TK_IF;
-  constexpr AST_type::elementType TK_ELSE = AST_type::elementType::TK_ELSE;
-  constexpr AST_type::elementType TK_GOTO = AST_type::elementType::TK_GOTO;
-  constexpr AST_type::elementType TK_NEW = AST_type::elementType::TK_NEW;
-  constexpr AST_type::elementType TK_DELETE = AST_type::elementType::TK_DELETE;
-  constexpr AST_type::elementType ND_SYNTAXERR = AST_type::elementType::ND_SYNTAXERR;
-  constexpr AST_type::elementType ND_CTRL_IF = AST_type::elementType::ND_CTRL_IF;
-  constexpr AST_type::elementType ND_CTRL_FOR = AST_type::elementType::ND_CTRL_FOR;
-  constexpr AST_type::elementType ND_CTRL_WHILE = AST_type::elementType::ND_CTRL_WHILE;
-  constexpr AST_type::elementType ND_CTRL_DO = AST_type::elementType::ND_CTRL_DO;
-  constexpr AST_type::elementType ND_CTRL_SWITCH = AST_type::elementType::ND_CTRL_SWITCH;
-  constexpr AST_type::elementType ND_SIMPLE_STATEMENT = AST_type::elementType::ND_SIMPLE_STATEMENT;
-  constexpr AST_type::elementType ND_BLOCK = AST_type::elementType::ND_BLOCK;
-  constexpr AST_type::elementType ND_DECL = AST_type::elementType::ND_DECL;
-  constexpr AST_type::elementType ND_TYPE_SPEC = AST_type::elementType::ND_TYPE_SPEC;
-  constexpr AST_type::elementType ND_TERMINAL = AST_type::elementType::ND_TERMINAL;
-  constexpr AST_type::elementType TK_SENTINEL = AST_type::elementType::TK_SENTINEL;
+  constexpr AST_type::elementType TK_INCREMENT =
+    AST_type::elementType::TK_INCREMENT;
+  constexpr AST_type::elementType TK_DECREMENT =
+    AST_type::elementType::TK_DECREMENT;
+  constexpr AST_type::elementType TK_COMMENT =
+    AST_type::elementType::TK_COMMENT;
+  constexpr AST_type::elementType TK_MACRO =
+    AST_type::elementType::TK_MACRO;
+  constexpr AST_type::elementType TK_NAME =
+    AST_type::elementType::TK_NAME;
+  constexpr AST_type::elementType TK_STRING =
+    AST_type::elementType::TK_STRING;
+  constexpr AST_type::elementType TK_NUMBER =
+    AST_type::elementType::TK_NUMBER;
+  constexpr AST_type::elementType TK_ERROR =
+    AST_type::elementType::TK_ERROR;
+  constexpr AST_type::elementType TK_UNARY_PLUS =
+    AST_type::elementType::TK_UNARY_PLUS;
+  constexpr AST_type::elementType TK_UNARY_MINUS =
+    AST_type::elementType::TK_UNARY_MINUS;
+  constexpr AST_type::elementType TK_NOT =
+    AST_type::elementType::TK_NOT;
+  constexpr AST_type::elementType TK_TILDE =
+    AST_type::elementType::TK_TILDE;
+  constexpr AST_type::elementType TK_QUESTION =
+    AST_type::elementType::TK_QUESTION;
+  constexpr AST_type::elementType TK_AMPERSAND =
+    AST_type::elementType::TK_AMPERSAND;
+  constexpr AST_type::elementType TK_STAR =
+    AST_type::elementType::TK_STAR;
+  constexpr AST_type::elementType TK_OPENPAREN =
+    AST_type::elementType::TK_OPENPAREN;
+  constexpr AST_type::elementType TK_CLOSEPAREN =
+    AST_type::elementType::TK_CLOSEPAREN;
+  constexpr AST_type::elementType TK_OPENBRACKET =
+    AST_type::elementType::TK_OPENBRACKET;
+  constexpr AST_type::elementType TK_CLOSEBRACKET =
+    AST_type::elementType::TK_CLOSEBRACKET;
+  constexpr AST_type::elementType TK_OPENBRACE =
+    AST_type::elementType::TK_OPENBRACE;
+  constexpr AST_type::elementType TK_CLOSEBRACE =
+    AST_type::elementType::TK_CLOSEBRACE;
+  constexpr AST_type::elementType TK_OPENTEMPLATE =
+    AST_type::elementType::TK_OPENTEMPLATE;
+  constexpr AST_type::elementType TK_CLOSETEMPLATE =
+    AST_type::elementType::TK_CLOSETEMPLATE;
+  constexpr AST_type::elementType TK_LOCI_DIRECTIVE =
+    AST_type::elementType::TK_LOCI_DIRECTIVE;
+  constexpr AST_type::elementType TK_LOCI_VARIABLE =
+    AST_type::elementType::TK_LOCI_VARIABLE;constexpr AST_type::elementType TK_LOCI_CONTAINER =
+                                              AST_type::elementType::TK_LOCI_CONTAINER;
+
+  constexpr AST_type::elementType TK_ALIGNAS =
+    AST_type::elementType::TK_ALIGNAS;
+  constexpr AST_type::elementType TK_ALIGNOF =
+    AST_type::elementType::TK_ALIGNOF;
+  constexpr AST_type::elementType TK_ASM =
+    AST_type::elementType::TK_ASM;
+  constexpr AST_type::elementType TK_BOOL =
+    AST_type::elementType::TK_BOOL;
+  constexpr AST_type::elementType TK_FALSE =
+    AST_type::elementType::TK_FALSE;
+  constexpr AST_type::elementType TK_TRUE =
+    AST_type::elementType::TK_TRUE;
+  constexpr AST_type::elementType TK_CHAR =
+    AST_type::elementType::TK_CHAR;
+  constexpr AST_type::elementType TK_INT =
+    AST_type::elementType::TK_INT;
+  constexpr AST_type::elementType TK_LONG =
+    AST_type::elementType::TK_LONG;
+  constexpr AST_type::elementType TK_SHORT =
+    AST_type::elementType::TK_SHORT;
+  constexpr AST_type::elementType TK_SIGNED =
+    AST_type::elementType::TK_SIGNED;
+  constexpr AST_type::elementType TK_UNSIGNED =
+    AST_type::elementType::TK_UNSIGNED;
+  constexpr AST_type::elementType TK_DOUBLE =
+    AST_type::elementType::TK_DOUBLE;
+  constexpr AST_type::elementType TK_FLOAT =
+    AST_type::elementType::TK_FLOAT;
+  constexpr AST_type::elementType TK_ENUM =
+    AST_type::elementType::TK_ENUM;
+  constexpr AST_type::elementType TK_MUTABLE =
+    AST_type::elementType::TK_MUTABLE;
+  constexpr AST_type::elementType TK_CONST =
+    AST_type::elementType::TK_CONST;
+  constexpr AST_type::elementType TK_STATIC =
+    AST_type::elementType::TK_STATIC;
+  constexpr AST_type::elementType TK_VOLATILE =
+    AST_type::elementType::TK_VOLATILE;
+  constexpr AST_type::elementType TK_AUTO =
+    AST_type::elementType::TK_AUTO;
+  constexpr AST_type::elementType TK_REGISTER =
+    AST_type::elementType::TK_REGISTER;
+  constexpr AST_type::elementType TK_EXPORT =
+    AST_type::elementType::TK_EXPORT;
+  constexpr AST_type::elementType TK_EXTERN =
+    AST_type::elementType::TK_EXTERN;
+  constexpr AST_type::elementType TK_INLINE =
+    AST_type::elementType::TK_INLINE;
+  constexpr AST_type::elementType TK_NAMESPACE =
+    AST_type::elementType::TK_NAMESPACE;
+  constexpr AST_type::elementType TK_USING =
+    AST_type::elementType::TK_USING;
+  constexpr AST_type::elementType TK_EXPLICIT =
+    AST_type::elementType::TK_EXPLICIT;
+  constexpr AST_type::elementType TK_DYNAMIC_CAST =
+    AST_type::elementType::TK_DYNAMIC_CAST;
+  constexpr AST_type::elementType TK_STATIC_CAST =
+    AST_type::elementType::TK_STATIC_CAST;
+  constexpr AST_type::elementType TK_REINTERPRET_CAST =
+    AST_type::elementType::TK_REINTERPRET_CAST;
+  constexpr AST_type::elementType TK_OPERATOR =
+    AST_type::elementType::TK_OPERATOR;
+  constexpr AST_type::elementType TK_PROTECTED =
+    AST_type::elementType::TK_PROTECTED;
+  constexpr AST_type::elementType TK_NOEXCEPT =
+    AST_type::elementType::TK_NOEXCEPT;
+  constexpr AST_type::elementType TK_NULLPTR =
+    AST_type::elementType::TK_NULLPTR;
+  constexpr AST_type::elementType TK_RETURN =
+    AST_type::elementType::TK_RETURN;
+  constexpr AST_type::elementType TK_SIZEOF =
+    AST_type::elementType::TK_SIZEOF;
+  constexpr AST_type::elementType TK_THIS =
+    AST_type::elementType::TK_THIS;
+  constexpr AST_type::elementType TK_TYPEID =
+    AST_type::elementType::TK_TYPEID;
+  constexpr AST_type::elementType TK_SWITCH =
+    AST_type::elementType::TK_SWITCH;
+  constexpr AST_type::elementType TK_CASE =
+    AST_type::elementType::TK_CASE;
+  constexpr AST_type::elementType TK_BREAK =
+    AST_type::elementType::TK_BREAK;
+  constexpr AST_type::elementType TK_DEFAULT =
+    AST_type::elementType::TK_DEFAULT;
+  constexpr AST_type::elementType TK_FOR =
+    AST_type::elementType::TK_FOR;
+  constexpr AST_type::elementType TK_DO =
+    AST_type::elementType::TK_DO;
+  constexpr AST_type::elementType TK_WHILE =
+    AST_type::elementType::TK_WHILE;
+  constexpr AST_type::elementType TK_CONTINUE =
+    AST_type::elementType::TK_CONTINUE;
+  constexpr AST_type::elementType TK_CLASS =
+    AST_type::elementType::TK_CLASS;
+  constexpr AST_type::elementType TK_STRUCT =
+    AST_type::elementType::TK_STRUCT;
+  constexpr AST_type::elementType TK_PUBLIC =
+    AST_type::elementType::TK_PUBLIC;
+  constexpr AST_type::elementType TK_PRIVATE =
+    AST_type::elementType::TK_PRIVATE;
+  constexpr AST_type::elementType TK_FRIEND =
+    AST_type::elementType::TK_FRIEND;
+  constexpr AST_type::elementType TK_UNION =
+    AST_type::elementType::TK_UNION;
+  constexpr AST_type::elementType TK_TYPENAME =
+    AST_type::elementType::TK_TYPENAME;
+  constexpr AST_type::elementType TK_TEMPLATE =
+    AST_type::elementType::TK_TEMPLATE;
+  constexpr AST_type::elementType TK_TYPEDEF =
+    AST_type::elementType::TK_TYPEDEF;
+  constexpr AST_type::elementType TK_VIRTUAL =
+    AST_type::elementType::TK_VIRTUAL;
+  constexpr AST_type::elementType TK_VOID =
+    AST_type::elementType::TK_VOID;
+  constexpr AST_type::elementType TK_TRY =
+    AST_type::elementType::TK_TRY;
+  constexpr AST_type::elementType TK_CATCH =
+    AST_type::elementType::TK_CATCH;
+  constexpr AST_type::elementType TK_THROW =
+    AST_type::elementType::TK_THROW;
+  constexpr AST_type::elementType TK_IF =
+    AST_type::elementType::TK_IF;
+  constexpr AST_type::elementType TK_ELSE =
+    AST_type::elementType::TK_ELSE;
+  constexpr AST_type::elementType TK_GOTO =
+    AST_type::elementType::TK_GOTO;
+  constexpr AST_type::elementType TK_NEW =
+    AST_type::elementType::TK_NEW;
+  constexpr AST_type::elementType TK_DELETE =
+    AST_type::elementType::TK_DELETE;
+  constexpr AST_type::elementType ND_SYNTAXERR =
+    AST_type::elementType::ND_SYNTAXERR;
+  constexpr AST_type::elementType ND_CTRL_IF =
+    AST_type::elementType::ND_CTRL_IF;
+  constexpr AST_type::elementType ND_CTRL_FOR =
+    AST_type::elementType::ND_CTRL_FOR;
+  constexpr AST_type::elementType ND_CTRL_WHILE =
+    AST_type::elementType::ND_CTRL_WHILE;
+  constexpr AST_type::elementType ND_CTRL_DO =
+    AST_type::elementType::ND_CTRL_DO;
+  constexpr AST_type::elementType ND_CTRL_SWITCH =
+    AST_type::elementType::ND_CTRL_SWITCH;
+  constexpr AST_type::elementType ND_SIMPLE_STATEMENT =
+    AST_type::elementType::ND_SIMPLE_STATEMENT;
+  constexpr AST_type::elementType ND_BLOCK =
+    AST_type::elementType::ND_BLOCK;
+  constexpr AST_type::elementType ND_DECL =
+    AST_type::elementType::ND_DECL;
+  constexpr AST_type::elementType ND_TYPE_SPEC =
+    AST_type::elementType::ND_TYPE_SPEC;
+  constexpr AST_type::elementType ND_TERMINAL =
+    AST_type::elementType::ND_TERMINAL;
+  constexpr AST_type::elementType TK_SENTINEL =
+    AST_type::elementType::TK_SENTINEL;
 }
 
 extern std::string OPtoString(AST_type::elementType val) ;
@@ -559,7 +781,7 @@ public:
   AST_exprOper() {nodeType = AST_type::elementType::OP_ERROR; }
 } ;
 
-/// Control statement (if else 
+/// Control statement (if else
 class AST_controlStatement: public AST_type {
 public:
   ASTP controlType ;
@@ -621,7 +843,7 @@ public:
   int lineno ;
   map<int,std::string> id2rename ;
   bool prettyPrint ;
-  AST_simplePrint(ostream &s, int line=-1,bool pp=true): out(s),lineno(line),prettyPrint(pp) {} 
+  AST_simplePrint(ostream &s, int line=-1,bool pp=true): out(s),lineno(line),prettyPrint(pp) {}
   virtual void visit(AST_exprOper &)  ;
   virtual void visit(AST_Token &) ;
 } ;
@@ -636,7 +858,7 @@ public:
   virtual void visit(AST_exprOper &) ;
   virtual void visit(AST_Token &) ;
 } ;
-  
+
 
 /// parse an identifier
 extern AST_type::ASTP parseIdentifier(std::istream &is, int &linecount,
@@ -645,18 +867,22 @@ extern AST_type::ASTP parseIdentifier(std::istream &is, int &linecount,
 /// Parse a general expression
 extern AST_type::ASTP parseExpression(std::istream &is, int &linecount,
 				      const string &fileName,
-				      varmap &typemap) ;
+				      varmap &typemap,
+                                      AST_type::operatorPrecedence prec=
+                                      AST_type::operatorPrecedence::PREC_NIL) ;
 /// Parse terms excluding operator
 extern AST_type::ASTP parseExpressionPartial(std::istream &is, int &linecount,
 					     const string &fileName,
-					     varmap &typemap) ;
+					     varmap &typemap,
+                                             AST_type::operatorPrecedence prec=
+                                             AST_type::operatorPrecedence::PREC_NIL) ;
 /// Parse a statement after the first identifier is parsed
 extern AST_type::ASTP parseExpressionOperator(AST_type::ASTP expr,
                                               std::istream &is, int &linecount,
                                               const string &fileName,
                                               varmap &typemap,
-                                              AST_type::elementType
-                                              term=AST_type::elementType::TK_SENTINEL) ;
+                                              AST_type::operatorPrecedence
+                                              prec=AST_type::operatorPrecedence::PREC_NIL) ;
 /// Parse operator token, convert from TK_* node type to OP_* nodetype
 extern AST_type::ASTP parseOperator(std::istream &is, int &linecount) ;
 /// Apply postfix operator to previous expression passed in expr
@@ -664,6 +890,7 @@ extern AST_type::ASTP applyPostFixOperator(AST_type::ASTP expr,
                                            std::istream &is, int &linecount,
                                            string fileName,
                                            varmap &typemap) ;
+
 /// Parse a named object using the scope operator
 extern AST_type::ASTP parseScopedObject(std::istream &is, int &linecount,
                                         const string &fileName,

--- a/src/lpp/parseAST.h
+++ b/src/lpp/parseAST.h
@@ -188,7 +188,7 @@ public:
     // Unary operations
     OP_UNARY_PLUS, OP_UNARY_MINUS, OP_NOT, OP_TILDE,
     OP_AMPERSAND, OP_DOLLAR, OP_STAR,
-    OP_CAST,
+    OP_CAST,OP_TEMPLATE_CAST,
     OP_GROUP,OP_GROUP_ERROR,
     OP_OPENPAREN,OP_CLOSEPAREN,OP_OPENBRACKET,OP_CLOSEBRACKET,
     OP_OPENBRACE,OP_CLOSEBRACE,
@@ -241,7 +241,7 @@ public:
     TK_MUTABLE,TK_CONST,TK_STATIC,TK_VOLATILE,TK_AUTO,
     TK_REGISTER,TK_EXPORT,TK_EXTERN,TK_INLINE,TK_NAMESPACE,
     TK_USING,TK_EXPLICIT,TK_DYNAMIC_CAST,TK_STATIC_CAST,
-    TK_REINTERPRET_CAST,
+    TK_REINTERPRET_CAST,TK_CONST_CAST,
     TK_OPERATOR,TK_PROTECTED,TK_NOEXCEPT,TK_NULLPTR,
     TK_RETURN,TK_SIZEOF,TK_THIS,TK_TYPEID,
     TK_SWITCH,TK_CASE,TK_BREAK,TK_DEFAULT,
@@ -390,6 +390,8 @@ namespace nodeTypes {
     AST_type::elementType::OP_STAR;
   constexpr AST_type::elementType OP_CAST =
     AST_type::elementType::OP_CAST;
+  constexpr AST_type::elementType OP_TEMPLATE_CAST =
+    AST_type::elementType::OP_TEMPLATE_CAST;
   constexpr AST_type::elementType OP_GROUP =
     AST_type::elementType::OP_GROUP;
   constexpr AST_type::elementType OP_GROUP_ERROR =
@@ -599,6 +601,8 @@ namespace nodeTypes {
     AST_type::elementType::TK_USING;
   constexpr AST_type::elementType TK_EXPLICIT =
     AST_type::elementType::TK_EXPLICIT;
+  constexpr AST_type::elementType TK_CONST_CAST =
+    AST_type::elementType::TK_CONST_CAST;
   constexpr AST_type::elementType TK_DYNAMIC_CAST =
     AST_type::elementType::TK_DYNAMIC_CAST;
   constexpr AST_type::elementType TK_STATIC_CAST =

--- a/src/lpp/parseLEX.cc
+++ b/src/lpp/parseLEX.cc
@@ -183,7 +183,6 @@ keywords keywordDictionary[] = {
   {"char", TK_CHAR},
   {"class", TK_CLASS},
   {"const", TK_CONST},
-  {"const_cast", TK_CONST_CAST},
   {"continue", TK_CONTINUE},
   {"default", TK_DEFAULT},
   {"delete", TK_DELETE},
@@ -626,18 +625,43 @@ CPTR<AST_Token> getTokenInternal(std::istream &is, int &linecount) {
 #endif
     return AST_data ;
   case '"':
-    while(is.peek() != '"' && !is.eof() && !is.fail()) {
+    {
+      while(is.peek() != '"' && !is.eof() && !is.fail()) {
+        AST_data->text += is.get() ;
+      }
+      if(is.peek() != '"') {
+        break ;
+      }
       AST_data->text += is.get() ;
-    }
-    if(is.peek() == '"') {
-      AST_data->text += is.get() ;
+      // C++: concatenate adjacent string literals ("a" "b" is one literal "ab")
+      for(;;) {
+        killsp(is, linecount) ;
+        if(is.peek() != '"' || is.eof() || is.fail()) {
+          break ;
+        }
+        if(AST_data->text.empty() || AST_data->text.back() != '"') {
+          break ;
+        }
+        AST_data->text.pop_back() ;
+        is.get() ; // opening '"' of the next literal
+        while(is.peek() != '"' && !is.eof() && !is.fail()) {
+          AST_data->text += is.get() ;
+        }
+        if(is.peek() != '"') {
+          AST_data->nodeType = TK_ERROR ;
+#ifdef VERBOSE
+          cerr << "get token ERR(unclosed string in concatenation)" << endl ;
+#endif
+          return AST_data ;
+        }
+        AST_data->text += is.get() ;
+      }
       AST_data->nodeType = TK_STRING ;
 #ifdef VERBOSE
       cerr << "get token STRING("<< AST_data->text<< ")" << endl ;
 #endif
       return AST_data ;
     }
-    break ;
   case '\'':
     while(is.peek() != '\'' && !is.eof() && !is.fail()) {
       AST_data->text += is.get() ;
@@ -896,10 +920,10 @@ CPTR<AST_Token> getToken(std::istream &is, int &linecount) {
 #endif
           toklist[LT_LIST.back()]->nodeType =
             TK_OPENTEMPLATE ;
-          toklist[LT_LIST.back()]->text = "<" ; ;
+          toklist[LT_LIST.back()]->text = "<<<" ; ;
           toklist.back()->nodeType =
             TK_CLOSETEMPLATE ;
-          toklist.back()->text = ">" ;
+          toklist.back()->text = ">>>" ;
           LT_LIST.pop_back() ;
           LT_DEPTH.pop_back() ;
           if(LT_LIST.size() == 0) {
@@ -1087,8 +1111,6 @@ string OPtoName(AST_type::elementType val) {
     return string("OP_STAR") ;
   case OP_CAST:
     return string("OP_CAST") ;
-  case OP_TEMPLATE_CAST:
-    return string("OP_TEMPLATE_CAST") ;
   case OP_GROUP:
     return string("OP_GROUP") ;
   case OP_GROUP_ERROR:
@@ -1347,9 +1369,6 @@ string OPtoName(AST_type::elementType val) {
 
   case TK_STATIC_CAST:
     return string("TK_STATIC_CAST") ;
-
-  case TK_CONST_CAST:
-    return string("TK_CONST_CAST") ;
 
   case TK_REINTERPRET_CAST:
     return string("TK_REINTERPRET_CAST") ;

--- a/src/lpp/parseLEX.cc
+++ b/src/lpp/parseLEX.cc
@@ -920,10 +920,10 @@ CPTR<AST_Token> getToken(std::istream &is, int &linecount) {
 #endif
           toklist[LT_LIST.back()]->nodeType =
             TK_OPENTEMPLATE ;
-          toklist[LT_LIST.back()]->text = "<<<" ; ;
+          toklist[LT_LIST.back()]->text = "<" ; ;
           toklist.back()->nodeType =
             TK_CLOSETEMPLATE ;
-          toklist.back()->text = ">>>" ;
+          toklist.back()->text = ">" ;
           LT_LIST.pop_back() ;
           LT_DEPTH.pop_back() ;
           if(LT_LIST.size() == 0) {

--- a/src/lpp/parseLEX.cc
+++ b/src/lpp/parseLEX.cc
@@ -183,6 +183,7 @@ keywords keywordDictionary[] = {
   {"char", TK_CHAR},
   {"class", TK_CLASS},
   {"const", TK_CONST},
+  {"const_cast", TK_CONST_CAST},
   {"continue", TK_CONTINUE},
   {"default", TK_DEFAULT},
   {"delete", TK_DELETE},
@@ -895,10 +896,10 @@ CPTR<AST_Token> getToken(std::istream &is, int &linecount) {
 #endif
           toklist[LT_LIST.back()]->nodeType =
             TK_OPENTEMPLATE ;
-          toklist[LT_LIST.back()]->text = "<<<" ; ;
+          toklist[LT_LIST.back()]->text = "<" ; ;
           toklist.back()->nodeType =
             TK_CLOSETEMPLATE ;
-          toklist.back()->text = ">>>" ;
+          toklist.back()->text = ">" ;
           LT_LIST.pop_back() ;
           LT_DEPTH.pop_back() ;
           if(LT_LIST.size() == 0) {
@@ -1086,6 +1087,8 @@ string OPtoName(AST_type::elementType val) {
     return string("OP_STAR") ;
   case OP_CAST:
     return string("OP_CAST") ;
+  case OP_TEMPLATE_CAST:
+    return string("OP_TEMPLATE_CAST") ;
   case OP_GROUP:
     return string("OP_GROUP") ;
   case OP_GROUP_ERROR:
@@ -1344,6 +1347,9 @@ string OPtoName(AST_type::elementType val) {
 
   case TK_STATIC_CAST:
     return string("TK_STATIC_CAST") ;
+
+  case TK_CONST_CAST:
+    return string("TK_CONST_CAST") ;
 
   case TK_REINTERPRET_CAST:
     return string("TK_REINTERPRET_CAST") ;

--- a/src/lpp/parseLEX.cc
+++ b/src/lpp/parseLEX.cc
@@ -778,7 +778,16 @@ CPTR<AST_Token> getTokenInternal(std::istream &is, int &linecount) {
 	      count-- ;
 	    AST_data->text += is.get() ;
 	  }
-	} else
+	} else if(is.peek() == ':') {
+          is.get() ;
+          if(is.peek() == ':') {
+            AST_data->text += ':' ;
+            AST_data->text += is.get() ;
+          } else {
+            is.putback(':') ;
+            break ;
+          }
+        } else
 	  AST_data->text += is.get() ;
       }
 


### PR DESCRIPTION
This fixes the last few parsing issues that are required to compile CHEM with the latest lpp parsing features.  This gives us a robust AST for GPU development work. 