### PR TITLE
Fixed parsing for cmake compiles of HDF5

### DIFF
--- a/configure
+++ b/configure
@@ -723,7 +723,7 @@ H5SUPPORTLIBSPATHS=
 
 if [ -e $H5PATH/lib/libhdf5.settings ]; then
     # Detect if cmake build system was used to build hdf5, and parse settings file if not.
-    TMP=`grep "Extra libraries" $H5PATH/lib/libhdf5.settings | sed "s/.*://"`
+    TMP=`grep "Extra libraries" $H5PATH/lib/libhdf5.settings | sed "s/[^:]*://"`
     if [[ $TMP != *";"* ]]; then
         H5SUPPORTLIBS=$TMP
         H5SUPPORTLIBSPATHS=`grep "AM_LDFLAGS" $H5PATH/lib/libhdf5.settings | sed "s/.*://"`


### PR DESCRIPTION
Recent versions of cmake compiles of HDF5 included Threads::Threads in extra libs.  