### PR TITLE
git submodule initial clone status

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,24 +2,31 @@
 	path = ext/hdf5
 	url = https://github.com/HDFGroup/hdf5.git
     branch = hdf5-1.14.5
+    shallow = true
 [submodule "ext/GKlib"]
 	path = ext/GKlib
 	url = https://github.com/KarypisLab/GKlib.git
+    shallow = true
 [submodule "ext/METIS"]
 	path = ext/METIS
 	url = https://github.com/KarypisLab/METIS.git
+    shallow = true
 [submodule "ext/ParMETIS"]
 	path = ext/ParMETIS
 	url = https://github.com/KarypisLab/ParMETIS.git
+    shallow = true
 [submodule "ext/scotch"]
 	path = ext/scotch
 	url = https://gitlab.inria.fr/scotch/scotch.git
     branch = v7.0.8
+    shallow = true
 [submodule "ext/petsc"]
 	path = ext/petsc
 	url = https://github.com/petsc/petsc.git
     branch = v3.22.2
+    shallow = true
 [submodule "ext/cgns"]
 	path = ext/cgns
 	url = https://github.com/CGNS/CGNS.git
     branch = v4.4.0
+    shallow = true

--- a/build_loci_deps.sh
+++ b/build_loci_deps.sh
@@ -48,25 +48,11 @@ have_submodule() { [[ -d "$ext/$1" && -n "$(ls -A "$ext/$1" 2>/dev/null || true)
 ensure_submodule() {
   local name="$1"
   local submodule_path="ext/$name"
-  local heartbeat_secs=15
-  local git_pid=0
-  local elapsed=0
   if ! have_submodule "$name"; then
-    say "Initializing submodule: $submodule_path (HTTPS clone may take several minutes)"
+    say "Initializing shallow submodule: $submodule_path"
     (
       cd "$root"
-      # Keep users informed during large first-time clones.
-      git submodule update --init --progress "$submodule_path" &
-      git_pid=$!
-      elapsed=0
-      while kill -0 "$git_pid" 2>/dev/null; do
-        sleep "$heartbeat_secs"
-        elapsed=$((elapsed + heartbeat_secs))
-        if kill -0 "$git_pid" 2>/dev/null; then
-          say "Submodule $submodule_path still downloading... ${elapsed}s elapsed"
-        fi
-      done
-      wait "$git_pid"
+      git submodule update --init --recursive --depth 1 "$submodule_path"
     )
     say "Submodule ready: $submodule_path"
   fi

--- a/build_loci_deps.sh
+++ b/build_loci_deps.sh
@@ -47,9 +47,28 @@ need cmake
 have_submodule() { [[ -d "$ext/$1" && -n "$(ls -A "$ext/$1" 2>/dev/null || true)" ]]; }
 ensure_submodule() {
   local name="$1"
+  local submodule_path="ext/$name"
+  local heartbeat_secs=15
+  local git_pid=0
+  local elapsed=0
   if ! have_submodule "$name"; then
-    say "Initializing submodule: ext/$name"
-    (cd "$root" && git submodule update --init "ext/$name")
+    say "Initializing submodule: $submodule_path (HTTPS clone may take several minutes)"
+    (
+      cd "$root"
+      # Keep users informed during large first-time clones.
+      git submodule update --init --progress "$submodule_path" &
+      git_pid=$!
+      elapsed=0
+      while kill -0 "$git_pid" 2>/dev/null; do
+        sleep "$heartbeat_secs"
+        elapsed=$((elapsed + heartbeat_secs))
+        if kill -0 "$git_pid" 2>/dev/null; then
+          say "Submodule $submodule_path still downloading... ${elapsed}s elapsed"
+        fi
+      done
+      wait "$git_pid"
+    )
+    say "Submodule ready: $submodule_path"
   fi
 }
 


### PR DESCRIPTION
add a feature to display information about initial submodule repo clones that might take a long time to fully clone.

One of the git repos in the ext/ is a very large initial clone when using the dependency build script. Added some coding to notify that the script hasn't frozen and is just cloning the repo, and periodically updates the user of this.