### PR TITLE
CUDA global reductions (unit/apply on param) for

### DIFF
--- a/configure
+++ b/configure
@@ -934,7 +934,7 @@ if [ $USE_CUDA == 1 ]; then
     echo CUDA_BASE = $CUDA_BASE >> sys.conf
     echo CUDA_LIBS = -L\$\(CUDA_BASE\)/lib64 -lcudart \$\(RPATH\)\$\(CUDA_BASE\)/lib64 >> sys.conf
     echo CUDA_INCLUDE = -I\$\(CUDA_BASE\)/include -I\$\(MPI_BASE\)/include -DUSE_CUDA_RT >> sys.conf
-    echo NVCC = nvcc -O3 -lineinfo -g -arch native >> sys.conf
+    echo NVCC = nvcc -O3 -lineinfo -g -arch native --expt-relaxed-constexpr >> sys.conf
 
 fi
 echo >> sys.conf

--- a/src/include/Tools/gpu_attr.h
+++ b/src/include/Tools/gpu_attr.h
@@ -4,7 +4,13 @@
 #ifdef __CUDACC__
 #define GPU_DECL __host__ __device__
 #else
-#define GPU_DECL 
+#define GPU_DECL
+#endif
+
+#ifdef __CUDACC__
+#define GPU_ONLY_DECL __device__
+#else
+#define GPU_ONLY_DECL
 #endif
 
 #endif

--- a/src/include/gpuLoci.h
+++ b/src/include/gpuLoci.h
@@ -23,3 +23,11 @@
 #include <gpustore.h>
 #include <gpuMap.h>
 #include <gpuMapVec.h>
+
+#ifdef USE_CUDA_RT
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <cub/cub.cuh>
+#endif

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -29,6 +29,8 @@
 #include <Tools/debug.h>
 #include <entitySet.h>
 #include <store_rep.h>
+#include <Tools/gpu_attr.h>
+#include <Tools/basic_types.h>
 
 #include <iostream>
 #include <string>
@@ -626,7 +628,11 @@ namespace Loci {
     }
 
   } ;
-  
+
+  template<typename Op, typename T>
+  struct ReductionIdentity {
+  } ;
+
   template <class T> struct NullOp {
     void operator()(T &res, const T &arg)
     { std::cerr << "join should not be called for NullOp" << std::endl; }
@@ -634,27 +640,139 @@ namespace Loci {
     { std::cerr << "join should not be called for NullOp" << std::endl; }
   } ;
 
-  template <class T> struct Summation {
-    void operator()(T &res, const T &arg)
-    { res += arg ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res += arg ; }
+  template<typename T> struct Summation {
+    GPU_DECL
+    void operator()(T &res, const T &arg) {
+      res += arg ;
+    }
+
+    template<typename U>
+    GPU_DECL
+    void operator()(T &res, const U &arg) {
+      res += arg ;
+    }
+
+    GPU_DECL
+    T identity() const {
+      return ReductionIdentity<Summation<T>, T>::get_value() ;
+    }
   } ;
 
-  template <class T> struct Product {
-    void operator()(T &res, const T &arg)
-    { res *= arg ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res *= arg ; }
-
+  template<typename T>
+  struct ReductionIdentity<
+    Summation<T>,
+    typename std::enable_if<std::is_arithmetic_v<T>, T>::type
+    > {
+    GPU_DECL
+    static T get_value() {
+      return 0 ;
+    }
   } ;
 
-  template <class T> struct Maximum {
-    void operator()(T &res ,const T &arg)
-    { res = max(res,arg) ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res = max(res,arg) ; }
+  template<typename T>
+  struct ReductionIdentity<
+    Summation<vector3d<T>>,
+    typename std::enable_if<std::is_arithmetic_v<T>, vector3d<T>>::type
+    > {
+    GPU_DECL
+    static vector3d<T> get_value() {
+      return vector3d<T>(0, 0, 0) ;
+    }
   } ;
+
+  template<typename T>
+  struct ReductionIdentity<
+    Summation<vector2d<T>>,
+    typename std::enable_if<std::is_arithmetic_v<T>, vector2d<T>>::type
+    > {
+    GPU_DECL
+    static vector2d<T> get_value() {
+      return vector2d<T>(0, 0) ;
+    }
+  } ;
+
+  template<typename T>
+  struct Product {
+    GPU_DECL
+    void operator()(T &res, const T &arg) {
+      res *= arg ;
+    }
+
+    template<typename U>
+    GPU_DECL
+    void operator()(T &res, const U &arg) {
+      res *= arg ;
+    }
+
+    GPU_DECL
+    T identity() const {
+      return ReductionIdentity<Product<T>, T>::get_value() ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<
+    Product<T>,
+    typename std::enable_if<std::is_arithmetic_v<T>, T>::type
+    > {
+    GPU_DECL
+    static T get_value() {
+      return 1.0 ;
+    }
+  } ;
+
+  template<typename T> struct Maximum {
+    GPU_DECL
+    void operator()(T &res ,const T &arg) {
+      res = max(res,arg) ;
+    }
+
+    template<typename U>
+    GPU_DECL
+    void operator()(T &res, const U &arg) {
+      res = max(res,arg) ;
+    }
+
+    GPU_DECL
+    T identity() const {
+      return ReductionIdentity<Maximum<T>, T>::get_value() ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<
+    Maximum<T>,
+    typename std::enable_if<std::is_arithmetic_v<T>, T>::type
+  > {
+    GPU_DECL
+    static T get_value() {
+      return std::numeric_limits<T>::lowest() ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<Maximum<vector3d<T>>, vector3d<T>> {
+    GPU_DECL
+    static vector3d<T> get_value() {
+      return vector3d<T>(
+                         ReductionIdentity<Maximum<T>, T>::get_value(),
+                         ReductionIdentity<Maximum<T>, T>::get_value(),
+                         ReductionIdentity<Maximum<T>, T>::get_value()
+                         ) ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<Maximum<vector2d<T>>, vector2d<T>> {
+    GPU_DECL
+    static vector2d<T> get_value() {
+      return vector2d<T>(
+                         ReductionIdentity<Maximum<T>, T>::get_value(),
+                         ReductionIdentity<Maximum<T>, T>::get_value()
+                         ) ;
+    }
+  } ;
+
   template <class T> struct Maximum<Vect<T> > {
     template <class U> void operator()(Vect<T> &res ,const U &arg)
     {
@@ -664,12 +782,59 @@ namespace Loci {
     }
   } ;  
 
-  template <class T> struct Minimum {
-    void operator()(T &res, const T &arg)
-    { res = min(res,arg) ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res = min(res,arg) ; }
+  template<typename T>
+  struct Minimum {
+    GPU_DECL
+    void operator()(T &res, const T &arg) {
+      res = min(res,arg) ;
+    }
+
+    template<typename U>
+    GPU_DECL
+    void operator()(T &res, const U &arg) {
+      res = min(res,arg) ;
+    }
+
+    GPU_DECL
+    T identity() const {
+      return ReductionIdentity<Minimum<T>, T>::get_value() ;
+    }
   } ;
+
+  template<typename T>
+  struct ReductionIdentity<
+    Minimum<T>,
+    typename std::enable_if<std::is_arithmetic_v<T>, T>::type
+  > {
+    GPU_DECL
+    static T get_value() {
+      return std::numeric_limits<T>::max() ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<Minimum<vector3d<T>>, vector3d<T>> {
+    GPU_DECL
+    static vector3d<T> get_value() {
+      return vector3d<T>(
+                         ReductionIdentity<Minimum<T>, T>::get_value(),
+                         ReductionIdentity<Minimum<T>, T>::get_value(),
+                         ReductionIdentity<Minimum<T>, T>::get_value()
+                         ) ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<Minimum<vector2d<T>>, vector2d<T>> {
+    GPU_DECL
+    static vector2d<T> get_value() {
+      return vector2d<T>(
+                         ReductionIdentity<Minimum<T>, T>::get_value(),
+                         ReductionIdentity<Minimum<T>, T>::get_value()
+                         ) ;
+    }
+  } ;
+
   template <class T> struct Minimum<Vect<T> > {
     template <class U> void operator()(Vect<T> &res ,const U &arg)
     {

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -721,7 +721,8 @@ namespace Loci {
     }
   } ;
 
-  template<typename T> struct Maximum {
+  template<typename T>
+  struct Maximum {
     GPU_DECL
     void operator()(T &res ,const T &arg) {
       res = max(res,arg) ;
@@ -748,45 +749,6 @@ namespace Loci {
     static T get_value() {
       return std::numeric_limits<T>::lowest() ;
     }
-  /// Combines values with logical AND.
-  template <class T> struct LogicalAnd {
-    void operator()(T &res, const T &arg)
-    { res = res && arg ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res = res && arg ; }
-  } ;
-  /// Combines matching entries of vector views with logical AND.
-  template <class T> struct LogicalAnd<Vect<T> > {
-    template <class U> void operator()(Vect<T> &res ,const U &arg)
-    {
-      int vs = res.getSize() ;
-      for(int i=0;i<vs;++i)
-        res[i] = res[i] && arg[i] ;
-    }
-  } ;
-
-  /// Combines values with logical OR.
-  template <class T> struct LogicalOr {
-    void operator()(T &res, const T &arg)
-    { res = res || arg ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res = res || arg ; }
-  } ;
-  /// Combines matching entries of vector views with logical OR.
-  template <class T> struct LogicalOr<Vect<T> > {
-    template <class U> void operator()(Vect<T> &res ,const U &arg)
-    {
-      int vs = res.getSize() ;
-      for(int i=0;i<vs;++i)
-        res[i] = res[i] || arg[i] ;
-    }
-  } ;
-
-  template <class T> struct Maximum {
-    void operator()(T &res ,const T &arg)
-    { res = max(res,arg) ; }
-    template <class U> void operator()(T &res, const U &arg)
-    { res = max(res,arg) ; }
   } ;
 
   template<typename T>
@@ -883,7 +845,88 @@ namespace Loci {
     }
   } ;  
 
-  
+  /// Combines values with logical AND.
+  template<typename T>
+  struct LogicalAnd {
+    GPU_DECL
+    void operator()(T &res, const T &arg) {
+      res = res && arg ;
+    }
+
+    template<typename U>
+    GPU_DECL
+    void operator()(T &res, const U &arg) {
+      res = res && arg ;
+    }
+
+    GPU_DECL
+    T identity() const {
+      return ReductionIdentity<LogicalAnd<T>, T>::get_value() ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<
+    LogicalAnd<T>,
+    typename std::enable_if<std::is_arithmetic_v<T>, T>::type
+  > {
+    GPU_DECL
+    static T get_value() {
+      return T(1) ;
+    }
+  } ;
+
+  /// Combines matching entries of vector views with logical AND.
+  template <class T> struct LogicalAnd<Vect<T> > {
+    template <class U> void operator()(Vect<T> &res ,const U &arg)
+    {
+      int vs = res.getSize() ;
+      for(int i=0;i<vs;++i)
+        res[i] = res[i] && arg[i] ;
+    }
+  } ;
+
+  /// Combines values with logical OR.
+  template<typename T>
+  struct LogicalOr {
+    GPU_DECL
+    void operator()(T &res, const T &arg) {
+      res = res || arg ;
+    }
+
+    template<typename U>
+    GPU_DECL
+    void operator()(T &res, const U &arg) {
+      res = res || arg ;
+    }
+
+    GPU_DECL
+    T identity() const {
+      return ReductionIdentity<LogicalOr<T>, T>::get_value() ;
+    }
+  } ;
+
+  template<typename T>
+  struct ReductionIdentity<
+    LogicalOr<T>,
+    typename std::enable_if<std::is_arithmetic_v<T>, T>::type
+  > {
+    GPU_DECL
+    static T get_value() {
+      return T(0) ;
+    }
+  } ;
+
+  /// Combines matching entries of vector views with logical OR.
+  template <class T> struct LogicalOr<Vect<T> > {
+    template <class U> void operator()(Vect<T> &res ,const U &arg)
+    {
+      int vs = res.getSize() ;
+      for(int i=0;i<vs;++i)
+        res[i] = res[i] || arg[i] ;
+    }
+  } ;
+
   class rule {
   public:
     enum rule_type {BUILD=0,COLLAPSE=1,GENERIC=2,TIME_SPECIFIC=3,INTERNAL=4} ;

--- a/src/lpp/Makefile
+++ b/src/lpp/Makefile
@@ -26,7 +26,7 @@ TARGET = lpp
 
 
 # List your object files here
-OBJS =  lpp.o parseLEX.o parseAST.o main.o 
+OBJS =  template.o lpp.o parseLEX.o parseAST.o main.o 
 
 
 LOCAL_LIBS =

--- a/src/lpp/lpp.cc
+++ b/src/lpp/lpp.cc
@@ -18,8 +18,11 @@
 //# along with the Loci Framework.  If not, see <http://www.gnu.org/licenses>
 //#
 //#############################################################################
+
 #include "lpp.h"
 #include "parseAST.h"
+#include "template.h"
+
 #include <ctype.h>
 #include <set>
 #include <iostream>
@@ -1672,6 +1675,174 @@ void AST_printTree::visit(AST_controlStatement &s) {
   popindent() ;
 }
 
+/// Visitor that prints an AST using a simple substitution map
+class AST_printObjectTree : public AST_visitor {
+public:
+  ostream & out ;
+  int indent_level ;
+
+  void indent() {
+    for(int i = 0; i < indent_level; ++i)
+      out << "  " ;
+  }
+
+  void pushindent() {
+    indent_level++ ;
+  }
+
+  void popindent() {
+    indent_level-- ;
+  }
+
+  AST_printObjectTree(ostream & s): out(s), indent_level(0) {}
+
+  virtual void visit(AST_exprOper &)  ;
+  virtual void visit(AST_Token &) ;
+  virtual void visit(AST_Block &) ;
+  virtual void visit(AST_typeSpec &) ;
+  virtual void visit(AST_declaration &) ;
+  virtual void visit(AST_SimpleStatement &) ;
+  virtual void visit(AST_controlStatement &) ;
+} ;
+
+void AST_printObjectTree::visit(AST_exprOper &s) {
+  indent() ;
+  out << "AST_exprOper(" << NTtoString(s.nodeType) << ")" << endl ;
+
+  pushindent() ;
+
+  indent() ;
+  out << "terms" << endl ;
+
+  pushindent() ;
+  for(AST_type::ASTList::iterator ii=s.terms.begin();ii!=s.terms.end();++ii) {
+    if(*ii != 0)
+      (*ii)->accept(*this) ;
+    }
+  popindent() ;
+
+  popindent() ;
+}
+
+void AST_printObjectTree::visit(AST_Token & s) {
+  indent() ;
+  out << "AST_Token(" << NTtoString(s.nodeType) << ", \"" << s.text << "\")" << endl ;
+}
+
+void AST_printObjectTree::visit(AST_Block & s) {
+  indent() ;
+  out << "AST_Block(" << NTtoString(s.nodeType) << ")" << endl ;
+
+  pushindent() ;
+
+  indent() ;
+  out << "elements" << endl ;
+
+  pushindent() ;
+  for(auto ii = s.elements.begin(); ii != s.elements.end(); ++ii)
+    if(*ii!=0)
+      (*ii)->accept(*this) ;
+  popindent() ;
+
+  popindent() ;
+}
+
+void AST_printObjectTree::visit(AST_typeSpec &s) {
+  indent() ;
+  out << "AST_typeSpec(" << NTtoString(s.nodeType) << ")" << endl ;
+
+  pushindent() ;
+
+  indent() ;
+  out << "type_spec" << endl ;
+
+  pushindent() ;
+  for(auto ii=s.type_spec.begin();ii!=s.type_spec.end();++ii)
+    if(*ii != 0)
+      (*ii)->accept(*this) ;
+  popindent() ;
+
+  popindent() ;
+}
+
+void AST_printObjectTree::visit(AST_declaration &s) {
+  indent() ;
+  out << "AST_declaration(" << NTtoString(s.nodeType) << ")" << endl ;
+
+  pushindent() ;
+
+  indent() ;
+  out << "type_decl" << endl ;
+
+  pushindent() ;
+  for(auto ii=s.type_decl.begin();ii!=s.type_decl.end();++ii)
+    if(*ii != 0)
+      (*ii)->accept(*this) ;
+  popindent() ;
+
+  indent() ;
+  out << "decls" << endl ;
+
+  pushindent() ;
+  for(auto ii=s.decls.begin();ii!=s.decls.end();++ii)
+    if(*ii != 0)
+      (*ii)->accept(*this) ;
+  popindent() ;
+
+  popindent() ;
+}
+
+void AST_printObjectTree::visit(AST_SimpleStatement &s) {
+  indent() ;
+  out << "AST_SimpleStatement(" << NTtoString(s.nodeType) << ")" << endl ;
+
+  pushindent() ;
+
+  indent() ;
+  out << "exp" << endl ;
+
+  pushindent() ;
+  if(s.exp!=0)
+    s.exp->accept(*this) ;
+  popindent() ;
+
+  indent() ;
+  out << "terminal" << endl ;
+
+  pushindent() ;
+  if(s.Terminal!=0) 
+    s.Terminal->accept(*this) ;
+  popindent() ;
+
+  popindent() ;
+}
+
+void AST_printObjectTree::visit(AST_controlStatement &s) {
+  indent() ;
+  out << "AST_controlStatement(" << NTtoString(s.nodeType) << ")" << endl ;
+
+  pushindent() ;
+
+  indent() ;
+  out << "controlType" << endl ;
+
+  pushindent() ;
+  s.controlType->accept(*this) ;
+  popindent() ;
+
+  indent() ;
+  out << "parts" << endl ;
+
+  pushindent() ;
+  for(auto ii=s.parts.begin();ii!=s.parts.end();++ii) {
+    if(*ii != 0)
+      (*ii)->accept(*this) ;
+  }
+  popindent() ;
+
+  popindent() ;
+}
+
 class AST_editLociMapArrayAccess : public AST_visitor {
 public:
   virtual void visit(AST_exprOper &) ;
@@ -2164,28 +2335,471 @@ std::vector<list<variable> > expand_mapping(std::vector<variableSet> vset) {
   return tmp2 ;
 }
 
+static char const * cuda_rule_template = "\
+$$#if pln$$#line $$rule.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+class $$rule.class$$ : public Loci::$$rule.type$$_rule\
+$$#if rule.is_apply$$<\
+Loci::gpu$$rule.apply.container$$\
+$$#if rule.apply.container_args$$<$$rule.apply.container_args$$>$$/if$$, \
+$$rule.apply.operator$$<$$rule.apply.container_args$$> >\
+$$/if$$\
+{\n\
+$$#each rule.input_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+  Loci::const_gpu$$ctype$$$$#if carg$$<$$carg$$>$$/if$$ $$vname$$ ;\n\
+$$/each$$\
+$$#each rule.output_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+  Loci::gpu$$ctype$$$$#if carg$$<$$carg$$>$$/if$$ $$vname$$ ;\n\
+$$/each$$\
+\n\
+public:\n\
+$$#if pln$$#line $$rule.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$() {\n\
+$$#each rule.name_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    name_store(\"$$name$$\", $$vname$$) ;\n\
+$$#if has_info_id$$\
+    store_info_id(\"$$name$$\", $$info_id$$) ;\n\
+$$/if$$\
+$$/each$$\
+$$#each rule.inputs$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    input(\"$$str$$\") ;\n\
+$$/each$$\
+$$#each rule.outputs$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    output(\"$$str$$\") ;\n\
+$$/each$$\
+$$#each rule.constraints.spec$$\
+$$#if ::pln$$#line $$::rule.constraints.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    constraint(\"$$str$$\") ;\n\
+$$/each$$\
+    disable_threading() ;\n\
+$$#if rule.is_parametric$$\
+$$#if pln$$#line $$rule.parametric.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    set_parametric_variable(\"$$rule.parametric.spec$$\") ;\n\
+$$/if$$\
+$$#if rule.is_specialized$$\
+$$#if pln$$#line $$rule.specialized.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    set_specialized() ;\n\
+$$/if$$\
+$$#if rule.is_conditional$$\
+$$#if pln$$#line $$rule.conditional.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    conditional(\"$$rule.conditional.spec$$\") ;\n\
+$$/if$$\
+$$#each rule.comments$$\
+$$#if ::pln$$#line $$line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    comments(\"$$str$$\") ;\n\
+$$/each$$\
+$$#if pln$$#line $$rule.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    set_file(\"$$rule.file$$:$$rule.line_number$$\") ;\n\
+  }\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  void compute(const Loci::sequence &seq) override ;\n\
+$$#if rule.is_pointwise$$\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  typedef struct {\n\
+$$#each rule.input_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    $$vtype$$ const * $$vname$$ ;\n\
+$$/each$$\
+$$#each rule.output_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    $$vtype$$ * $$vname$$ ;\n\
+$$/each$$\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    GPU_DECL\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    void operator()(Entity _e_) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$rule.compute.spec$$\n\
+    }\n\
+  } compute_t ;\n\
+$$/if$$\
+$$#if rule.is_unit$$\
+\n\
+$$#if pln$$#line $$rule.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  typedef $$rule.unit.container_args$$ value_t ;\n\
+$$/if$$\
+$$#if rule.is_apply$$\
+\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  typedef $$rule.apply.container_args$$ value_t ;\n\
+\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  typedef $$rule.apply.operator$$<value_t> loci_reduction_t ;\n\
+\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  typedef struct {\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    GPU_DECL\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    value_t operator()(value_t const & lhs, value_t const & rhs) {\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+      value_t tmp = lhs ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+      loci_reduction_t op ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+      op(tmp, rhs) ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+      return tmp ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    }\n\
+\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    GPU_DECL\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    value_t identity() const {\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+      loci_reduction_t tmp ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+      return tmp.identity() ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    }\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  } reduction_t ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  typedef struct {\n\
+$$#each rule.input_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    $$vtype$$ const * $$vname$$ ;\n\
+$$/each$$\
+$$#each rule.output_stores$$\
+$$#if ::pln$$#line $$::rule.signature.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+    $$vtype$$ * $$vname$$ ;\n\
+$$/each$$\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    GPU_DECL\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    value_t operator()(Entity _e_) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$rule.compute.spec$$\n\
+    }\n\
+  } compute_t ;\n\
+$$/if$$\
+} ;\n\
+\n\
+$$#if rule.is_unit$$\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+__global__\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+void $$rule.class$$_kernel($$rule.class$$::value_t * $$rule.unit.target_vname$$) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$rule.compute.spec$$\n\
+}\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+void $$rule.class$$::compute(const Loci::sequence &seq) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$#if debug_info$$nvtxRangePush(\"$$rule.debug_name$$\") ;\n$$/if$$\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$_kernel<<<1, 1>>>($$rule.unit.target_vname$$.ptr()) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$#if debug_info$$nvtxRangePop(\"$$rule.debug_name$$\") ;\n$$/if$$\
+}\n\
+$$/if$$\
+$$#if rule.is_apply$$\
+$$#if rule.apply.is_singleton$$\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+__global__\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+void $$rule.class$$_computevar_kernel(\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$::value_t * res,\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$::compute_t compute_op\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+) {\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  if(threadIdx.x == 0)\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    *res = compute_op(0) ;\n\
+}\n\
+$$/if$$\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+__global__\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+void $$rule.class$$_reducevar_kernel(\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$::value_t * res,\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$::value_t const * part\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+) {\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$::loci_reduction_t op ;\n\
+$$#if pln$$#line $$rule.apply.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  op(*res, *part) ;\n\
+}\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+void $$rule.class$$::compute(const Loci::sequence &seq) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$#if debug_info$$nvtxRangePush(\"$$rule.debug_name$$\") ;\n$$/if$$\
+$$#if rule.apply.is_singleton$$\
+  compute_t compute_op ;\n\
+$$#each rule.input_stores$$\
+$$#if ::pln$$#line $$::rule.compute.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+  compute_op.$$vname$$ = $$vname$$.ptr() ;\n\
+$$/each$$\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::device_vector<value_t> d_result(1) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  value_t * d_result_ptr  = thrust::raw_pointer_cast(d_result.data()) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$_computevar_kernel<<<1, 1>>>(d_result_ptr, compute_op) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$_reducevar_kernel<<<1, 1>>>(\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    $$rule.apply.target_vname$$.ptr(),\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_result_ptr\n\
+  ) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cudaDeviceSynchronize() ;\n\
+\n\
+$$#else$$\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  size_t num_intervals = seq.num_intervals() ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::device_vector<value_t> d_interval_result(num_intervals+1) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  value_t * d_interval_result_ptr = thrust::raw_pointer_cast(d_interval_result.data()) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::host_vector<Entity> h_interval_offsets(num_intervals*2) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  for(size_t i = 0; i < num_intervals; ++i) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    h_interval_offsets[i] = seq[i].first ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    h_interval_offsets[i+num_intervals] = seq[i].second+1 ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  }\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::device_vector<Entity> d_interval_offsets(h_interval_offsets) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  compute_t compute_op ;\n\
+$$#each rule.input_stores$$\
+$$#if ::pln$$#line $$::rule.compute.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+  compute_op.$$vname$$ = $$vname$$.ptr() ;\n\
+$$/each$$\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  reduction_t reduce_op ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  value_t const unit_value = reduce_op.identity() ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::counting_iterator entity_iter = thrust::make_counting_iterator(0) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::transform_iterator transform_iter = thrust::make_transform_iterator(entity_iter, compute_op) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  void * d_temp_storage = nullptr ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  size_t temp_storage_bytes = 0 ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cub::DeviceSegmentedReduce::Reduce(\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_temp_storage,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    temp_storage_bytes,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    transform_iter,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_offsets.begin(),\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_offsets.begin()+num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    reduce_op,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    unit_value\n\
+  ) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data()) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cub::DeviceSegmentedReduce::Reduce(\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_temp_storage,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    temp_storage_bytes,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    transform_iter,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_offsets.begin(),\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_offsets.begin()+num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    reduce_op,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    unit_value\n\
+  ) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  d_temp_storage = nullptr ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  temp_storage_bytes = 0 ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cub::DeviceReduce::Reduce(\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_temp_storage,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    temp_storage_bytes,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr+num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    reduce_op,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    unit_value\n\
+  ) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  temp_storage.resize(temp_storage_bytes) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data()) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cub::DeviceReduce::Reduce(\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_temp_storage,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    temp_storage_bytes,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr+num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    num_intervals,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    reduce_op,\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    unit_value\n\
+  ) ;\n\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  $$rule.class$$_reducevar_kernel<<<1, 1>>>(\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    $$rule.apply.target_vname$$.ptr(),\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    d_interval_result_ptr+num_intervals\n\
+  ) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cudaDeviceSynchronize() ;\n\
+$$/if$$\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$#if debug_info$$nvtxRangePop() ;\n$$/if$$\
+}\n\
+\n\
+$$/if$$\
+$$#if rule.is_pointwise$$\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+void $$rule.class$$::compute(const Loci::sequence &seq) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$#if debug_info$$nvtxRangePush(\"$$rule.debug_name$$\") ;\n$$/if$$\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  compute_t compute_op ;\n\
+$$#each rule.input_stores$$\
+$$#if ::pln$$#line $$::rule.compute.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+  compute_op.$$vname$$ = $$vname$$.ptr() ;\n\
+$$/each$$\
+$$#each rule.output_stores$$\
+$$#if ::pln$$#line $$::rule.compute.line_number$$ \"$$::rule.file$$\"\n$$/if$$\
+  compute_op.$$vname$$ = $$vname$$.ptr() ;\n\
+$$/each$$\
+\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  const int ni = seq.num_intervals() ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  for(int i = 0; i < ni; ++i) {\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    thrust::counting_iterator start_iter = thrust::make_counting_iterator(seq[i].first) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    thrust::counting_iterator end_iter = thrust::make_counting_iterator(seq[i].second+1) ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+    thrust::for_each(thrust::cuda::par.on(Loci::getGPUStream()), start_iter, end_iter, compute_op) ;\n\
+  }\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+  cudaDeviceSynchronize() ;\n\
+$$#if pln$$#line $$rule.compute.line_number$$ \"$$rule.file$$\"\n$$/if$$\
+$$#if debug_info$$nvtxRangePop() ;\n$$/if$$\
+\n\
+}\n\
+$$/if$$\
+\n\
+Loci::register_rule<$$rule.class$$> register_$$rule.class$$ ;\n\
+" ;
 
 void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
                                const parseSharedInfo &parseInfo) {
+  int rule_type_line_no = 0 ;
+  int signature_line_no = 0 ;
+  int apply_op_line_no = 0 ;
+  int constraint_line_no = 0 ;
+  int parametric_line_no = 0 ;
+  int conditional_line_no = 0 ;
+  int specialized_line_no = 0 ;
+  vector<int> comments_line_no ;
+  int compute_line_no = 0 ;
+
   killsp() ;
   string rule_type ;
   if(is_name(is)) {
+    rule_type_line_no = line_no ;
     rule_type = get_name(is) ;
   } else 
     throw parseError("syntax error") ;
-  if(rule_type != "pointwise")
-    throw parseError("cudaRule only valid for pointwise") ;
-  nestedparenstuff signature ;
 
+  nestedparenstuff signature ;
   signature.get(is) ;
+  signature_line_no = line_no ;
   line_no += signature.num_lines() ;
+
   nestedbracketstuff apply_op ;
   killsp() ;
+  if(rule_type == "apply") {
+    if(is.peek() != '[')
+      throw parseError("apply rule missing '[operator]'") ;
+    apply_op.get(is) ;
+    apply_op_line_no = line_no ;
+    line_no += apply_op.num_lines() ;
+    killsp() ;
+  }
 
   string constraint, conditional ;
   string parametric_var ;
   list<string> options ;
-  list<string> comments ;
+  vector<string> comments ;
   list<pair<variable,variable> > inplace ;
   
   bool use_prelude = false ;
@@ -2205,30 +2819,35 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
         constraint = con.str() ;
       else 
         constraint += "," + con.str() ;
+      constraint_line_no = line_no ;
       line_no += con.num_lines() ;
     } else if(s == "parametric") {
       nestedparenstuff con ;
       con.get(is) ;
       if(parametric_var != "") {
-        throw parseError("syntax error: canot specify more than one parametric variable") ;
+        throw parseError("syntax error: cannot specify more than one parametric variable") ;
       }
-        
+
       parametric_var = con.str() ;
+      parametric_line_no = line_no ;
       line_no += con.num_lines() ;
     } else if(s == "conditional") {
       nestedparenstuff con ;
       con.get(is) ;
       if(conditional != "") {
-        throw parseError("syntax error: canot specify more than one conditional variable") ;
+        throw parseError("syntax error: cannot specify more than one conditional variable") ;
       }
       conditional = con.str() ;
+      conditional_line_no = line_no ;
       line_no += con.num_lines() ;
       // Check variable
       variable cond(conditional) ;
       auto mi  = lookupVarType(cond) ;
 
       if(!checkTypeValid(mi)) {
-        cerr << filename << ':' << line_no << ":0: warning: type of conditional variable '" << cond << "' not found!"  << endl  ;
+        cerr << filename << ':' << line_no
+             << ":0: warning: type of conditional variable '"
+             << cond << "' not found!"  << endl  ;
       } else {
         // clean up type string
         string val = mi->second.container + mi->second.container_args ;
@@ -2266,17 +2885,23 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     } else if(s == "option") {
       nestedparenstuff ip ;
       ip.get(is) ;
+      specialized_line_no = line_no ;
       line_no += ip.num_lines() ;
       options.push_back(ip.str()) ;
     } else if(s == "comments") {
       nestedparenstuff ip ;
       ip.get(is) ;
+      comments_line_no.push_back(line_no) ;
       line_no += ip.num_lines() ;
       comments.push_back(ip.str()) ;
     } else {
       throw parseError("unknown rule modifier") ;
     }
     killsp() ;
+  }
+
+  if(use_prelude) {
+    throw parseError("prelude not compatible with cuda rules") ;
   }
 
   string sig = signature.str() ;
@@ -2297,7 +2922,7 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
       throw parseError("rules without bodies should have a defined constraint as input!") ;
     }
   }
-  
+
   string class_name = "file_" ;
   for(size_t i=0;i<filename.size();++i) {
     char c = filename[i] ;
@@ -2314,14 +2939,13 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
   //  ftime(&tdata) ;
   timespec tdata ;
   clock_gettime(CLOCK_MONOTONIC,&tdata) ;
-  
-  
+
   ostringstream tss ;
   tss << '_' << tdata.tv_sec << 'm' << tdata.tv_nsec/1000000 ;
-  
+
   class_name += tss.str() ;
   cnt++ ;
-  
+
   set<vmap_info> sources ;
   set<vmap_info> targets ;
   if(body != 0)
@@ -2346,7 +2970,7 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     if(i->mapping.size() == 0) {
       for(auto vi=i->var.begin();vi!=i->var.end();++vi) {
         std::list<variable> vbasic ;
-      
+
         vbasic.push_back(*vi) ;
         validate_set.insert(vbasic) ;
       }
@@ -2403,12 +3027,7 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     }
   }
 
-  
-
-  map<variable,string> vnames ;
-  variableSet all_vars = input;
-  all_vars += output ;
-
+  // Inputs cannot have priority.
   for(auto vi=input.begin();vi!=input.end();++vi) {
     if(vi->get_info().priority.size() != 0) {
       ostringstream oss ;
@@ -2417,6 +3036,34 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     }
   }
 
+  // Only pointwise rules can have priority over output variables.
+  if(rule_type != "pointwise" && rule_type != "default") {
+    for(auto vi = output.begin(); vi != output.end(); ++vi) {
+      if(vi->get_info().priority.size() != 0) {
+        ostringstream oss ;
+        oss << "only pointwise rules can use priority annotation, var=" << *vi << endl ;
+        throw parseError(oss.str()) ;
+      }
+    }
+  }
+
+  // Set of inputs + outputs.
+  variableSet all_vars = input;
+  all_vars += output ;
+
+  // Catch undeclared Loci variable.
+  for(auto vi=all_vars.begin();vi!=all_vars.end();++vi) {
+    auto mi = lookupVarType(*vi) ;
+    if(!checkTypeValid(mi)) {
+      string s ;
+      s = "unable to determine type of variable " ;
+      s += (*vi).str() ;
+      throw parseError(s) ;
+    }
+  }
+
+  // Create C++ variable names for Loci variables.
+  map<variable,string> vnames ;
   for(auto vi=all_vars.begin();vi!=all_vars.end();++vi) {
     vnames[*vi] = var2name(*vi) ;
     if(vi->get_info().priority.size() != 0) {
@@ -2426,8 +3073,12 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
       vnames[v] = vnames[*vi] ;
     }
   }
+  for(auto ipi=inplace.begin();ipi!=inplace.end();++ipi) {
+    vnames[ipi->first] = vnames[ipi->second] ;
+  }
 
-
+  // Check if variables paired by inplace specification are specified as either
+  // input or output to the rule.
   variableSet checkset ;
   for(auto vi=all_vars.begin();vi!=all_vars.end();++vi) {
     variable v = *vi ;
@@ -2436,7 +3087,6 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     checkset += v ;
   }
   for(auto ipi=inplace.begin();ipi!=inplace.end();++ipi) {
-    vnames[ipi->first] = vnames[ipi->second] ;
     variable v = ipi->first ;
     while(v.get_info().priority.size() != 0)
       v = v.drop_priority() ;
@@ -2453,23 +3103,8 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
       oss << "inplace variable '"<< ipi->second << "' not input or output variable!" ;
       throw parseError(oss.str()) ;
     }
-    
-  }
-  
-  for(auto vi=all_vars.begin();vi!=all_vars.end();++vi) {
-    auto mi = lookupVarType(*vi) ;
-    if(!checkTypeValid(mi)) {
-      string s ;
-      s = "unable to determine type of variable " ;
-      s += (*vi).str() ;
-      throw parseError(s) ;
-    }
   }
 
-
-  //  if(!prettyOutput)
-  //    outputFile << "namespace {" ;
-  outputFile << "class " << class_name << " : public Loci::" << rule_type << "_rule" ;
   if(rule_type == "pointwise") {
     for(auto vi=output.begin();vi!=output.end();++vi) {
       auto mi = lookupVarType(*vi) ;
@@ -2479,250 +3114,84 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     }
   }
 
-  outputFile << " {" << endl ;
-  syncFile(outputFile) ;
-
-  variableSet outs = output ;
-  for(auto ipi=inplace.begin();ipi!=inplace.end();++ipi) {
-    outs -= ipi->first ;
-    outs += ipi->second ;
-  }
-  variableSet ins = input ;
-  ins -= outs ;
-  map<variable,string> typetable ;
-  map<variable,string> ctypetable ;
-  for(auto vi=ins.begin();vi!=ins.end();++vi) {
-    auto mi = lookupVarType(*vi) ;
-    if(!checkTypeValid(mi)) {
-      cerr << "unknown type for variable " << *vi << endl ;
-      throw parseError("untyped Loci variable") ;
+  bool paramUnit = 0 ;
+  if(rule_type == "unit") {
+    if(output.size() != 1) {
+      throw parseError("unit rule should have only one output variable") ;
     }
-    ctypetable[*vi] = mi->second.container ;
-    if(mi->second.container == "Map") {
-      typetable[*vi] = "int" ;
-    } else if(mi->second.container == "MapVec") {
-      string scratch = mi->second.container_args ;
-      if(scratch.size() > 2) {
-        typetable[*vi] = string("Array<Entity,") + scratch.substr(1,scratch.size()-3) + ">" ;
-      } else {
-        cerr << "unexpected loci variable type!" << endl ;
-      }
-    } else {
-      string scratch = mi->second.container_args ;
-      if(scratch.size() > 2) {
-        typetable[*vi] = scratch.substr(1,scratch.size()-3) ;
-      } else {
-        cerr << "unexpected loci variable type!" << endl ;
+
+    variable v = *(output.begin()) ;
+    typedoc tinfo = lookupVarType(v)->second ;
+    if(tinfo.container != "param") {
+      throw parseError("unit rule should have only param output variable") ;
+    }
+
+    paramUnit = 1 ;
+  }
+
+  int singletonApply = 0 ;
+  if(rule_type == "apply") {
+    if(output.size() != 1) {
+      throw parseError("apply rule should have only one output variable") ;
+    }
+
+    variable v = *(output.begin()) ;
+    typedoc tinfo = lookupVarType(v)->second ;
+    if(tinfo.container != "param") {
+      throw parseError("apply rule should have param as output variable") ;
+    }
+
+    bool allparam = true ;
+    for(auto vi = input.begin(); vi != input.end(); ++vi) {
+      typedoc tinfo2 = lookupVarType(*vi)->second ;
+      if(tinfo2.container != "param") {
+        allparam = false ;
       }
     }
 
-    if(!prettyOutput) {
-      outputFile << "    Loci::const_gpu" << mi->second.container
-                 <<  mi->second.container_args ;
-    } else {
-      outputFile << "    const_gpu" << mi->second.container
-                 <<  mi->second.container_args ;
+    if(allparam) {
+      singletonApply = 1 ;
     }
-
-    outputFile << " " << vnames[*vi] << " ; " << endl ;
-    syncFile(outputFile) ;
   }
 
-  for(auto vi=outs.begin();vi!=outs.end();++vi) {
-    auto mi = lookupVarType(*vi) ;
-    if(!checkTypeValid(mi)) {
-      cerr << "unknown type for variable " << *vi << endl ;
-      throw parseError("untyped Loci variable") ;
-    }
-    ctypetable[*vi] = mi->second.container ;
-    if(mi->second.container == "Map") {
-      typetable[*vi] = "int" ;
-    } else if(mi->second.container == "MapVec") {
-      string scratch = mi->second.container_args ;
-      if(scratch.size() > 2) {
-        typetable[*vi] = string("Array<Entity,") + scratch.substr(1,scratch.size()-3) + ">" ;
-      } else {
-        cerr << "unexpected loci variable type!" << endl ;
-      }
-    } else {
-      string scratch = mi->second.container_args ;
-      if(scratch.size() > 2) {
-        typetable[*vi] = scratch.substr(1,scratch.size()-3) ;
-      } else {
-        cerr << "unexpected loci variable type!" << endl ;
-      }
-    }
-    if(!prettyOutput)
-      outputFile << "    Loci::gpu" << mi->second.container
-		 <<  mi->second.container_args ;
-    else
-      outputFile << "    gpu" << mi->second.container <<
-	mi->second.container_args ;
-    outputFile << " " << vnames[*vi] << " ; " << endl ;
-    syncFile(outputFile) ;
-  }
-  outputFile << "public:" << endl ;
-  syncFile(outputFile) ;
-  outputFile <<   "    " << class_name << "() {" << endl ;
-  syncFile(outputFile) ;
-  for(auto ipi=inplace.begin();ipi!=inplace.end();++ipi) {
-    all_vars -= ipi->first ;
+  if(singletonApply) {
+    cerr << "NOTE: parameter only apply rule on '"
+         << *(output.begin()) << "' now executes single instance." << endl ;
   }
 
-  for(auto vi=all_vars.begin();vi!=all_vars.end();++vi) {
-    outputFile << "       name_store(\"" << *vi << "\","
-               << vnames[*vi] << ") ;" << endl ;
-    syncFile(outputFile) ;
-  }
-  if(bodys != "") {
-    outputFile <<   "       input(\"" << bodys << "\") ;" << endl ;
-    syncFile(outputFile) ;
-  }
-
-  for(auto i=targets.begin();i!=targets.end();++i) {
-    outputFile <<   "       output(\"" ;
-    for(size_t j=0;j<i->mapping.size();++j)
-      outputFile << i->mapping[j] << "->" ;
-
-    // Output target variables, adding inplace notation if needed
-    if(i->var.size() > 1)
-      outputFile << '(' ;
-    for(auto vi=i->var.begin();vi!=i->var.end();++vi) {
-      if(vi != i->var.begin())
-        outputFile << ',' ;
-      auto ipi = inplace.begin() ;
-      for(;ipi!=inplace.end();++ipi) {
-        if((ipi->first) == *vi)
-          break ;
-      }
-      if(ipi!=inplace.end()) {
-        if(i->mapping.size() == 0 || i->var.size() > 1)
-          outputFile << ipi->first << "=" << ipi->second ;
-        else
-          outputFile << '('<<ipi->first << "=" << ipi->second <<')';
-      } else
-        outputFile << *vi ;
-    }
-    if(i->var.size() > 1)
-      outputFile << ')' ;
-
-    outputFile <<  "\") ;" << endl ;
-    syncFile(outputFile) ;
-  }
-  outputFile << "disable_threading() ;" << endl ;
-  syncFile(outputFile) ;
-  //  outputFile <<   "       output(\"" << heads << "\") ;" << endl ;
-  //  syncFile(outputFile) ;
-
-  if(constraint!="") {
-    // Check to see that the constraint is typed
+  // Extract constraint variables and check if they are typed.
+  variableSet constraint_vars ;
+  set<vmap_info> constraints ;
+  if(constraint != "") {
     exprP C = expression::create(constraint) ;
-    set<vmap_info> Cdigest ;
-    fill_descriptors(Cdigest,collect_associative_op(C,OP_COMMA)) ;
-    variableSet constraint_vars ;
-    for(auto i=Cdigest.begin();i!=Cdigest.end();++i) {
-      for(size_t j=0;j<i->mapping.size();++j)
-	constraint_vars += i->mapping[j] ;
+    fill_descriptors(constraints, collect_associative_op(C,OP_COMMA)) ;
+
+    for(auto i = constraints.begin(); i != constraints.end(); ++i) {
+      for(size_t j = 0; j < i->mapping.size(); ++j)
+        constraint_vars += i->mapping[j] ;
       constraint_vars += i->var ;
     }
 
-    for(auto vi=constraint_vars.begin();vi!=constraint_vars.end();++vi) {
+    for(auto vi = constraint_vars.begin(); vi!=constraint_vars.end(); ++vi) {
       auto mi = lookupVarType(*vi) ;
 
       if(!checkTypeValid(mi)) {
-
-        cerr << filename << ':' << line_no << ":0: warning: type of constraint variable '" << *vi << "' not found!"  << endl  ;
-
+        cerr << filename << ':' << constraint_line_no
+             << ":0: warning: type of constraint variable '"
+             << *vi << "' not found!"  << endl  ;
       }
     }
-
-    outputFile <<   "       constraint(\"" << constraint << "\") ;" << endl ;
-    syncFile(outputFile) ;
   }
 
-  if(parametric_var != "") {
-    outputFile <<   "       set_parametric_variable(\""
-               << parametric_var << "\") ;" << endl ;
-    syncFile(outputFile) ;
-  }
-  if(is_specialized) {
-    outputFile <<   "       set_specialized() ; " << endl ;
-    syncFile(outputFile) ;
-  }
-  if(conditional!="") {
-    outputFile <<   "       conditional(\"" << conditional << "\") ;" << endl ;
-    syncFile(outputFile) ;
-  }
-  for(auto lsi=options.begin();lsi!=options.end();++lsi) {
-    string s = *lsi ;
-    bool has_paren = false ;
-    for(size_t i = 0;i<s.size();++i)
-      if(s[i] == '(')
-        has_paren = true ;
-    outputFile <<   "       " << s ;
-    if(!has_paren)
-      outputFile << "()" ;
-    outputFile << " ;" << endl;
-    syncFile(outputFile) ;
-  }
-  if(comments.size() == 0) {
-    // check to see if there is a javadoc compatible comment before
-    if(comment.size() > 0)
-      comments.push_back(comment) ;
-    else if(rule_type=="optional" || rule_type=="default") {
-      auto mi = lookupVarType(*output.begin()) ;
-      comments.push_back(mi->second.comment) ;
-    }
-  }
-  for(auto lsi=comments.begin();lsi!=comments.end();++lsi) {
-    outputFile <<   "       comments(" << *lsi << ") ;" << endl ;
-    syncFile(outputFile) ;
-  }
-  // document file location of rule
-  outputFile << "       set_file(\"" << filename << ":" << line_no << "\") ;" << endl ;
-  syncFile(outputFile) ;
-  outputFile <<   "    }" << endl ;
-  syncFile(outputFile) ;
-
-  //  bool use_compute = true ;
-
-  if(use_prelude) {
-    throw parseError("prelude not compatible with cuda rules") ;
-  }
-
-  //  if(use_compute && is.peek() != '{')
-  //    throw parseError("syntax error, expecting '{'") ;
-
-  bool sized_outputs = false;
-  variableSet outsmi = outs ;
-  outsmi -= input ;
-  for(auto vi=outsmi.begin();vi!=outsmi.end();++vi) {
-    auto mi = lookupVarType(*vi) ;
-    const string &ot  = mi->second.container ;
-    if(ot == "storeVec" || ot == "storeMat" || ot == "multiStore")
-      sized_outputs = true ;
-  }
-  if(sized_outputs)
-    throw parseError("cuda rules currently incompatible with storeVec, storemat or multiStore types") ;
-
-  //  if(use_compute)
-  //    process_Calculate(outputFile,vnames,validate_set) ;
-
-  outputFile <<   "    void compute(const Loci::sequence &seq) ;" << endl ;
-  syncFile(outputFile) ;
-  outputFile <<   "} ;" << endl ;
-  syncFile(outputFile) ;
-
-  //  process_Calculate(outputFile,vnames,validate_set) ;
   varmap typemap ;
 
-  if(is.peek() != '{')
+  if(is.peek() != '{') {
     throw parseError("syntax error, expecting '{'") ;
+  }
 
-  int startline = line_no ;
+  compute_line_no = line_no ;
 
-  CPTR<AST_type> ap = parseBlock(is,line_no,filename,typemap) ;
-  //    outputFile << "Parsed TEST:" << endl ;
+  CPTR<AST_type> ap = parseBlock(is, line_no, filename, typemap) ;
 
   AST_condenseLeftAssociative condenseOps ;
   ap->accept(condenseOps) ;
@@ -2739,12 +3208,12 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
   ap->accept(syntaxChecker) ;
   if(syntaxChecker.hasErrors()) {
 #ifdef VERBOSE
-    AST_simplePrint printer(cerr,-1,false) ;
+    AST_simplePrint printer(cerr, -1, false) ;
     ap->accept(printer) ;
 #endif
     throw parseError("syntax error") ;
   }
-  
+
   AST_collectAccessInfo varaccess ;
   ap->accept(varaccess) ;
   //cerr << "variables = " << varaccess.accessed << endl ;
@@ -2758,93 +3227,234 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
 
   variableSet readvars ;
   variableSet writevars ;
-  
-  for(auto i=varaccess.accessed.begin();i!=varaccess.accessed.end();++i) {
+
+  for(auto i = varaccess.accessed.begin(); i != varaccess.accessed.end(); ++i) {
     readvars += i->var ;
-    for(size_t j=0;j<i->mapping.size();++j)
+    for(size_t j = 0; j < i->mapping.size(); ++j) {
       readvars += i->mapping[j] ;
+    }
   }
-  for(auto i=varaccess.writes.begin();i!=varaccess.writes.end();++i) {
+  for(auto i = varaccess.writes.begin(); i != varaccess.writes.end(); ++i) {
     writevars += i->var ;
-    for(size_t j=0;j<i->mapping.size();++j)
+    for(size_t j = 0; j < i->mapping.size(); ++j) {
       readvars += i->mapping[j] ;
+    }
   }
 
   readvars -= writevars ;
-  
+
   // Now remove and save the open and close braces in the parseBlock
   CPTR<AST_Block> bigblock = CPTR<AST_Block>(ap) ;
   CPTR<AST_type> open = bigblock->elements[0] ;
   int bsz = bigblock->elements.size() ;
   CPTR<AST_type> close = bigblock->elements[bsz-1] ;
-  for(int i=0;i<bsz-1;++i)
+  for(int i = 0; i < bsz-1; ++i) {
     bigblock->elements[i] = bigblock->elements[i+1] ;
+  }
   bigblock->elements.pop_back() ;
   bigblock->elements.pop_back() ;
-  
-  AST_simplePrint printer(outputFile,-1,prettyOutput) ;
 
-  if(!prettyOutput)
-    outputFile << "#line " << startline << endl ;
-  outputFile << "__global__" << endl ;
-  if(!prettyOutput)
-    outputFile << "#line " << startline << endl ;
-  outputFile << "void "<< class_name << "_kernel(" ;
-  for(auto i=writevars.begin();i!=writevars.end();) {
-    outputFile << typetable[*i]<< " *" << vnames[*i] ;
-    ++i ;
-    if(i!=writevars.end())
-      outputFile << "," ;
+  if(rule_type == "apply") {
+    std::stringstream ss ;
+    int linecount = compute_line_no ;
+
+    ss << "loci_reduction_t _reduce_op_ ;" ;
+    linecount = compute_line_no ;
+    AST_type::ASTP reduce_op_decl = parseDeclaration(
+      ss, linecount, filename, typemap
+    ) ;
+
+    ss.str("") ;
+    ss.clear() ;
+    ss << "value_t _local_ = _reduce_op_.identity() ;" ;
+    linecount = compute_line_no ;
+    AST_type::ASTP local_value_decl = parseDeclaration(
+      ss, linecount, filename, typemap
+    ) ;
+
+    ss.str("") ;
+    ss.clear() ;
+    ss << "return _local_ ;" ;
+    linecount = compute_line_no ;
+    AST_type::ASTP return_local_value = parseSpecialControlStatement(
+      ss, linecount, filename, typemap
+    ) ;
+
+    bigblock->elements.insert(bigblock->elements.begin(), local_value_decl) ;
+    bigblock->elements.insert(bigblock->elements.begin(), reduce_op_decl) ;
+    bigblock->elements.insert(bigblock->elements.end(), return_local_value) ;
+
+    AST_editJoin edit_join ;
+    ap->accept(edit_join) ;
   }
-  if(readvars!=EMPTY)
-    outputFile << "," ;
-  for(auto i=readvars.begin();i!=readvars.end();) {
-    outputFile << "const " << typetable[*i] << " *" << vnames[*i] ;
-    ++i ;
-    if(i!=readvars.end())
-      outputFile << "," ;
+
+  //AST_printObjectTree treeout(cerr) ;
+  //ap->accept(treeout) ;
+
+  variableSet outs = output ;
+  for(auto ipi=inplace.begin();ipi!=inplace.end();++ipi) {
+    outs -= ipi->first ;
+    outs += ipi->second ;
   }
-  outputFile << ", int _start_, int _end_, int _blksz_)" << endl ;
+  variableSet ins = input ;
+  ins -= outs ;
 
-  open->accept(printer) ;
+  map<variable,string> typetable ;
+  map<variable,string> ctypetable ;
+  map<variable,string> cargtable ;
+  for(auto vi=ins.begin();vi!=ins.end();++vi) {
+    auto mi = lookupVarType(*vi) ;
+    if(!checkTypeValid(mi)) {
+      cerr << "unknown type for variable " << *vi << endl ;
+      throw parseError("untyped Loci variable") ;
+    }
 
-  if(!prettyOutput)
-    outputFile << endl << "#line " << printer.lineno  << endl ;
-  outputFile << "   int _e_ = _start_+blockIdx.x*_blksz_+threadIdx.x ;" <<endl;
-  if(!prettyOutput)
-    outputFile << "#line " << printer.lineno  << endl ;
-  outputFile << "   if(_e_ <= _end_) {" << endl ;
-  if(!prettyOutput)
-    outputFile <<  "#line " << printer.lineno << endl  ;
+    if(mi->second.container != "param" &&
+       mi->second.container != "Map" &&
+       mi->second.container != "MapVec" &&
+       mi->second.container != "store" &&
+       mi->second.container != "storeVec" &&
+       mi->second.container != "storeMat" &&
+       mi->second.container != "multiStore") {
+       cerr << "unknown container type '" << mi->second.container
+            << "' for variable " << *vi << endl ;
+       throw parseError("unsupported Loci container") ;
+    }
+
+    ctypetable[*vi] = mi->second.container ;
+
+    if(mi->second.container == "Map") {
+      typetable[*vi] = "int" ;
+      cargtable[*vi] = "" ;
+    } else if(mi->second.container == "MapVec") {
+      string scratch = mi->second.container_args ;
+      string::size_type start = scratch.find('<') ;
+      string::size_type end = scratch.rfind('>') ;
+      if(start != string::npos && end != string::npos && start+1 < end) {
+        string arg = scratch.substr(start+1, end-start-1) ;
+        typetable[*vi] = string("Array<Entity,") + arg + ">" ;
+        cargtable[*vi] = arg ;
+      } else {
+        cerr << "unexpected loci variable type!" << endl ;
+      }
+    } else {
+      string scratch = mi->second.container_args ;
+      string::size_type start = scratch.find('<') ;
+      string::size_type end = scratch.rfind('>') ;
+      if(start != string::npos && end != string::npos && start+1 < end) {
+        string arg = scratch.substr(start+1, end-start-1) ;
+        typetable[*vi] = arg ;
+        cargtable[*vi] = arg ;
+      } else {
+        cerr << "unexpected loci variable type!" << endl ;
+      }
+    }
+  }
+
+  for(auto vi=outs.begin();vi!=outs.end();++vi) {
+    auto mi = lookupVarType(*vi) ;
+    if(!checkTypeValid(mi)) {
+      cerr << "unknown type for variable " << *vi << endl ;
+      throw parseError("untyped Loci variable") ;
+    }
+
+    if(mi->second.container != "param" &&
+       mi->second.container != "Map" &&
+       mi->second.container != "MapVec" &&
+       mi->second.container != "store" &&
+       mi->second.container != "storeVec" &&
+       mi->second.container != "storeMat" &&
+       mi->second.container != "multiStore") {
+       cerr << "unknown container type '" << mi->second.container
+            << "' for variable " << *vi << endl ;
+       throw parseError("unsupported Loci container") ;
+    }
+
+    ctypetable[*vi] = mi->second.container ;
+
+    if(mi->second.container == "Map") {
+      typetable[*vi] = "int" ;
+      cargtable[*vi] = "" ;
+    } else if(mi->second.container == "MapVec") {
+      string scratch = mi->second.container_args ;
+      string::size_type start = scratch.find('<') ;
+      string::size_type end = scratch.rfind('>') ;
+      if(start != string::npos && end != string::npos && start+1 < end) {
+        string arg = scratch.substr(start+1, end-start-1) ;
+        typetable[*vi] = string("Array<Entity,") + arg + ">" ;
+        cargtable[*vi] = arg ;
+      } else {
+        cerr << "unexpected loci variable type!" << endl ;
+      }
+    } else {
+      string scratch = mi->second.container_args ;
+      string::size_type start = scratch.find('<') ;
+      string::size_type end = scratch.rfind('>') ;
+      if(start != string::npos && end != string::npos && start+1 < end) {
+        string arg = scratch.substr(start+1, end-start-1) ;
+        typetable[*vi] = arg ;
+        cargtable[*vi] = arg ;
+      } else {
+        cerr << "unexpected loci variable type!" << endl ;
+      }
+    }
+  }
+
+  for(auto ipi=inplace.begin();ipi!=inplace.end();++ipi) {
+    all_vars -= ipi->first ;
+  }
+
+  if(constraint != "") {
+    // Check to see that the constraint is typed
+    exprP C = expression::create(constraint) ;
+    set<vmap_info> Cdigest ;
+    fill_descriptors(Cdigest,collect_associative_op(C,OP_COMMA)) ;
+    variableSet constraint_vars ;
+    for(auto i=Cdigest.begin();i!=Cdigest.end();++i) {
+      for(size_t j=0;j<i->mapping.size();++j)
+	constraint_vars += i->mapping[j] ;
+      constraint_vars += i->var ;
+    }
+
+    for(auto vi=constraint_vars.begin();vi!=constraint_vars.end();++vi) {
+      auto mi = lookupVarType(*vi) ;
+
+      if(!checkTypeValid(mi)) {
+        cerr << filename << ':' << line_no
+             << ":0: warning: type of constraint variable '"
+             << *vi << "' not found!"  << endl  ;
+      }
+    }
+  }
+
+  if(comments.size() == 0) {
+    // check to see if there is a javadoc compatible comment before
+    if(comment.size() > 0) {
+      comments.push_back(comment) ;
+      comments_line_no.push_back(rule_type_line_no) ;
+    } else if(rule_type=="optional" || rule_type=="default") {
+      auto mi = lookupVarType(*output.begin()) ;
+      comments.push_back(mi->second.comment) ;
+      comments_line_no.push_back(mi->second.lineno) ;
+    }
+  }
+
+  bool sized_outputs = false;
+  variableSet outsmi = outs ;
+  outsmi -= input ;
+  for(auto vi=outsmi.begin();vi!=outsmi.end();++vi) {
+    auto mi = lookupVarType(*vi) ;
+    const string &ot  = mi->second.container ;
+    if(ot == "storeVec" || ot == "storeMat" || ot == "multiStore")
+      sized_outputs = true ;
+  }
+  if(sized_outputs)
+    throw parseError("cuda rules currently incompatible with storeVec, storeMat or multiStore types") ;
 
   AST_editLociVariableAccess2 AST_editor(vnames, ctypetable) ;
   ap->accept(AST_editor) ;
 
-  ap->accept(printer) ;
-
-  close->accept(printer) ;
-  close->accept(printer) ;
-  outputFile << endl ;
-  syncFile(outputFile) ;
-  outputFile << "void " << class_name << "::compute(const Loci::sequence &seq) {" << endl ;
-  syncFile(outputFile) ;
-  outputFile << "  const int NTHREADS=64 ;" << endl ;
-  syncFile(outputFile) ;
-  outputFile << "  const int ni = seq.num_intervals() ;"<< endl ;
-  syncFile(outputFile) ;
-  outputFile << "  for(int i=0;i<ni;++i) {" << endl ;
-  syncFile(outputFile) ;
-  outputFile << "    const Loci::int_type i1 = seq[i].first ;" << endl ;
-  syncFile(outputFile) ;
-  outputFile << "    const Loci::int_type i2 = seq[i].second  ;" << endl ; 
-  syncFile(outputFile) ;
-  outputFile << "    const Loci::int_type start = min(i1,i2) ;" << endl ;
-  syncFile(outputFile) ;
-  outputFile << "    const Loci::int_type stop = max(i1,i2) ;" << endl ;
-  syncFile(outputFile) ;
-  outputFile << "    const int nblks = (stop-start+NTHREADS)/NTHREADS ;" << endl ;
-  syncFile(outputFile) ;
-
+  string rule_debug_name ;
   if(parseInfo.debug_info > 0) {
     ostringstream oss ;
     for(auto i=targets.begin();i!=targets.end();) {
@@ -2868,50 +3478,323 @@ void parseFile::setup_cudaRule(std::ostream &outputFile, const string &comment,
     oss << bodys ;
     if(constraint!="")
       oss << ",constraint(" << constraint<<")" ;
-    outputFile << "nvtxRangePush(\"" << oss.str() << "\");" << endl ;
-    syncFile(outputFile) ;
-  }
-  outputFile <<"    " <<class_name << "_kernel<<<nblks,NTHREADS,0,Loci::getGPUStream()>>>(";
-  for(auto i=writevars.begin();i!=writevars.end();) {
-    outputFile << vnames[*i] << ".ptr()";
-    ++i ;
-    if(i!=writevars.end())
-      outputFile << "," ;
-  }
-  if(readvars!=EMPTY)
-    outputFile << "," ;
-  for(auto i=readvars.begin();i!=readvars.end();) {
-    outputFile <<vnames[*i]<< ".ptr()" ;
-    ++i ;
-    if(i!=readvars.end())
-      outputFile << "," ;
-  }
-  outputFile << ",start, stop, NTHREADS) ;"  ;
-  if(parseInfo.debug_info > 0) {
-    outputFile << "nvtxRangePop();" ;
-  }
-  outputFile<<endl ;
-  syncFile(outputFile) ;
-  syncFile(outputFile) ;
-  outputFile << "}" << endl; // end of for loop
-  syncFile(outputFile) ;
-  outputFile << "}" << endl; // end of compute method
-  syncFile(outputFile) ;
-  
-  if(!prettyOutput)
-    outputFile << "Loci::register_rule<"<<class_name<<"> register_"<<class_name
-               << " ;" << endl ;
-  else
-    outputFile << "register_rule<"<<class_name<<"> register_"<<class_name
-               << " ;" << endl ;
-  syncFile(outputFile) ;
 
-  //  if(!prettyOutput) {
-  //    outputFile << "}" << endl ;
-  //    syncFile(outputFile) ;
-  //  }
+    rule_debug_name = oss.str() ;
+  }
 
-  
+  TemplateContext rule_ctx ;
+
+  rule_ctx.set("type", rule_type) ;
+  rule_ctx.set("class", class_name) ;
+  rule_ctx.set("file", filename) ;
+  rule_ctx.set("line_number", rule_type_line_no) ;
+  rule_ctx.set("debug_name", rule_debug_name) ;
+
+  {
+    TemplateContext signature_ctx ;
+    signature_ctx.set("line_number", signature_line_no) ;
+    rule_ctx.set_object("signature", signature_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> input_stores_ctx ;
+    for(auto vi = ins.begin(); vi != ins.end(); ++vi) {
+      TemplateContext ctx ;
+      ctx.set("name", (*vi).str()) ;
+      ctx.set("vname", vnames[*vi]) ;
+      ctx.set("ctype", ctypetable[*vi]) ;
+      ctx.set("vtype", typetable[*vi]) ;
+      ctx.set("carg", cargtable[*vi]) ;
+      input_stores_ctx.push_back(ctx) ;
+    }
+    rule_ctx.set_array("input_stores", input_stores_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> output_stores_ctx ;
+    for(auto vi = outs.begin(); vi != outs.end(); ++vi) {
+      TemplateContext ctx ;
+      ctx.set("name", (*vi).str()) ;
+      ctx.set("vname", vnames[*vi]) ;
+      ctx.set("ctype", ctypetable[*vi]) ;
+      ctx.set("vtype", typetable[*vi]) ;
+      ctx.set("carg", cargtable[*vi]) ;
+      output_stores_ctx.push_back(ctx) ;
+    }
+    rule_ctx.set_array("output_stores", output_stores_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> name_stores_ctx ;
+    for(auto vi = all_vars.begin(); vi != all_vars.end(); ++vi) {
+      TemplateContext ctx ;
+      ctx.set("name", (*vi).str()) ;
+      ctx.set("vname", vnames[*vi]) ;
+
+      auto mi = access_map.find(lookupVarType(*vi)->second.getFileLoc()) ;
+      if(mi != access_map.end()) {
+        ctx.set("has_info_id", 1) ;
+        ctx.set("info_id", mi->second) ;
+      } else {
+        ctx.set("has_info_id", 0) ;
+      }
+
+      name_stores_ctx.push_back(ctx) ;
+    }
+    rule_ctx.set_array("name_stores", name_stores_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> inputs_ctx ;
+    for(auto i = sources.begin(); i != sources.end(); ++i) {
+      ostringstream ss ;
+      if(i->mapping.size() > 1) {
+        ss << '(' ;
+      }
+      for(auto vi = i->mapping.begin(); vi != i->mapping.end(); ++vi) {
+        if(vi != i->mapping.begin()) {
+          ss << ',' ;
+        }
+        ss << *vi ;
+      }
+      if(i->mapping.size() > 1) {
+        ss << ')' ;
+      }
+      if(i->mapping.size() > 0) {
+        ss << "->" ;
+      }
+
+      if(i->var.size() > 1) {
+        ss << '(' ;
+      }
+      for(auto vi = i->var.begin(); vi != i->var.end(); ++vi) {
+        if(vi != i->var.begin()) {
+          ss << ',' ;
+        }
+        ss << *vi ;
+      }
+      if(i->var.size() > 1) {
+        ss << ')' ;
+      }
+      TemplateContext ctx ;
+      ctx.set("str", ss.str()) ;
+      inputs_ctx.push_back(ctx) ;
+    }
+    rule_ctx.set_array("inputs", inputs_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> outputs_ctx ;
+    for(auto i = targets.begin(); i != targets.end(); ++i) {
+      ostringstream ss ;
+      if(i->mapping.size() > 1) {
+        ss << '(' ;
+      }
+      for(auto vi = i->mapping.begin(); vi != i->mapping.end(); ++vi) {
+        if(vi != i->mapping.begin()) {
+          ss << ',' ;
+        }
+        ss << *vi ;
+      }
+      if(i->mapping.size() > 1) {
+        ss << ')' ;
+      }
+      if(i->mapping.size() > 0) {
+        ss << "->" ;
+      }
+
+      if(i->var.size() > 1) {
+        ss << '(' ;
+      }
+      for(auto vi = i->var.begin(); vi != i->var.end(); ++vi) {
+        if(vi != i->var.begin()) {
+          ss << ',' ;
+        }
+
+        auto ipi = inplace.begin() ;
+        while(ipi != inplace.end()) {
+          if(ipi->first == *vi) break ;
+          ++ipi ;
+        }
+        if(ipi != inplace.end()) {
+          if(i->mapping.size() == 0 || i->var.size() > 1) {
+            ss << ipi->first << '=' << ipi->second ;
+          } else {
+            ss << '(' << ipi->first << '=' << ipi->second << ')' ;
+          }
+        } else {
+          ss << *vi ;
+        }
+      }
+      if(i->var.size() > 1) {
+        ss << ')' ;
+      }
+
+      TemplateContext ctx ;
+      ctx.set("str", ss.str()) ;
+      outputs_ctx.push_back(ctx) ;
+    }
+
+    rule_ctx.set_array("outputs", outputs_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> constraint_spec_ctx ;
+    for(auto i = constraints.begin(); i != constraints.end(); ++i) {
+      ostringstream ss ;
+      if(i->mapping.size() > 1) {
+        ss << '(' ;
+      }
+      for(auto vi = i->mapping.begin(); vi != i->mapping.end(); ++vi) {
+        if(vi != i->mapping.begin()) {
+          ss << ',' ;
+        }
+        ss << *vi ;
+      }
+      if(i->mapping.size() > 1) {
+        ss << ')' ;
+      }
+      if(i->mapping.size() > 0) {
+        ss << "->" ;
+      }
+
+      if(i->var.size() > 1) {
+        ss << '(' ;
+      }
+      for(auto vi = i->var.begin(); vi != i->var.end(); ++vi) {
+        if(vi != i->var.begin()) {
+          ss << "," ;
+        }
+        ss << *vi ;
+      }
+      if(i->var.size() > 1) {
+        ss << ')' ;
+      }
+
+      TemplateContext ctx ;
+      ctx.set("str", ss.str()) ;
+      constraint_spec_ctx.push_back(ctx) ;
+    }
+
+    TemplateContext constraints_ctx ;
+    constraints_ctx.set_array("spec", constraint_spec_ctx) ;
+    constraints_ctx.set("line_number", constraint_line_no) ;
+    rule_ctx.set_object("constraints", constraints_ctx) ;
+  }
+
+  {
+    TemplateContext parametric_ctx ;
+    if(parametric_var != "") {
+      rule_ctx.set("is_parametric", 1) ;
+      parametric_ctx.set("spec", parametric_var) ;
+      parametric_ctx.set("line_number", parametric_line_no) ;
+    } else {
+      rule_ctx.set("is_parametric", 0) ;
+    }
+    rule_ctx.set_object("parametric", parametric_ctx) ;
+  }
+
+  {
+    TemplateContext specialized_ctx ;
+    if(is_specialized) {
+      specialized_ctx.set("line_number", specialized_line_no) ;
+    }
+    rule_ctx.set("is_specialized", is_specialized) ;
+    rule_ctx.set_object("specialized", specialized_ctx) ;
+  }
+
+  {
+    TemplateContext conditional_ctx ;
+
+    if(conditional != "") {
+      rule_ctx.set("is_conditional", 1) ;
+      conditional_ctx.set("spec", conditional) ;
+      conditional_ctx.set("line_number", conditional_line_no) ;
+    } else {
+      rule_ctx.set("is_conditional", 0) ;
+    }
+
+    rule_ctx.set_object("conditional", conditional_ctx) ;
+  }
+
+  {
+    vector<TemplateContext> comments_ctx ;
+
+    size_t size = comments.size() ;
+    for(size_t i = 0; i < size; ++i) {
+      TemplateContext ctx ;
+      ctx.set("str", comments[i]) ;
+      ctx.set("line_number", comments_line_no[i]) ;
+      comments_ctx.push_back(ctx) ;
+    }
+
+    rule_ctx.set_array("comments", comments_ctx) ;
+  }
+
+  if(rule_type == "pointwise") {
+    rule_ctx.set("is_pointwise", 1) ;
+    rule_ctx.set("is_unit", 0) ;
+    rule_ctx.set("is_apply", 0) ;
+  } else if(rule_type == "unit") {
+    variable unit_var = *(output.begin()) ;
+
+    TemplateContext unit_ctx ;
+    unit_ctx.set("target_name", unit_var.str()) ;
+    unit_ctx.set("target_vname", vnames[unit_var]) ;
+    unit_ctx.set("container", ctypetable[unit_var]) ;
+    unit_ctx.set("container_args", cargtable[unit_var]) ;
+    unit_ctx.set("is_param", paramUnit) ;
+
+    rule_ctx.set("is_pointwise", 0) ;
+    rule_ctx.set("is_unit", 1) ;
+    rule_ctx.set("is_apply", 0) ;
+    rule_ctx.set_object("unit", unit_ctx) ;
+  } else if(rule_type == "apply") {
+    variable apply_var = *(output.begin()) ;
+
+    TemplateContext apply_ctx ;
+    apply_ctx.set("target_name", apply_var.str()) ;
+    apply_ctx.set("target_vname", vnames[apply_var]) ;
+    apply_ctx.set("container", ctypetable[apply_var]) ;
+    apply_ctx.set("container_args", cargtable[apply_var]) ;
+    apply_ctx.set("operator", apply_op.str()) ;
+    apply_ctx.set("line_number", apply_op_line_no) ;
+    apply_ctx.set("is_singleton", singletonApply) ;
+
+    rule_ctx.set("is_pointwise", 0) ;
+    rule_ctx.set("is_unit", 0) ;
+    rule_ctx.set("is_apply", 1) ;
+    rule_ctx.set_object("apply", apply_ctx) ;
+  }
+
+  {
+    ostringstream compute_ss ;
+    AST_simplePrint printer(compute_ss, -1, prettyOutput) ;
+    ap->accept(printer) ;
+
+    TemplateContext compute_ctx ;
+    compute_ctx.set("line_number", compute_line_no) ;
+    compute_ctx.set("spec", compute_ss.str()) ;
+    rule_ctx.set_object("compute", compute_ctx) ;
+  }
+
+  TemplateContext root_ctx ;
+  root_ctx.set("pln", !prettyOutput) ;
+  root_ctx.set("debug_info", parseInfo.debug_info) ;
+  root_ctx.set_object("rule", rule_ctx) ;
+
+  TemplateEngine engine ;
+  std::string rule_text = "" ;
+  try {
+    rule_text = engine.render(cuda_rule_template, root_ctx) ;
+  } catch(std::runtime_error const & error) {
+    ostringstream ss ;
+    string const message = error.what() ;
+    ss << "error rendering rule: " << error.what() ;
+    throw parseError(ss.str()) ;
+  }
+  outputFile << rule_text << endl ;
+
   if(!use_prelude && sized_outputs && (rule_type != "apply")) 
     throw parseError("need prelude to size output type!") ;
 }
@@ -2966,7 +3849,7 @@ void parseFile::setup_Rule(std::ostream &outputFile, const string &comment,
       nestedparenstuff con ;
       con.get(is) ;
       if(parametric_var != "") {
-        throw parseError("syntax error: canot specify more than one parametric variable") ;
+        throw parseError("syntax error: cannot specify more than one parametric variable") ;
       }
         
       parametric_var = con.str() ;
@@ -2975,7 +3858,7 @@ void parseFile::setup_Rule(std::ostream &outputFile, const string &comment,
       nestedparenstuff con ;
       con.get(is) ;
       if(conditional != "") {
-        throw parseError("syntax error: canot specify more than one conditional variable") ;
+        throw parseError("syntax error: cannot specify more than one conditional variable") ;
       }
       conditional = con.str() ;
       line_no += con.num_lines() ;

--- a/src/lpp/parseAST.cc
+++ b/src/lpp/parseAST.cc
@@ -163,6 +163,230 @@ string OPtoString(AST_type::elementType val) {
   return string("/*error*/") ;
 }
 
+std::string NTtoString(AST_type::elementType val) {
+  switch(val) {
+  case OP_SCOPE: return "OP_SCOPE" ;
+  case OP_AT: return "OP_AT" ;
+  case OP_DOT: return "OP_DOT" ;
+  case OP_ARROW: return "OP_ARROW" ;
+  case OP_ARRAY: return "OP_ARRAY" ;
+  case OP_TIMES: return "OP_TIMES" ;
+  case OP_DIVIDE: return "OP_DIVIDE" ;
+  case OP_MODULUS: return "OP_MODULUS" ;
+  case OP_PLUS: return "OP_PLUS" ;
+  case OP_MINUS: return "OP_MINUS" ;
+  case OP_SHIFT_RIGHT: return "OP_SHIFT_RIGHT" ;
+  case OP_SHIFT_LEFT: return "OP_SHIFT_LEFT" ;
+  case OP_LT: return "OP_LT" ;
+  case OP_GT: return "OP_GT" ;
+  case OP_GE: return "OP_GE" ;
+  case OP_LE: return "OP_LE" ;
+  case OP_EQUAL: return "OP_EQUAL" ;
+  case OP_NOT_EQUAL: return "OP_NOT_EQUAL" ;
+  case OP_AND: return "OP_AND" ;
+  case OP_EXOR: return "OP_EXOR" ;
+  case OP_OR: return "OP_OR" ;
+  case OP_LOGICAL_AND: return "OP_LOGICAL_AND" ;
+  case OP_LOGICAL_OR: return "OP_LOGICAL_OR" ;
+  case OP_TERNARY: return "OP_TERNARY" ;
+  case OP_ASSIGN: return "OP_ASSIGN" ;
+  case OP_TIMES_ASSIGN: return "OP_TIMES_ASSIGN" ;
+  case OP_DIVIDE_ASSIGN: return "OP_DIVIDE_ASSIGN" ;
+  case OP_MODULUS_ASSIGN: return "OP_MODULUS_ASSIGN" ;
+  case OP_PLUS_ASSIGN: return "OP_PLUS_ASSIGN" ;
+  case OP_MINUS_ASSIGN: return "OP_MINUS_ASSIGN" ;
+  case OP_SHIFT_LEFT_ASSIGN: return "OP_SHIFT_LEFT_ASSIGN" ;
+  case OP_SHIFT_RIGHT_ASSIGN: return "OP_SHIFT_RIGHT_ASSIGN" ;
+  case OP_AND_ASSIGN: return "OP_AND_ASSIGN" ;
+  case OP_OR_ASSIGN: return "OP_OR_ASSIGN" ;
+  case OP_EXOR_ASSIGN: return "OP_EXOR_ASSIGN" ;
+  case OP_COMMA: return "OP_COMMA" ;
+  case OP_COLON: return "OP_COLON" ;
+  case OP_SEMICOLON: return "OP_SEMICOLON" ;
+  case OP_NIL: return "OP_NIL" ;
+  case OP_INCREMENT: return "OP_INCREMENT" ;
+  case OP_DECREMENT: return "OP_DECREMENT" ;
+  case OP_POSTINCREMENT: return "OP_POSTINCREMENT" ;
+  case OP_POSTDECREMENT: return "OP_POSTDECREMENT" ;
+  case OP_COMMENT: return "OP_COMMENT" ;
+  case OP_BRACEBLOCK: return "OP_BRACEBLOCK" ;
+  case OP_NAME: return "OP_NAME" ;
+  case OP_FUNC: return "OP_FUNC" ;
+  case OP_NAME_BRACE: return "OP_NAME_BRACE" ;
+  case OP_FUNC_BRACE: return "OP_FUNC_BRACE" ;
+  case OP_TEMPLATE: return "OP_TEMPLATE" ;
+  case OP_TEMPLATE_FUNC: return "OP_TEMPLATE_FUNC" ;
+  case OP_STRING: return "OP_STRING" ;
+  case OP_NUMBER: return "OP_NUMBER" ;
+  case OP_ERROR: return "OP_ERROR" ;
+  case OP_UNARY_PLUS: return "OP_UNARY_PLUS" ;
+  case OP_UNARY_MINUS: return "OP_UNARY_MINUS" ;
+  case OP_NOT: return "OP_NOT" ;
+  case OP_TILDE: return "OP_TILDE" ;
+  case OP_AMPERSAND: return "OP_AMPERSAND" ;
+  case OP_DOLLAR: return "OP_DOLLAR" ;
+  case OP_STAR: return "OP_STAR" ;
+  case OP_CAST: return "OP_CAST" ;
+  case OP_TEMPLATE_CAST: return "OP_TEMPLATE_CAST" ;
+  case OP_GROUP: return "OP_GROUP" ;
+  case OP_GROUP_ERROR: return "OP_GROUP_ERROR";
+  case OP_OPENPAREN: return "OP_OPENPAREN" ;
+  case OP_CLOSEPAREN: return "OP_CLOSEPAREN" ;
+  case OP_OPENBRACKET: return "OP_OPENBRACKET" ;
+  case OP_CLOSEBRACKET: return "OP_CLOSEBRACKET" ;
+  case OP_OPENBRACE: return "OP_OPENBRACE" ;
+  case OP_CLOSEBRACE: return "OP_CLOSEBRACE" ;
+  case OP_LOCI_DIRECTIVE: return "OP_LOCI_DIRECTIVE" ;
+  case OP_LOCI_VARIABLE: return "OP_LOCI_VARIABLE" ;
+  case OP_LOCI_CONTAINER: return "OP_LOCI_CONTAINER" ;
+  case OP_TERM: return "OP_TERM" ;
+  case OP_SPECIAL: return "OP_SPECIAL" ;
+  case TK_BRACEBLOCK: return "TK_BRACEBLOCK" ;
+  case TK_SCOPE: return "TK_SCOPE" ;
+  case TK_AT: return "TK_AT" ;
+  case TK_ARROW: return "TK_ARROW" ;
+  case TK_TIMES: return "TK_TIMES" ;
+  case TK_DIVIDE: return "TK_DIVIDE" ;
+  case TK_MODULUS: return "TK_MODULUS" ;
+  case TK_PLUS: return "TK_PLUS" ;
+  case TK_MINUS: return "TK_MINUS" ;
+  case TK_SHIFT_RIGHT: return "TK_SHIFT_RIGHT" ;
+  case TK_SHIFT_LEFT: return "TK_SHIFT_LEFT" ;
+  case TK_LT: return "TK_LT" ;
+  case TK_GT: return "TK_GT" ;
+  case TK_GE: return "TK_GE" ;
+  case TK_LE: return "TK_LE" ;
+  case TK_EQUAL: return "TK_EQUAL" ;
+  case TK_NOT_EQUAL: return "TK_NOT_EQUAL" ;
+  case TK_AND: return "TK_AND" ;
+  case TK_EXOR: return "TK_EXOR" ;
+  case TK_OR: return "TK_OR" ;
+  case TK_LOGICAL_AND: return "TK_LOGICAL_AND" ;
+  case TK_LOGICAL_OR: return "TK_LOGICAL_OR" ;
+  case TK_ASSIGN: return "TK_ASSIGN" ;
+  case TK_TIMES_ASSIGN: return "TK_TIMES_ASSIGN" ;
+  case TK_DIVIDE_ASSIGN: return "TK_DIVIDE_ASSIGN" ;
+  case TK_MODULUS_ASSIGN: return "TK_MODULUS_ASSIGN" ;
+  case TK_PLUS_ASSIGN: return "TK_PLUS_ASSIGN" ;
+  case TK_MINUS_ASSIGN: return "TK_MINUS_ASSIGN" ;
+  case TK_SHIFT_LEFT_ASSIGN: return "TK_SHIFT_LEFT_ASSIGN" ;
+  case TK_SHIFT_RIGHT_ASSIGN: return "TK_SHIFT_RIGHT_ASSIGN" ;
+  case TK_AND_ASSIGN: return "TK_AND_ASSIGN" ;
+  case TK_OR_ASSIGN: return "TK_OR_ASSIGN" ;
+  case TK_EXOR_ASSIGN: return "TK_EXOR_ASSIGN" ;
+  case TK_COMMA: return "TK_COMMA" ;
+  case TK_DOT: return "TK_DOT" ;
+  case TK_COLON: return "TK_COLON" ;
+  case TK_SEMICOLON: return "TK_SEMICOLON" ;
+  case TK_NIL: return "TK_NIL" ;
+  case TK_INCREMENT: return "TK_INCREMENT" ;
+  case TK_DECREMENT: return "TK_DECREMENT" ;
+  case TK_COMMENT: return "TK_COMMENT" ;
+  case TK_MACRO: return "TK_MACRO" ;
+  case TK_NAME: return "TK_NAME" ;
+  case TK_STRING: return "TK_STRING" ;
+  case TK_NUMBER: return "TK_NUMBER" ;
+  case TK_ERROR: return "TK_ERROR" ;
+  case TK_UNARY_PLUS: return "TK_UNARY_PLUS" ;
+  case TK_UNARY_MINUS: return "TK_UNARY_MINUS" ;
+  case TK_NOT: return "TK_NOT" ;
+  case TK_TILDE: return "TK_TILDE" ;
+  case TK_QUESTION: return "TK_QUESTION" ;
+  case TK_AMPERSAND: return "TK_AMPERSAND" ;
+  case TK_STAR: return "TK_STAR" ;
+  case TK_OPENPAREN: return "TK_OPENPAREN" ;
+  case TK_CLOSEPAREN: return "TK_CLOSEPAREN" ;
+  case TK_OPENBRACKET: return "TK_OPENBRACKET" ;
+  case TK_CLOSEBRACKET: return "TK_CLOSEBRACKET" ;
+  case TK_OPENBRACE: return "TK_OPENBRACE" ;
+  case TK_CLOSEBRACE: return "TK_CLOSEBRACE" ;
+  case TK_OPENTEMPLATE: return "TK_OPENTEMPLATE" ;
+  case TK_CLOSETEMPLATE: return "TK_CLOSETEMPLATE" ;
+  case TK_LOCI_DIRECTIVE: return "TK_LOCI_DIRECTIVE" ;
+  case TK_LOCI_VARIABLE: return "TK_LOCI_VARIABLE" ;
+  case TK_LOCI_CONTAINER: return "TK_LOCI_CONTAINER" ;
+  case TK_ALIGNAS: return "TK_ALIGNAS" ;
+  case TK_ALIGNOF: return "TK_ALIGNOF" ;
+  case TK_ASM: return "TK_ASM" ;
+  case TK_BOOL: return "TK_BOOL" ;
+  case TK_FALSE: return "TK_FALSE" ;
+  case TK_TRUE: return "TK_TRUE" ;
+  case TK_CHAR: return "TK_CHAR" ;
+  case TK_INT: return "TK_INT" ;
+  case TK_LONG: return "TK_LONG" ;
+  case TK_SHORT: return "TK_SHORT" ;
+  case TK_SIGNED: return "TK_SIGNED" ;
+  case TK_UNSIGNED: return "TK_UNSIGNED" ;
+  case TK_DOUBLE: return "TK_DOUBLE" ;
+  case TK_FLOAT: return "TK_FLOAT" ;
+  case TK_ENUM: return "TK_ENUM" ;
+  case TK_MUTABLE: return "TK_MUTABLE" ;
+  case TK_CONST: return "TK_CONST" ;
+  case TK_STATIC: return "TK_STATIC" ;
+  case TK_VOLATILE: return "TK_VOLATILE" ;
+  case TK_AUTO: return "TK_AUTO" ;
+  case TK_REGISTER: return "TK_REGISTER" ;
+  case TK_EXPORT: return "TK_EXPORT" ;
+  case TK_EXTERN: return "TK_EXTERN" ;
+  case TK_INLINE: return "TK_INLINE" ;
+  case TK_NAMESPACE: return "TK_NAMESPACE" ;
+  case TK_USING: return "TK_USING" ;
+  case TK_EXPLICIT: return "TK_EXPLICIT" ;
+  case TK_CONST_CAST: return "TK_CONST_CAST" ;
+  case TK_DYNAMIC_CAST: return "TK_DYNAMIC_CAST" ;
+  case TK_STATIC_CAST: return "TK_STATIC_CAST" ;
+  case TK_REINTERPRET_CAST: return "TK_REINTERPRET_CAST" ;
+  case TK_OPERATOR: return "TK_OPERATOR" ;
+  case TK_PROTECTED: return "TK_PROTECTED" ;
+  case TK_NOEXCEPT: return "TK_NOEXCEPT" ;
+  case TK_NULLPTR: return "TK_NULLPTR" ;
+  case TK_RETURN: return "TK_RETURN" ;
+  case TK_SIZEOF: return "TK_SIZEOF" ;
+  case TK_THIS: return "TK_THIS" ;
+  case TK_TYPEID: return "TK_TYPEID" ;
+  case TK_SWITCH: return "TK_SWITCH" ;
+  case TK_CASE: return "TK_CASE" ;
+  case TK_BREAK: return "TK_BREAK" ;
+  case TK_DEFAULT: return "TK_DEFAULT" ;
+  case TK_FOR: return "TK_FOR" ;
+  case TK_DO: return "TK_DO" ;
+  case TK_WHILE: return "TK_WHILE" ;
+  case TK_CONTINUE: return "TK_CONTINUE" ;
+  case TK_CLASS: return "TK_CLASS" ;
+  case TK_STRUCT: return "TK_STRUCT" ;
+  case TK_PUBLIC: return "TK_PUBLIC" ;
+  case TK_PRIVATE: return "TK_PRIVATE" ;
+  case TK_FRIEND: return "TK_FRIEND" ;
+  case TK_UNION: return "TK_UNION" ;
+  case TK_TYPENAME: return "TK_TYPENAME" ;
+  case TK_TEMPLATE: return "TK_TEMPLATE" ;
+  case TK_TYPEDEF: return "TK_TYPEDEF" ;
+  case TK_VIRTUAL: return "TK_VIRTUAL" ;
+  case TK_VOID: return "TK_VOID" ;
+  case TK_TRY: return "TK_TRY" ;
+  case TK_CATCH: return "TK_CATCH" ;
+  case TK_THROW: return "TK_THROW" ;
+  case TK_IF: return "TK_IF" ;
+  case TK_ELSE: return "TK_ELSE" ;
+  case TK_GOTO: return "TK_GOTO" ;
+  case TK_NEW: return "TK_NEW" ;
+  case TK_DELETE: return "TK_DELETE" ;
+  case ND_SYNTAXERR: return "ND_SYNTAXERR" ;
+  case ND_CTRL_IF: return "ND_CTRL_IF" ;
+  case ND_CTRL_FOR: return "ND_CTRL_FOR" ;
+  case ND_CTRL_WHILE: return "ND_CTRL_WHILE" ;
+  case ND_CTRL_DO: return "ND_CTRL_DO" ;
+  case ND_CTRL_SWITCH: return "ND_CTRL_SWITCH" ;
+  case ND_SIMPLE_STATEMENT: return "ND_SIMPLE_STATEMENT" ;
+  case ND_BLOCK: return "ND_BLOCK" ;
+  case ND_DECL: return "ND_DECL" ;
+  case ND_TYPE_SPEC: return "ND_TYPE_SPEC" ;
+  case ND_TERMINAL: return "ND_TERMINAL" ;
+  case TK_SENTINEL: return "TK_SENTINEL" ;
+  }
+  return "UNKNOWN" ;
+}
+
 // Parse a type specification used in either a type declaration statement
 // or a template argument.
 AST_type::ASTP parseTypeSpecifier(std::istream &is, int &linecount,
@@ -2754,6 +2978,30 @@ void AST_simplePrint::visit(AST_Token &s) {
       out << endl << '#' << s.text << endl ;
     } else
       out <<s.text << ' ' ;
+  }
+}
+
+void AST_editJoin::visit(AST_SimpleStatement & s) {
+  if(ASTEqual(s.exp, OP_FUNC)) {
+    CPTR<AST_exprOper> func(s.exp) ;
+    if(func->terms.size() == 2) {
+      if(ASTEqual(func->terms[0], TK_NAME)) {
+        CPTR<AST_Token> func_name(func->terms[0]) ;
+        if(func_name->text == "join") {
+          if(ASTEqual(func->terms[1], OP_COMMA)) {
+            CPTR<AST_exprOper> comma(func->terms[1]) ;
+            if(comma->terms.size() == 2) {
+              if(ASTEqual(comma->terms[0], TK_LOCI_VARIABLE)) {
+                CPTR<AST_Token> var(comma->terms[0]) ;
+                func_name->text = "_reduce_op_" ;
+                var->text = "_local_" ;
+                var->nodeType = TK_NAME ;
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/lpp/parseAST.h
+++ b/src/lpp/parseAST.h
@@ -707,6 +707,8 @@ namespace nodeTypes {
 
 extern std::string OPtoString(AST_type::elementType val) ;
 
+extern std::string NTtoString(AST_type::elementType val) ;
+
 class AST_syntaxError: public AST_type {
 public:
   string error ;
@@ -850,6 +852,12 @@ public:
   AST_simplePrint(ostream &s, int line=-1,bool pp=true): out(s),lineno(line),prettyPrint(pp) {}
   virtual void visit(AST_exprOper &)  ;
   virtual void visit(AST_Token &) ;
+} ;
+
+class AST_editJoin : public AST_visitor {
+public:
+  AST_editJoin() { } ;
+  virtual void visit(AST_SimpleStatement &) ;
 } ;
 
 class AST_collectAccessInfo: public AST_visitor {

--- a/src/lpp/template.cc
+++ b/src/lpp/template.cc
@@ -1,0 +1,1036 @@
+//#############################################################################
+//#
+//# Copyright 2008-2025, Mississippi State University
+//#
+//# This file is part of the Loci Framework.
+//#
+//# The Loci Framework is free software: you can redistribute it and/or modify
+//# it under the terms of the Lesser GNU General Public License as published by
+//# the Free Software Foundation, either version 3 of the License, or
+//# (at your option) any later version.
+//#
+//# The Loci Framework is distributed in the hope that it will be useful,
+//# but WITHOUT ANY WARRANTY; without even the implied warranty of
+//# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//# Lesser GNU General Public License for more details.
+//#
+//# You should have received a copy of the Lesser GNU General Public License
+//# along with the Loci Framework.  If not, see <http://www.gnu.org/licenses>
+//#
+//#############################################################################
+
+#include "template.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace Loci {
+
+namespace {
+
+std::string head_segment(std::string_view path) {
+  const auto dot = path.find('.');
+  if (dot == std::string_view::npos) {
+    return std::string(path);
+  }
+  return std::string(path.substr(0, dot));
+}
+
+std::string_view tail_segment(std::string_view path) {
+  const auto dot = path.find('.');
+  if (dot == std::string_view::npos) {
+    return {};
+  }
+  return path.substr(dot + 1);
+}
+
+std::string lower_copy(std::string_view value) {
+  std::string out(value);
+  std::transform(out.begin(), out.end(), out.begin(),
+         [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return out;
+}
+
+bool is_true_string(std::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+
+  const std::string lower = lower_copy(value);
+  if (lower == "false" || lower == "0" || lower == "no" || lower == "off") {
+    return false;
+  }
+  return true;
+}
+
+std::string trim_copy(const std::string& s) {
+  const auto start = s.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos) {
+    return {};
+  }
+  const auto end = s.find_last_not_of(" \t\r\n");
+  return s.substr(start, end - start + 1);
+}
+
+struct PathRef {
+  bool from_root = false;
+  std::string_view path;
+};
+
+std::string_view trim_leading_path(std::string_view path) {
+  const auto start = path.find_first_not_of(" \t");
+  if (start == std::string_view::npos) {
+    return {};
+  }
+  return path.substr(start);
+}
+
+PathRef parse_path_ref(std::string_view path) {
+  if (path.size() >= 2 && path[0] == ':' && path[1] == ':') {
+    return {true, trim_leading_path(path.substr(2))};
+  }
+  return {false, path};
+}
+
+bool is_path_char(char c) {
+  return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_' || c == '.' || c == '@';
+}
+
+[[noreturn]] void throw_condition_error(const std::string& message) {
+  throw std::runtime_error("Invalid condition expression: " + message);
+}
+
+struct RenderState;
+
+enum class CondTokenKind { Path, And, Or, Not, LParen, RParen, End };
+
+struct CondLexer {
+  std::string_view input;
+  std::size_t pos = 0;
+  CondTokenKind kind = CondTokenKind::End;
+  std::string path;
+
+  explicit CondLexer(std::string_view input) : input(input) {
+    advance();
+  }
+
+  void skip_space() {
+    while (pos < input.size() &&
+       (input[pos] == ' ' || input[pos] == '\t')) {
+      ++pos;
+    }
+  }
+
+  void advance() {
+    skip_space();
+    if (pos >= input.size()) {
+      kind = CondTokenKind::End;
+      path.clear();
+      return;
+    }
+
+    const char c = input[pos];
+    if (c == '(') {
+      ++pos;
+      kind = CondTokenKind::LParen;
+      path.clear();
+      return;
+    }
+    if (c == ')') {
+      ++pos;
+      kind = CondTokenKind::RParen;
+      path.clear();
+      return;
+    }
+    if (c == '!') {
+      ++pos;
+      kind = CondTokenKind::Not;
+      path.clear();
+      return;
+    }
+    if (c == '&' && pos + 1 < input.size() && input[pos + 1] == '&') {
+      pos += 2;
+      kind = CondTokenKind::And;
+      path.clear();
+      return;
+    }
+    if (c == '|' && pos + 1 < input.size() && input[pos + 1] == '|') {
+      pos += 2;
+      kind = CondTokenKind::Or;
+      path.clear();
+      return;
+    }
+    if (c == '&' || c == '|') {
+      throw_condition_error("expected '&&' or '||' operator");
+    }
+
+    const std::size_t start = pos;
+    if (pos + 1 < input.size() && input[pos] == ':' && input[pos + 1] == ':') {
+      pos += 2;
+      skip_space();
+      if (pos >= input.size() || !is_path_char(input[pos])) {
+        throw_condition_error("expected path after '::'");
+      }
+    }
+    if (pos >= input.size() || !is_path_char(input[pos])) {
+      throw_condition_error(std::string("expected path, found '") + c + "'");
+    }
+    while (pos < input.size() && is_path_char(input[pos])) {
+      ++pos;
+    }
+    if (pos == start) {
+      throw_condition_error("expected path");
+    }
+
+    kind = CondTokenKind::Path;
+    path = std::string(input.substr(start, pos - start));
+  }
+
+  void expect(CondTokenKind expected) {
+    if (kind != expected) {
+      throw_condition_error("unexpected token in condition");
+    }
+    advance();
+  }
+};
+
+struct ConditionEvaluator;
+
+struct TemplateNode {
+  enum class Type { Text, Variable, IfBlock, EachBlock };
+
+  struct ElifBranch {
+    std::string condition;
+    std::vector<TemplateNode> body;
+  };
+
+  Type type = Type::Text;
+  std::string value;
+  std::vector<TemplateNode> then_branch;
+  std::vector<ElifBranch> elif_branches;
+  std::vector<TemplateNode> else_branch;
+  std::vector<TemplateNode> body;
+};
+
+using NodeList = std::vector<TemplateNode>;
+
+enum class TokenKind {
+  Text,
+  Variable,
+  IfOpen,
+  ElifOpen,
+  Else,
+  IfClose,
+  EachOpen,
+  EachClose,
+  End
+};
+
+struct SourceLocation {
+  std::size_t line = 1;
+  std::size_t column = 1;
+};
+
+struct Token {
+  TokenKind kind = TokenKind::End;
+  std::string value;
+  SourceLocation location;
+};
+
+std::string token_kind_label(TokenKind kind) {
+  switch (kind) {
+    case TokenKind::Text:
+      return "text";
+    case TokenKind::Variable:
+      return "variable";
+    case TokenKind::IfOpen:
+      return "#if";
+    case TokenKind::ElifOpen:
+      return "#else if";
+    case TokenKind::Else:
+      return "#else";
+    case TokenKind::IfClose:
+      return "/if";
+    case TokenKind::EachOpen:
+      return "#each";
+    case TokenKind::EachClose:
+      return "/each";
+    case TokenKind::End:
+      return "end of template";
+  }
+  return "unknown token";
+}
+
+[[noreturn]] void throw_parse_error(const SourceLocation& location, const std::string& message) {
+  std::ostringstream out;
+  out << message << " at line " << location.line << ", column " << location.column;
+  throw std::runtime_error(out.str());
+}
+
+[[noreturn]] void throw_parse_error(const Token& token, const std::string& message) {
+  std::ostringstream out;
+  out << message << " at line " << token.location.line << ", column " << token.location.column;
+  if (token.kind != TokenKind::End && token.kind != TokenKind::Text) {
+    out << " (found " << token_kind_label(token.kind);
+    if (!token.value.empty()) {
+      out << " '" << token.value << "'";
+    }
+    out << ")";
+  }
+  throw std::runtime_error(out.str());
+}
+
+[[noreturn]] void throw_unknown_control(const std::string& content, SourceLocation location) {
+  std::ostringstream out;
+  out << "Unrecognized control statement '" << content << "'";
+  if (content == "/fi") {
+    out << " (did you mean '/if'?)";
+  }
+  throw_parse_error(location, out.str());
+}
+
+class Tokenizer {
+public:
+  explicit Tokenizer(std::string_view input) : input_(input) {}
+
+  Token next() {
+    return lex_next();
+  }
+
+private:
+  std::string_view input_;
+  std::size_t pos_ = 0;
+  std::size_t line_ = 1;
+  std::size_t column_ = 1;
+
+  SourceLocation current_location() const {
+    return {line_, column_};
+  }
+
+  void advance_to(std::size_t new_pos) {
+    while (pos_ < new_pos && pos_ < input_.size()) {
+      if (input_[pos_] == '\n') {
+        ++line_;
+        column_ = 1;
+      } else {
+        ++column_;
+      }
+      ++pos_;
+    }
+  }
+
+  Token lex_next() {
+    if (pos_ >= input_.size()) {
+      return {TokenKind::End, {}, current_location()};
+    }
+
+    const std::size_t open = input_.find("$$", pos_);
+    if (open == std::string_view::npos) {
+      const SourceLocation location = current_location();
+      Token token{TokenKind::Text, std::string(input_.substr(pos_)), location};
+      advance_to(input_.size());
+      return token;
+    }
+
+    if (open > pos_) {
+      const SourceLocation location = current_location();
+      Token token{TokenKind::Text, std::string(input_.substr(pos_, open - pos_)), location};
+      advance_to(open);
+      return token;
+    }
+
+    const SourceLocation location = current_location();
+    const std::size_t content_start = open + 2;
+    const std::size_t close = input_.find("$$", content_start);
+    if (close == std::string_view::npos) {
+      Token token{TokenKind::Text, std::string(input_.substr(pos_)), location};
+      advance_to(input_.size());
+      return token;
+    }
+
+    const std::string content =
+      trim_copy(std::string(input_.substr(content_start, close - content_start)));
+    advance_to(close + 2);
+    return classify(content, location);
+  }
+
+  static Token classify(const std::string& content, SourceLocation location) {
+    if (content == "/if") {
+      return {TokenKind::IfClose, {}, location};
+    }
+    if (content == "/each") {
+      return {TokenKind::EachClose, {}, location};
+    }
+    if (content == "#else") {
+      return {TokenKind::Else, {}, location};
+    }
+    if (content.rfind("#else if ", 0) == 0) {
+      const std::string condition = trim_copy(content.substr(9));
+      if (condition.empty()) {
+        throw_parse_error(location, "Expected condition after '#else if'");
+      }
+      return {TokenKind::ElifOpen, condition, location};
+    }
+    if (content.rfind("#elseif ", 0) == 0) {
+      const std::string condition = trim_copy(content.substr(8));
+      if (condition.empty()) {
+        throw_parse_error(location, "Expected condition after '#elseif'");
+      }
+      return {TokenKind::ElifOpen, condition, location};
+    }
+    if (content.rfind("#if ", 0) == 0) {
+      const std::string condition = trim_copy(content.substr(4));
+      if (condition.empty()) {
+        throw_parse_error(location, "Expected condition after '#if'");
+      }
+      return {TokenKind::IfOpen, condition, location};
+    }
+    if (content == "#if") {
+      throw_parse_error(location, "Expected condition after '#if'");
+    }
+    if (content.rfind("#each ", 0) == 0) {
+      const std::string list = trim_copy(content.substr(6));
+      if (list.empty()) {
+        throw_parse_error(location, "Expected list path after '#each'");
+      }
+      return {TokenKind::EachOpen, list, location};
+    }
+    if (content == "#each") {
+      throw_parse_error(location, "Expected list path after '#each'");
+    }
+
+    if (!content.empty() && (content[0] == '#' || content[0] == '/')) {
+      throw_unknown_control(content, location);
+    }
+
+    return {TokenKind::Variable, content, location};
+  }
+};
+
+class Parser {
+public:
+  explicit Parser(std::string_view input) : tokenizer_(input) {
+    current_ = tokenizer_.next();
+  }
+
+  NodeList parse_document() {
+    NodeList nodes =
+      parse_segments({TokenKind::IfClose, TokenKind::EachClose, TokenKind::End});
+    if (current_.kind != TokenKind::End) {
+      throw_parse_error(current_, "Unexpected token after document end");
+    }
+    return nodes;
+  }
+
+private:
+  Tokenizer tokenizer_;
+  Token current_;
+
+  void advance() {
+    current_ = tokenizer_.next();
+  }
+
+  bool at(TokenKind kind) const {
+    return current_.kind == kind;
+  }
+
+  bool at_end() const {
+    return current_.kind == TokenKind::End;
+  }
+
+  void expect(TokenKind kind, const char* message) {
+    if (!at(kind)) {
+      throw_parse_error(current_, message);
+    }
+    advance();
+  }
+
+  NodeList parse_segments(std::initializer_list<TokenKind> stop_tokens) {
+    NodeList nodes;
+    while (!at_end()) {
+      bool stop = false;
+      for (TokenKind kind : stop_tokens) {
+        if (at(kind)) {
+          stop = true;
+          break;
+        }
+      }
+      if (stop) {
+        break;
+      }
+      nodes.push_back(parse_segment());
+    }
+    return nodes;
+  }
+
+  TemplateNode parse_segment() {
+    switch (current_.kind) {
+      case TokenKind::Text: {
+        TemplateNode node;
+        node.type = TemplateNode::Type::Text;
+        node.value = std::move(current_.value);
+        advance();
+        return node;
+      }
+      case TokenKind::Variable: {
+        TemplateNode node;
+        node.type = TemplateNode::Type::Variable;
+        node.value = std::move(current_.value);
+        advance();
+        return node;
+      }
+      case TokenKind::IfOpen:
+        return parse_if_block();
+      case TokenKind::EachOpen:
+        return parse_each_block();
+      default:
+        throw_parse_error(current_, "Unexpected token in template segment");
+    }
+  }
+
+  TemplateNode parse_if_block() {
+    TemplateNode node;
+    node.type = TemplateNode::Type::IfBlock;
+    node.value = std::move(current_.value);
+    advance();
+
+    const std::initializer_list<TokenKind> branch_stops = {
+      TokenKind::IfClose, TokenKind::Else, TokenKind::ElifOpen};
+
+    node.then_branch = parse_segments(branch_stops);
+    while (at(TokenKind::ElifOpen)) {
+      TemplateNode::ElifBranch branch;
+      branch.condition = std::move(current_.value);
+      advance();
+      branch.body = parse_segments(branch_stops);
+      node.elif_branches.push_back(std::move(branch));
+    }
+    if (at(TokenKind::Else)) {
+      advance();
+      node.else_branch = parse_segments({TokenKind::IfClose});
+    }
+    expect(TokenKind::IfClose, "Expected $$/if$$");
+    return node;
+  }
+
+  TemplateNode parse_each_block() {
+    TemplateNode node;
+    node.type = TemplateNode::Type::EachBlock;
+    node.value = std::move(current_.value);
+    advance();
+
+    node.body = parse_segments({TokenKind::EachClose});
+    expect(TokenKind::EachClose, "Expected $$/each$$");
+    return node;
+  }
+};
+
+struct RenderState {
+  const TemplateContext& root;
+  const RenderOptions& options;
+  std::vector<const TemplateContext*> scopes;
+  std::string result;
+
+  const TemplateContext* owning_context(std::string_view path) const {
+    for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+      if ((*it)->has_path(path)) {
+        return *it;
+      }
+    }
+    if (root.has_path(path)) {
+      return &root;
+    }
+    return nullptr;
+  }
+
+  std::optional<std::string> lookup(std::string_view raw_path) const {
+    const PathRef ref = parse_path_ref(raw_path);
+    if (ref.path.empty()) {
+      return std::nullopt;
+    }
+    if (ref.from_root) {
+      return root.resolve(ref.path);
+    }
+    if (const TemplateContext* ctx = owning_context(ref.path)) {
+      return ctx->resolve(ref.path);
+    }
+    return std::nullopt;
+  }
+
+  bool path_is_true(std::string_view raw_path) const {
+    const PathRef ref = parse_path_ref(raw_path);
+    if (ref.path.empty()) {
+      return false;
+    }
+    if (ref.from_root) {
+      return root.is_true(ref.path);
+    }
+    if (const TemplateContext* ctx = owning_context(ref.path)) {
+      return ctx->is_true(ref.path);
+    }
+    return false;
+  }
+
+  bool is_true(std::string_view condition) const;
+
+  const std::vector<TemplateContext>* array_at(std::string_view raw_path) const {
+    const PathRef ref = parse_path_ref(raw_path);
+    if (ref.path.empty()) {
+      return nullptr;
+    }
+    if (ref.from_root) {
+      return root.array_at(ref.path);
+    }
+    if (const TemplateContext* ctx = owning_context(ref.path)) {
+      return ctx->array_at(ref.path);
+    }
+    return nullptr;
+  }
+
+  void append_variable(std::string_view path) {
+    if (const auto value = lookup(path)) {
+      result += *value;
+      return;
+    }
+
+    if (options.keep_missing_placeholders) {
+      result += "$$";
+      result += path;
+      result += "$$";
+    }
+  }
+};
+
+struct ConditionEvaluator {
+  const RenderState& state;
+  CondLexer lex;
+
+  ConditionEvaluator(const RenderState& state, std::string_view input)
+    : state(state), lex(input) {}
+
+  bool parse_or();
+  bool parse_and();
+  bool parse_unary();
+  bool parse_primary();
+  bool evaluate();
+};
+
+bool ConditionEvaluator::parse_or() {
+  bool value = parse_and();
+  while (lex.kind == CondTokenKind::Or) {
+    lex.advance();
+    const bool rhs = parse_and();
+    value = value || rhs;
+  }
+  return value;
+}
+
+bool ConditionEvaluator::parse_and() {
+  bool value = parse_unary();
+  while (lex.kind == CondTokenKind::And) {
+    lex.advance();
+    const bool rhs = parse_unary();
+    value = value && rhs;
+  }
+  return value;
+}
+
+bool ConditionEvaluator::parse_unary() {
+  if (lex.kind == CondTokenKind::Not) {
+    lex.advance();
+    return !parse_unary();
+  }
+  return parse_primary();
+}
+
+bool ConditionEvaluator::parse_primary() {
+  if (lex.kind == CondTokenKind::Path) {
+    const std::string path = std::move(lex.path);
+    lex.advance();
+    return state.path_is_true(path);
+  }
+  if (lex.kind == CondTokenKind::LParen) {
+    lex.advance();
+    const bool value = parse_or();
+    lex.expect(CondTokenKind::RParen);
+    return value;
+  }
+  throw_condition_error("expected path or '('");
+}
+
+bool ConditionEvaluator::evaluate() {
+  if (lex.kind == CondTokenKind::End) {
+    throw_condition_error("empty condition");
+  }
+  const bool value = parse_or();
+  if (lex.kind != CondTokenKind::End) {
+    throw_condition_error("unexpected token after expression");
+  }
+  return value;
+}
+
+bool RenderState::is_true(std::string_view condition) const {
+  return ConditionEvaluator(*this, condition).evaluate();
+}
+
+void render_nodes(const NodeList& nodes, RenderState& state);
+
+void render_node(const TemplateNode& node, RenderState& state) {
+  switch (node.type) {
+    case TemplateNode::Type::Text:
+      state.result += node.value;
+      break;
+
+    case TemplateNode::Type::Variable:
+      state.append_variable(node.value);
+      break;
+
+    case TemplateNode::Type::IfBlock:
+      if (state.is_true(node.value)) {
+        render_nodes(node.then_branch, state);
+      } else {
+        bool matched = false;
+        for (const auto& elif : node.elif_branches) {
+          if (state.is_true(elif.condition)) {
+            render_nodes(elif.body, state);
+            matched = true;
+            break;
+          }
+        }
+        if (!matched) {
+          render_nodes(node.else_branch, state);
+        }
+      }
+      break;
+
+    case TemplateNode::Type::EachBlock: {
+      const auto* items = state.array_at(node.value);
+      if (items == nullptr) {
+        break;
+      }
+      const int size = static_cast<int>(items->size());
+      for (std::size_t i = 0; i < items->size(); ++i) {
+        TemplateContext loop_ctx = (*items)[i];
+        loop_ctx.set("@index", static_cast<int>(i));
+        loop_ctx.set("@size", size);
+        state.scopes.push_back(&loop_ctx);
+        render_nodes(node.body, state);
+        state.scopes.pop_back();
+      }
+      break;
+    }
+  }
+}
+
+void render_nodes(const NodeList& nodes, RenderState& state) {
+  for (const auto& node : nodes) {
+    render_node(node, state);
+  }
+}
+
+std::string parse_and_render(std::string_view template_text,
+              const TemplateContext& context,
+              const RenderOptions& options) {
+  Parser parser(template_text);
+  const NodeList document = parser.parse_document();
+
+  RenderState state{context, options, {}, {}};
+  render_nodes(document, state);
+  return state.result;
+}
+
+using ContextValue = std::variant<
+  std::string,
+  bool,
+  char,
+  short,
+  int,
+  long,
+  long long,
+  unsigned short,
+  unsigned int,
+  unsigned long,
+  unsigned long long,
+  float,
+  double,
+  long double,
+  TemplateContext,
+  std::vector<TemplateContext>>;
+
+std::string value_as_string(const ContextValue& value) {
+  return std::visit(
+    [](const auto& v) -> std::string {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, std::string>) {
+        return v;
+      } else if constexpr (std::is_same_v<T, bool>) {
+        return v ? "1" : "0";
+      } else if constexpr (std::is_same_v<T, char>) {
+        return std::string(1, v);
+      } else if constexpr (std::is_same_v<T, TemplateContext> ||
+                 std::is_same_v<T, std::vector<TemplateContext>>) {
+        return {};
+      } else {
+        return std::to_string(v);
+      }
+    },
+    value);
+}
+
+}  // namespace
+
+template<>
+bool TemplateContext::value_is_true<ContextValue>(const ContextValue& value) {
+  return std::visit(
+    [](const auto& v) -> bool {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, std::string>) {
+        return is_true_string(v);
+      } else if constexpr (std::is_same_v<T, bool>) {
+        return v;
+      } else if constexpr (std::is_same_v<T, char>) {
+        return v != '\0';
+      } else if constexpr (std::is_same_v<T, std::vector<TemplateContext>>) {
+        return !v.empty();
+      } else if constexpr (std::is_same_v<T, TemplateContext>) {
+        return !v.is_empty();
+      } else {
+        return v != 0;
+      }
+    },
+    value);
+}
+
+struct TemplateContext::Impl {
+  std::unordered_map<std::string, ContextValue> members_;
+};
+
+TemplateContext::TemplateContext()
+  : impl_(std::make_unique<Impl>()) {}
+
+TemplateContext::TemplateContext(const TemplateContext& other)
+  : impl_(other.impl_ ? std::make_unique<Impl>(*other.impl_)
+                      : std::make_unique<Impl>()) {}
+
+TemplateContext::TemplateContext(TemplateContext&& other) noexcept = default;
+
+TemplateContext& TemplateContext::operator=(const TemplateContext& other) {
+  if (this != &other) {
+    impl_ = other.impl_ ? std::make_unique<Impl>(*other.impl_)
+                        : std::make_unique<Impl>();
+  }
+  return *this;
+}
+
+TemplateContext& TemplateContext::operator=(TemplateContext&& other) noexcept = default;
+
+TemplateContext::~TemplateContext() = default;
+
+void TemplateContext::set(std::string key, std::string value) {
+  impl_->members_[std::move(key)] = std::move(value);
+}
+
+void TemplateContext::set(std::string key, const char* value) {
+  set(std::move(key), std::string(value));
+}
+
+void TemplateContext::set(std::string key, bool value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, char value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, short value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, int value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, long value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, long long value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, unsigned short value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, unsigned int value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, unsigned long value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, unsigned long long value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, float value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, double value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set(std::string key, long double value) {
+  impl_->members_[std::move(key)] = value;
+}
+
+void TemplateContext::set_object(std::string key, TemplateContext object) {
+  impl_->members_[std::move(key)] = std::move(object);
+}
+
+void TemplateContext::set_array(std::string key, std::vector<TemplateContext> items) {
+  impl_->members_[std::move(key)] = std::move(items);
+}
+
+TemplateContext TemplateContext::from_flat(
+  const std::unordered_map<std::string, std::string>& values) {
+  TemplateContext ctx;
+  for (const auto& [key, value] : values) {
+    ctx.set(key, value);
+  }
+  return ctx;
+}
+
+std::optional<std::string> TemplateContext::resolve(std::string_view path) const {
+  if (path.empty()) {
+    return std::nullopt;
+  }
+
+  const std::string head = head_segment(path);
+  const std::string_view tail = tail_segment(path);
+
+  const auto it = impl_->members_.find(head);
+  if (it == impl_->members_.end()) {
+    return std::nullopt;
+  }
+
+  if (!tail.empty()) {
+    if (const auto* object = std::get_if<TemplateContext>(&it->second)) {
+      return object->resolve(tail);
+    }
+    return std::nullopt;
+  }
+
+  if (std::holds_alternative<TemplateContext>(it->second) ||
+    std::holds_alternative<std::vector<TemplateContext>>(it->second)) {
+    return std::nullopt;
+  }
+
+  return value_as_string(it->second);
+}
+
+const std::vector<TemplateContext>* TemplateContext::array_at(std::string_view path) const {
+  if (path.empty()) {
+    return nullptr;
+  }
+
+  const std::string head = head_segment(path);
+  const std::string_view tail = tail_segment(path);
+
+  const auto it = impl_->members_.find(head);
+  if (it == impl_->members_.end()) {
+    return nullptr;
+  }
+
+  if (!tail.empty()) {
+    if (const auto* object = std::get_if<TemplateContext>(&it->second)) {
+      return object->array_at(tail);
+    }
+    return nullptr;
+  }
+
+  if (const auto* array = std::get_if<std::vector<TemplateContext>>(&it->second)) {
+    return array;
+  }
+  return nullptr;
+}
+
+bool TemplateContext::has_path(std::string_view path) const {
+  if (path.empty()) {
+    return false;
+  }
+
+  const std::string head = head_segment(path);
+  const std::string_view tail = tail_segment(path);
+
+  const auto it = impl_->members_.find(head);
+  if (it == impl_->members_.end()) {
+    return false;
+  }
+
+  if (tail.empty()) {
+    return true;
+  }
+
+  if (const auto* object = std::get_if<TemplateContext>(&it->second)) {
+    return object->has_path(tail);
+  }
+  return false;
+}
+
+bool TemplateContext::is_empty() const {
+  return impl_->members_.empty();
+}
+
+bool TemplateContext::is_true(std::string_view path) const {
+  if (path.empty()) {
+    return false;
+  }
+
+  const std::string head = head_segment(path);
+  const std::string_view tail = tail_segment(path);
+
+  const auto it = impl_->members_.find(head);
+  if (it == impl_->members_.end()) {
+    return false;
+  }
+
+  if (tail.empty()) {
+    return value_is_true<ContextValue>(it->second);
+  }
+
+  if (const auto* object = std::get_if<TemplateContext>(&it->second)) {
+    return object->is_true(tail);
+  }
+  return false;
+}
+
+TemplateEngine::TemplateEngine(RenderOptions options)
+  : options_(std::move(options)) {}
+
+std::string TemplateEngine::render(std::string_view template_text,
+                 const TemplateContext& context) const {
+  return parse_and_render(template_text, context, options_);
+}
+
+std::string TemplateEngine::render_file(const std::string& path,
+                    const TemplateContext& context) const {
+  std::ifstream file(path);
+  if (!file) {
+    throw std::runtime_error("Failed to open template file: " + path);
+  }
+
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return render(buffer.str(), context);
+}
+
+}  // namespace Loci

--- a/src/lpp/template.h
+++ b/src/lpp/template.h
@@ -1,0 +1,99 @@
+//#############################################################################
+//#
+//# Copyright 2008-2025, Mississippi State University
+//#
+//# This file is part of the Loci Framework.
+//#
+//# The Loci Framework is free software: you can redistribute it and/or modify
+//# it under the terms of the Lesser GNU General Public License as published by
+//# the Free Software Foundation, either version 3 of the License, or
+//# (at your option) any later version.
+//#
+//# The Loci Framework is distributed in the hope that it will be useful,
+//# but WITHOUT ANY WARRANTY; without even the implied warranty of
+//# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//# Lesser GNU General Public License for more details.
+//#
+//# You should have received a copy of the Lesser GNU General Public License
+//# along with the Loci Framework.  If not, see <http://www.gnu.org/licenses>
+//#
+//#############################################################################
+
+#ifndef LOCI_TEMPLATE_H
+#define LOCI_TEMPLATE_H
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Loci {
+
+class TemplateContext {
+public:
+  TemplateContext();
+  TemplateContext(const TemplateContext& other);
+  TemplateContext(TemplateContext&& other) noexcept;
+  TemplateContext& operator=(const TemplateContext& other);
+  TemplateContext& operator=(TemplateContext&& other) noexcept;
+  ~TemplateContext();
+
+  void set(std::string key, std::string value);
+  void set(std::string key, const char* value);
+  void set(std::string key, bool value);
+  void set(std::string key, char value);
+  void set(std::string key, short value);
+  void set(std::string key, int value);
+  void set(std::string key, long value);
+  void set(std::string key, long long value);
+  void set(std::string key, unsigned short value);
+  void set(std::string key, unsigned int value);
+  void set(std::string key, unsigned long value);
+  void set(std::string key, unsigned long long value);
+  void set(std::string key, float value);
+  void set(std::string key, double value);
+  void set(std::string key, long double value);
+
+  void set_object(std::string key, TemplateContext object);
+  void set_array(std::string key, std::vector<TemplateContext> items);
+
+  std::optional<std::string> resolve(std::string_view path) const;
+  const std::vector<TemplateContext>* array_at(std::string_view path) const;
+  bool has_path(std::string_view path) const;
+  bool is_true(std::string_view path) const;
+
+  static TemplateContext from_flat(
+    const std::unordered_map<std::string, std::string>& values);
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+
+  template<typename T>
+  static bool value_is_true(const T& value);
+
+  bool is_empty() const;
+};
+
+struct RenderOptions {
+  bool keep_missing_placeholders = false;
+};
+
+class TemplateEngine {
+public:
+  explicit TemplateEngine(RenderOptions options = {});
+
+  std::string render(std::string_view template_text, const TemplateContext& context) const;
+
+  std::string render_file(const std::string& path, const TemplateContext& context) const;
+
+private:
+  RenderOptions options_;
+};
+
+}  // namespace Loci
+
+#endif  // LOCI_TEMPLATE_H


### PR DESCRIPTION
single CPU/GPU schedule.

1. Added --expt-relaxed-constexpr flag to nvcc compile.
2. Created identity type traits for Loci built in reduction operators.
3. Created text substitution template engine to facilitate generation of CUDA rule boilerplate code from Loci preprocessor.
4. Developed $cudarule support for generating CUDA backend for unit/apply rules on param, that includes parameter only apply rules.
5. This modification currently supports single CPU - single GPU global reductions only.
6. CUDA stream and device synchronizations needs further review.