### PR TITLE
removed unused part of rule API

### DIFF
--- a/src/System/rule.cc
+++ b/src/System/rule.cc
@@ -693,58 +693,6 @@ namespace Loci {
 
   }
 
-  void
-  rule_impl::split_constraints(const variableSet& dc) {
-
-    vector<vmap_info> new_constraints ;
-
-    set<vmap_info>::iterator si=rule_info.constraints.begin() ;
-    set<vmap_info>::iterator si_bak ;
-
-    // split the constraints field into static & dynamic ones
-    while(si != rule_info.constraints.end()) {
-      variableSet local_dc ;
-      // get the constraints variables
-      for(variableSet::const_iterator vi=si->var.begin();
-          vi!=si->var.end();++vi) {
-        // since a constraints variables may appear in other forms
-        // e.g., having an offset, or an assign operator, e.g.,
-        // if we have a dynamic constraints A{n}, it may appear in
-        // a rule as "A{n=0}" or "A{n+1}". therefore, we need to
-        // drop possible assigns and offsets.
-        variable nv = (vi->new_offset(0)).drop_assign() ;
-        if(dc.inSet(nv))
-          local_dc += *vi ;
-      }
-      if(local_dc != EMPTY) {
-        // make a copy of vmap_info
-        vmap_info dc_copy(*si) ;
-        // modify its var field
-        dc_copy.var = local_dc ;
-        // insert it into the dynamic_constraints set
-        rule_info.dynamic_constraints.insert(dc_copy) ;
-
-        // construct a new copy of static constraints
-        variableSet local_sc = variableSet(si->var - local_dc) ;
-        if(local_sc != EMPTY) {
-          vmap_info sc_copy(*si) ;
-          sc_copy.var = local_sc ;
-          new_constraints.push_back(sc_copy) ;
-        }
-        // then erase original copy in constraints set
-        si_bak = si ;
-        ++si_bak ;
-        rule_info.constraints.erase(si) ;
-        si = si_bak ;
-      } else
-        ++si ;
-    }
-    // finally push the new static constraints ones to the set
-    rule_info.constraints.insert(new_constraints.begin(),
-                                 new_constraints.end()) ;
-  }
-
-
   variableSet rule_impl::get_var_list() {
     storeIMap::iterator sp ;
     set<vmap_info>::const_iterator i ;

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -213,8 +213,6 @@ namespace Loci {
     // to reflect the substitution of constraints for maps.
     void replace_map_constraints(fact_db& facts) ;
 
-    void split_constraints(const variableSet& dc) ;
-    
     void set_variable_times(time_ident tl) ;
     void copy_store_from(rule_impl &f) ;
     void Print(std::ostream &s) const ;


### PR DESCRIPTION
Removed part of the rule API that was used by the recently removed dynamic scheduling option.