### PR TITLE
add logical apply rule templates

### DIFF
--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -649,6 +649,40 @@ namespace Loci {
 
   } ;
 
+  /// Combines values with logical AND.
+  template <class T> struct LogicalAnd {
+    void operator()(T &res, const T &arg)
+    { res = res && arg ; }
+    template <class U> void operator()(T &res, const U &arg)
+    { res = res && arg ; }
+  } ;
+  /// Combines matching entries of vector views with logical AND.
+  template <class T> struct LogicalAnd<Vect<T> > {
+    template <class U> void operator()(Vect<T> &res ,const U &arg)
+    {
+      int vs = res.getSize() ;
+      for(int i=0;i<vs;++i)
+        res[i] = res[i] && arg[i] ;
+    }
+  } ;
+
+  /// Combines values with logical OR.
+  template <class T> struct LogicalOr {
+    void operator()(T &res, const T &arg)
+    { res = res || arg ; }
+    template <class U> void operator()(T &res, const U &arg)
+    { res = res || arg ; }
+  } ;
+  /// Combines matching entries of vector views with logical OR.
+  template <class T> struct LogicalOr<Vect<T> > {
+    template <class U> void operator()(Vect<T> &res ,const U &arg)
+    {
+      int vs = res.getSize() ;
+      for(int i=0;i<vs;++i)
+        res[i] = res[i] || arg[i] ;
+    }
+  } ;
+
   template <class T> struct Maximum {
     void operator()(T &res ,const T &arg)
     { res = max(res,arg) ; }


### PR DESCRIPTION
This is addressing subissue #352. This logical template is used in the FVMAdapt module in the older C++ style apply rules. This will allow us to remove that locally defined template when we update the rules to the $rule syntax and use these newly defined templates, with them being provided directly by Loci now.

I'm open to any suggestions for better names for these.