### PR TITLE
[#343]: (BUG FIX) Remove redeclaration of `d`

### DIFF
--- a/src/FVMtools/geomTools/gridMotion/treeApprox.h
+++ b/src/FVMtools/geomTools/gridMotion/treeApprox.h
@@ -118,7 +118,7 @@ namespace gridMotion {
       werr = 0 ;
       disp = vector3d<double>(0.,0.,0.) ;
       approxTree.TreeApprox(disp,w,werr,posf,0,a,b,L,aL,errpn) ;
-      vector3d<double> d = disp ;
+      d = disp ;
       d *= 1./w ;
     }
     return d ;


### PR DESCRIPTION
The redeclaration of `d` inside of the conditional block creates a temporary variable that is lost when leaving the scope of the block. Thus, the current code has the unintended side effect of computing the displacement that satisfies the tighter relative error tolerance, but then immediately discarding it.

Removing the type declaration allows the updated `disp` that is returned from the second call to `approxTree.TreeApprox(...)` to be assigned to the instance of `d` declared outside of the block. This value can then be properly returned to the caller of the `approxDisplacement(...)` function.