### PR TITLE
395 multi gpu global reductions

### DIFF
--- a/src/System/gpusupport.cc
+++ b/src/System/gpusupport.cc
@@ -984,84 +984,92 @@ namespace Loci {
 #endif
   }
 
-  inline variable makeGPUVAR(variable v) {
-    variable::info vinfo = v.get_info() ;
-    string vname = string("__GPU__") + vinfo.name ;
-    vinfo.name = vname ;
-    return variable(vinfo) ;
-  }
-  rule_db rename_gpu_containers(fact_db  &facts,
-				const rule_db &rdb)  {
-
+  rule_db rename_gpu_containers(fact_db  &facts, const rule_db &rdb) {
     rule_db gpu_rdb ;
 
     variableSet gpuInputs ;
     variableSet gpuOutputs ;
+    variableSet gpuReduceParams ;
     variableSet gpuMaps ;
     variableSet inputs  ;
     variableSet outputs = facts.get_typed_variables();
+    variableSet reduceParams ;
     ruleSet gpurules, mixedrules ;
     ruleSet rset = rdb.all_rules() ;
+    std::map<variable, rule> param2unit ;
 
     map<variable,ruleSet> vargenerators ;
     for(ruleSet::const_iterator rsi = rset.begin(); rsi != rset.end();++rsi) {
       rule_implP rp = rsi->get_rule_implP() ;
+
       if(rp == 0) {
-	// Not a rule with an implementation so no GPU container
-	// types
-	gpu_rdb.add_rule(*rsi) ;
+        // Not a rule with an implementation so no GPU container
+        // types
+        gpu_rdb.add_rule(*rsi) ;
         continue ;
       }
-      variableSet targets = rsi->targets() ;
+
       bool hasGPUVar = false ;
       bool hasCPUVar = false ;
+
+      variableSet targets = rsi->targets() ;
       for(variableSet::const_iterator vsi = targets.begin(); vsi !=
-	    targets.end(); ++vsi) {
-	variable vt = vsi->drop_assign() ;
-	variable vbase = vt.new_offset(0) ;
-	vargenerators[vbase] += *rsi ;
-	storeRepP sp = rp->get_store(*vsi) ;
-	if(isGPU(sp)) {
-	    gpuOutputs += *vsi ;
-	  hasGPUVar = true ;
-	} else {
-	  outputs += *vsi ;
-	  hasCPUVar = true ;
-	}
+            targets.end(); ++vsi) {
+        variable vt = vsi->drop_assign() ;
+        variable vbase = vt.new_offset(0) ;
+        vargenerators[vbase] += *rsi ;
+        storeRepP sp = rp->get_store(*vsi) ;
+        if(isGPU(sp)) {
+          if(isPARAMETER(sp) &&
+             (rp->get_rule_class() == rule_impl::UNIT ||
+              rp->get_rule_class() == rule_impl::APPLY)) {
+            gpuReduceParams += *vsi ;
+          } else {
+            gpuOutputs += *vsi ;
+          }
+          hasGPUVar = true ;
+        } else {
+          if(isPARAMETER(sp) &&
+             (rp->get_rule_class() == rule_impl::UNIT ||
+              rp->get_rule_class() == rule_impl::APPLY)) {
+            reduceParams += *vsi ;
+          }
+          outputs += *vsi ;
+          hasCPUVar = true ;
+        }
       }
+
       variableSet sources = rsi->sources() ;
       for(variableSet::const_iterator vsi = sources.begin(); vsi !=
-	    sources.end(); ++vsi) {
-	storeRepP sp = rp->get_store(*vsi) ;
-	if(isGPU(sp)) {
-	  if(isMAP(sp))
-	    gpuMaps += *vsi ;
-	  else
-	    gpuInputs += *vsi ;
-	  hasGPUVar = true ;
-	} else if(sp != 0) {
-	  inputs += *vsi ;
-	  hasCPUVar = true ;
-	}
+            sources.end(); ++vsi) {
+        storeRepP sp = rp->get_store(*vsi) ;
+        if(isGPU(sp)) {
+          if(isMAP(sp))
+            gpuMaps += *vsi ;
+          else
+            gpuInputs += *vsi ;
+          hasGPUVar = true ;
+        } else if(sp != 0) {
+          inputs += *vsi ;
+          hasCPUVar = true ;
+        }
       }
       if(hasGPUVar) {
-	if(hasCPUVar) {
-	  mixedrules += rule(rp) ;
-	} else {
-	  gpurules += rule(rp) ;
-	}
-	gpurules += rule(rp) ;
+        if(hasCPUVar) {
+          mixedrules += rule(rp) ;
+        } else {
+          gpurules += rule(rp) ;
+        }
       } else {
-	gpu_rdb.add_rule(*rsi) ;
+        gpu_rdb.add_rule(*rsi) ;
       }
-      
     }
 
     if(mixedrules != EMPTY) {
       for(ruleSet::const_iterator iter = mixedrules.begin();
-	  iter != mixedrules.end(); ++iter) {
-	cerr << "ERROR: rule " << *iter
-	     << " contains both CPU and GPU containers!" << endl ;
+            iter != mixedrules.end(); ++iter) {
+        cerr << "ERROR: rule " << *iter
+             << " contains both CPU and GPU containers!" << endl ;
       }
       Loci::Abort() ;
     }
@@ -1073,143 +1081,241 @@ namespace Loci {
         Loci::Abort() ;
       }
     }
-    
+
     variableSet loopVarBase ;
     for(auto rsi = gpurules.begin(); rsi != gpurules.end();++rsi) {
       if(rsi->type() == rule::BUILD) {
-	//	cout << "BUILD: " << *rsi << endl ;
-	variableSet targets = rsi->targets() ;
-	for(variableSet::const_iterator vsi = targets.begin(); vsi !=
-	      targets.end(); ++vsi) {
+        //cout << "BUILD: " << *rsi << endl ;
+        variableSet targets = rsi->targets() ;
+        for(variableSet::const_iterator vsi = targets.begin(); vsi !=
+              targets.end(); ++vsi) {
           variable vt = vsi->drop_assign() ;
           variable vbase = vt.new_offset(0) ;
-	  loopVarBase += vbase ;
-	  //	  cout << "vt = " << vt << " vbase = " << vbase <<" *vsi = " << *vsi << endl ;
-	}
+          loopVarBase += vbase ;
+        }
       }
-      //      if(rsi->type() == rule::COLLAPSE) {
-      //	cout << "COLLAPSE: " << *rsi << endl ;
-      //      }      
+      //if(rsi->type() == rule::COLLAPSE) {
+      //  cout << "COLLAPSE: " << *rsi << endl ;
+      //}
     }
     if(MPI_rank == 0 && loopVarBase!=EMPTY)
       cout << "gpu looping vars = " << loopVarBase <<endl ;
-    ruleSet processed ;
 
-    variableSet cpu2gpu = gpuInputs ;
-    variableSet gpu2cpu = gpuOutputs ;
+    ruleSet processed ;
 
     for(auto vi = loopVarBase.begin(); vi != loopVarBase.end(); ++vi) {
       ruleSet generators = vargenerators[*vi] ;
-      for(auto ri=generators.begin(); ri!=generators.end();++ri) {
-	if(!gpurules.inSet(*ri)) {
-	  cerr << "rule "<<*ri << " should generate a gpu variable"
-	       << endl ;
-	  processed += *ri ;
-	  continue ;
-	}
-	if(processed.inSet(*ri))
-	  continue ;
-	processed += *ri ;
-	rule_implP rp = ri->get_rule_implP() ;
-	map<variable,variable> vm ;
-	variableSet targets = ri->targets() ;
-	gpu2cpu -= targets ;
-	cpu2gpu -= targets ;
-	for(auto vsi = targets.begin(); vsi != targets.end(); ++vsi) {
+      for(auto ri = generators.begin(); ri != generators.end(); ++ri) {
+        if(!gpurules.inSet(*ri)) {
+          cerr << "rule "<< *ri << " should generate a gpu variable"
+               << endl ;
+          processed += *ri ;
+          continue ;
+        }
+        if(processed.inSet(*ri))
+          continue ;
+        processed += *ri ;
+        rule_implP rp = ri->get_rule_implP() ;
+
+        map<variable,variable> vm ;
+        variableSet targets = ri->targets() ;
+        gpuInputs -= targets ;
+        gpuOutputs -= targets ;
+        gpuReduceParams -= targets ;
+        for(auto vsi = targets.begin(); vsi != targets.end(); ++vsi) {
           variable vt = vsi->drop_assign() ;
           variable vbase = vt.new_offset(0) ;
-	  gpu2cpu += vbase ;
-	  storeRepP sp = rp->get_store(*vsi) ;
-	  if(sp!=0) {
-	    vm[*vsi] = makeGPUVAR(*vsi) ;
-	  } else {
-	    vm[*vsi] = *vsi ;
-	  }
-	}
-	variableSet sources = ri->sources() ;
-	for(auto vsi = sources.begin(); vsi != sources.end(); ++vsi) {
-	  storeRepP sp = rp->get_store(*vsi) ;
-	  if(sp!=0) {
-	    vm[*vsi] = makeGPUVAR(*vsi) ;
-	  } else {
-	    vm[*vsi] = *vsi ;
-	  }
-	}
-	rp->rename_vars(vm) ;
-	rule r = rule(rp) ;
-	gpu_rdb.add_rule(r) ;
-	//	cout << "r1=" << r << endl ;
+
+          storeRepP sp = rp->get_store(*vsi) ;
+
+          if(sp!=0) {
+            if((rp->get_rule_class() == rule_impl::UNIT ||
+                rp->get_rule_class() == rule_impl::APPLY) &&
+               isPARAMETER(sp)) {
+              gpuReduceParams += vbase ;
+              vm[*vsi] = makeREDUCEVAR(makeGPUVAR(*vsi)) ;
+            } else {
+              gpuOutputs += vbase ;
+              vm[*vsi] = makeGPUVAR(*vsi) ;
+            }
+          } else {
+            vm[*vsi] = *vsi ;
+          }
+        }
+
+        variableSet sources = ri->sources() ;
+        for(auto vsi = sources.begin(); vsi != sources.end(); ++vsi) {
+          storeRepP sp = rp->get_store(*vsi) ;
+          if(sp!=0) {
+            vm[*vsi] = makeGPUVAR(*vsi) ;
+          } else {
+            vm[*vsi] = *vsi ;
+          }
+        }
+
+        rp->rename_vars(vm) ;
+        rule r = rule(rp) ;
+        gpu_rdb.add_rule(r) ;
       }
     }
     gpurules -= processed ;
-    
+
     for(ruleSet::const_iterator rsi = gpurules.begin(); rsi != gpurules.end();++rsi) {
       rule_implP rp = rsi->get_rule_implP() ;
-      
+
       map<variable,variable> vm ;
       variableSet targets = rsi->targets() ;
       for(variableSet::const_iterator vsi = targets.begin(); vsi !=
-	    targets.end(); ++vsi) {
-	storeRepP sp = rp->get_store(*vsi) ;
-	if(sp!=0) {
-	  vm[*vsi] = makeGPUVAR(*vsi) ;
-	} else {
-	  vm[*vsi] = *vsi ;
-	}
+            targets.end(); ++vsi) {
+        storeRepP sp = rp->get_store(*vsi) ;
+
+        if(sp!=0) {
+          if((rp->get_rule_class() == rule_impl::UNIT ||
+              rp->get_rule_class() == rule_impl::APPLY) &&
+             isPARAMETER(sp)) {
+            vm[*vsi] = makeGPUVAR(makeREDUCEVAR(*vsi)) ;
+          } else {
+            vm[*vsi] = makeGPUVAR(*vsi) ;
+          }
+        } else {
+          vm[*vsi] = *vsi ;
+        }
       }
       variableSet sources = rsi->sources() ;
       for(variableSet::const_iterator vsi = sources.begin(); vsi !=
-	    sources.end(); ++vsi) {
-	storeRepP sp = rp->get_store(*vsi) ;
-	if(sp!=0) {
-	  vm[*vsi] = makeGPUVAR(*vsi) ;
-	} else {
-	  vm[*vsi] = *vsi ;
-	}
+            sources.end(); ++vsi) {
+        storeRepP sp = rp->get_store(*vsi) ;
+        if(sp!=0) {
+          vm[*vsi] = makeGPUVAR(*vsi) ;
+        } else {
+          vm[*vsi] = *vsi ;
+        }
       }
       rp->rename_vars(vm) ;
       gpu_rdb.add_rule(rule(rp)) ;
     }
 
-   
-
     if(gpuMaps != EMPTY && MPI_rank==0)
       cout << "gpuMaps = " << gpuMaps << endl ;
-    //    cout << "inputs = " << inputs << endl ;
-    //    cout << "outputs = " << outputs << endl ;
-    //    cout << "gpuInputs = " << gpuInputs << endl ;
-    //    cout << "gpuOutputs = " << gpuOutputs << endl ;
+    //cout << "inputs = " << inputs << endl ;
+    //cout << "outputs = " << outputs << endl ;
+    //cout << "gpuInputs = " << gpuInputs << endl ;
+    //cout << "gpuOutputs = " << gpuOutputs << endl ;
+    //cout << "gpuReduceParams = " << gpuReduceParams << endl ;
 
-    //cpu2gpu -= gpuOutputs ;
+    if((gpuReduceParams - reduceParams) != EMPTY) {
+      cerr << "gpu unit/apply on params must also have cpu unit rule" << endl ;
+      Loci::Abort() ;
+    }
+
+    variableSet cpu2gpu = gpuInputs ;
+    cpu2gpu -= gpuOutputs ;
     cpu2gpu &= outputs ;
-    //    gpu2cpu -= gpuInputs ;
-    gpu2cpu -= cpu2gpu ;
-    //    gpu2cpu &= inputs ;
-    for(variableSet::const_iterator vsi = cpu2gpu.begin(); vsi !=
-	  cpu2gpu.end(); ++vsi) {
-      rule r = create_rule(*vsi,makeGPUVAR(*vsi),"cpu2gpu") ;
-      gpu_rdb.add_rule(r) ;
-      //      cout << "r=" << r << endl ;
-    }
-    for(variableSet::const_iterator vsi = gpuMaps.begin(); vsi !=
-	  gpuMaps.end(); ++vsi) {
-      rule r = create_rule(*vsi,makeGPUVAR(*vsi),"map2gpu") ;
-      gpu_rdb.add_rule(r) ;
-      //      cout << "r=" << r << endl ;
-    }
-    for(variableSet::const_iterator vsi = gpu2cpu.begin(); vsi !=
-	  gpu2cpu.end(); ++vsi) {
-      rule r = create_rule(makeGPUVAR(*vsi),*vsi,"gpu2cpu") ;
-      gpu_rdb.add_rule(r) ;
-      //      cout << "r=" << r << endl ;
-    }    
+
+    variableSet gpu2cpu = inputs ;
+    gpu2cpu -= outputs ;
+    gpu2cpu &= gpuOutputs ;
+
+    variableSet globalreduce = gpuReduceParams ;
+    globalreduce &= reduceParams ;
 
     variableSet overlap = cpu2gpu ;
     overlap &= gpu2cpu ;
     if(overlap != EMPTY) {
       cerr << "warning, loops formed in interactions between gpu and cpu kernels" << endl ;
-      cerr << "offending variables is " << overlap << endl ;
+      cerr << "offending variables are " << overlap << endl ;
     }
+
+    for(variableSet::const_iterator vsi = cpu2gpu.begin(); vsi !=
+          cpu2gpu.end(); ++vsi) {
+      rule r = create_rule(*vsi,makeGPUVAR(*vsi),"cpu2gpu") ;
+      gpu_rdb.add_rule(r) ;
+      //cout << "r=" << r << endl ;
+    }
+
+    for(variableSet::const_iterator vsi = gpuMaps.begin(); vsi !=
+          gpuMaps.end(); ++vsi) {
+      rule r = create_rule(*vsi,makeGPUVAR(*vsi),"map2gpu") ;
+      gpu_rdb.add_rule(r) ;
+      //cout << "r=" << r << endl ;
+    }
+
+    for(variableSet::const_iterator vsi = gpu2cpu.begin(); vsi !=
+          gpu2cpu.end(); ++vsi) {
+      rule r = create_rule(makeGPUVAR(*vsi),*vsi,"gpu2cpu") ;
+      gpu_rdb.add_rule(r) ;
+      //cout << "r=" << r << endl ;
+    }
+
+    for(variableSet::const_iterator vsi = globalreduce.begin();
+          vsi != globalreduce.end(); ++vsi) {
+      variable cpuvar = *vsi ;
+      variable cpupartvar = makeREDUCEVAR(cpuvar) ;
+      variable gpupartvar = makeGPUVAR(cpupartvar) ;
+
+      rule r = create_rule(gpupartvar,cpupartvar,"gpu2cpu") ;
+      gpu_rdb.add_rule(r) ;
+
+      storeRepP cpuvar_type(0) ;
+      CPTR<joiner> join_op(0) ;
+
+      // Search through cpu unit/apply rules that produce the cpu reduction
+      // variable. The type provided by the cpu unit rule is used as store type
+      // for the cpu partial variable. The joiner provided by the first cpu
+      // apply rule in the ruleSet is used to set joiner for combining cpu
+      // partial variable with cpu reduction variable.
+      std::map<variable, ruleSet>::const_iterator v2rsi = vargenerators.find(cpuvar) ;
+      if(v2rsi != vargenerators.end()) {
+        for(ruleSet::const_iterator rsi = v2rsi->second.begin();
+            rsi != v2rsi->second.end(); ++rsi) {
+          if(rsi->type() != rule::INTERNAL) {
+            rule_implP rp = rsi->get_rule_implP() ;
+            if(rp->get_rule_class() == rule_impl::UNIT) {
+              if(cpuvar_type == 0) {
+                storeRepP sp = rp->get_store(cpuvar) ;
+                if(!isGPU(sp)) {
+                  cpuvar_type = sp ;
+                }
+              }
+            } else if(rp->get_rule_class() == rule_impl::APPLY) {
+              if(join_op == 0) {
+                CPTR<joiner> join = rp->get_joiner() ;
+                if(join != 0) {
+                  storeRepP sp = join->getTargetRep() ;
+                  if(!isGPU(sp)) {
+                    join_op = join->clone() ;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Not having a cpu unit rule for a gpu reduction variable is an error.
+      // In this case, the scheduler will subsequently fail because it cannot
+      // determine the type the partial reduction variable.
+      if(cpuvar_type == 0) {
+        cerr << "no cpu unit rule for gpu reduction variable " << cpuvar << endl ;
+        Loci::Abort() ;
+      }
+
+      // Not having a cpu apply rule for a gpu reduction variable is an error.
+      // The joiner needs to be compatible with the cpu parameters.
+      if(join_op == 0) {
+        cerr << "no cpu apply rule for gpu reduction variable " << cpuvar << endl ;
+        Loci::Abort() ;
+      }
+
+      // Create a special apply rule to combine the gpu partial reduction
+      // variable with the cpu reduction variable, which then completes the
+      // reduction across all MPI ranks.
+      gpu2cpu_param_apply_rule * rapply = new gpu2cpu_param_apply_rule(
+        cpuvar.str(), cpupartvar.str(), cpuvar_type, join_op
+      ) ;
+      gpu_rdb.add_rule(rapply) ;
+    }
+
     return gpu_rdb ;
   }
 

--- a/src/System/rule.cc
+++ b/src/System/rule.cc
@@ -844,6 +844,34 @@ namespace Loci {
     return ks ;
   }
 
+  void gpu2cpu_param_apply_rule::compute(const sequence & seq) {
+    if(joinop != 0) {
+      storeRepP tp = target.Rep() ;
+      storeRepP sp = source.Rep() ;
+      entitySet e = interval(0,0) ;
+      sequence s = sequence(e) ;
+      joinop->SetArgs(tp, sp) ;
+      joinop->Join(s) ;
+    } else {
+      cerr << "gpu2cpu_param_apply_rule: join operator is null" << endl ;
+      Loci::Abort() ;
+    }
+  }
+
+  rule_implP gpu2cpu_param_apply_rule::new_rule_impl() const {
+    rule_implP clone = new gpu2cpu_param_apply_rule(target_name, source_name, target.Rep(), joinop) ;
+    for(list_iter li = rvlist.begin(); li != rvlist.end(); ++li) { 
+      std::map<variable, variable> rvm = *li;
+      clone->rename_vars(rvm) ;
+    }
+    return clone ;
+  }
+
+  void gpu2cpu_param_apply_rule::rename_vars(std::map<variable, variable>  &rvm) {
+    rvlist.push_back(rvm) ;
+    rule_impl::prot_rename_vars(rvm) ;
+  }
+
   rule::rule_db *rule::rdb = 0 ;
 
 

--- a/src/System/store_rep.cc
+++ b/src/System/store_rep.cc
@@ -181,5 +181,310 @@ namespace Loci {
   redistribute(const std::vector<entitySet>& dom_ptn,
                const dMap& remap, MPI_Comm comm)
   { return Rep()->redistribute(dom_ptn,remap,comm) ;}
-  
+ 
+  int abstractStoreRepI::get_alloc_id() const {
+    if(defer_rep != 0) {
+      return defer_rep->get_alloc_id() ;
+    } else {
+      return storeRep::get_alloc_id() ;
+    }
+  }
+
+  void abstractStoreRepI::allocate(const entitySet &p) {
+    if(defer_rep != 0) {
+      defer_rep->allocate(p) ;
+    }
+  }
+
+  void abstractStoreRepI::erase(const entitySet &rm) {
+    if(defer_rep != 0) {
+      defer_rep->erase(rm) ;
+    } else {
+      storeRep::erase(rm) ;
+    }
+  }
+
+  void abstractStoreRepI::invalidate(const entitySet& valid) {
+    if(defer_rep != 0) {
+      defer_rep->invalidate(valid) ;
+    } else {
+      storeRep::invalidate(valid) ;
+    }
+  }
+
+  void abstractStoreRepI::guarantee_domain(const entitySet &include) {
+    if(defer_rep != 0) {
+      defer_rep->guarantee_domain(include) ;
+    } else {
+      storeRep::guarantee_domain(include) ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::redistribute(
+    const std::vector<entitySet> &dom_ptn, MPI_Comm comm
+  ) {
+    if(defer_rep != 0) {
+      return defer_rep->redistribute(dom_ptn, comm) ;
+    } else {
+      return storeRep::redistribute(dom_ptn, comm) ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::redistribute(
+    const std::vector<entitySet> &dom_ptn,
+    const dMap &remap, MPI_Comm comm
+  ) {
+    if(defer_rep != 0) {
+      return defer_rep->redistribute(dom_ptn, remap, comm) ;
+    } else {
+      return storeRep::redistribute(dom_ptn, remap, comm) ;
+    }
+  }
+
+  store_type abstractStoreRepI::RepType() const {
+    if(defer_rep != 0) {
+      return defer_rep->RepType() ;
+    } else {
+      return ABSTRACTSTORE ;
+    }
+  }
+
+  entitySet abstractStoreRepI::domain() const {
+    if(defer_rep != 0) {
+      return defer_rep->domain() ;
+    } else {
+      return EMPTY ;
+    }
+  }
+
+  void abstractStoreRepI::shift(int_type offset) {
+    if(defer_rep != 0) {
+      defer_rep->shift(offset) ;
+    }
+  }
+
+  void abstractStoreRepI::set_elem_size(int sz) {
+    if(defer_rep != 0) {
+      defer_rep->set_elem_size(sz) ;
+    } else {
+      storeRep::set_elem_size(sz) ;
+    }
+  }
+
+  void abstractStoreRepI::setIsMat(bool im) {
+    if(defer_rep != 0) {
+      defer_rep->setIsMat(im) ;
+    } else {
+      storeRep::setIsMat(im) ;
+    }
+  }
+
+  storeRep * abstractStoreRepI::new_store(const entitySet &p) const {
+    if(defer_rep != 0) {
+      return defer_rep->new_store(p) ;
+    } else {
+      return new abstractStoreRepI ;
+    }
+  }
+
+  storeRep * abstractStoreRepI::new_store(const entitySet &p, const int *cnt) const {
+    if(defer_rep != 0) {
+      return defer_rep->new_store(p, cnt) ;
+    } else {
+      return new abstractStoreRepI ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::remap(const dMap &m) const {
+    if(defer_rep != 0) {
+      return defer_rep->remap(m) ;
+    } else {
+      return storeRepP(new abstractStoreRepI) ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::freeze() {
+    if(defer_rep != 0) {
+      return defer_rep->freeze() ;
+    } else {
+      return storeRepP(this) ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::thaw() {
+    if(defer_rep != 0) {
+      return defer_rep->thaw() ;
+    } else {
+      return storeRepP(this) ;
+    }
+  }
+
+  void abstractStoreRepI::copy(storeRepP &sp, const entitySet &context) {
+    if(defer_rep != 0) {
+      defer_rep->copy(sp, context) ;
+    }
+  }
+
+  void abstractStoreRepI::fast_copy(storeRepP &st, const entitySet &context) {
+    if(defer_rep != 0) {
+      defer_rep->fast_copy(st, context) ;
+    } else {
+      storeRep::fast_copy(st, context) ;
+    }
+  }
+
+  void abstractStoreRepI::gather(const dMap &m, storeRepP &st, const entitySet &context) {
+    if(defer_rep != 0) {
+      defer_rep->gather(m, st, context) ;
+    }
+  }
+
+  void abstractStoreRepI::scatter(const dMap &m, storeRepP &st, const entitySet &context) {
+    if(defer_rep != 0) {
+      defer_rep->scatter(m, st, context) ;
+    }
+  }
+
+  int abstractStoreRepI::pack_size(const entitySet &e, entitySet &packed) {
+    if(defer_rep != 0) {
+      return defer_rep->pack_size(e, packed) ;
+    } else {
+      return 0 ;
+    }
+  }
+
+  int abstractStoreRepI::pack_size(const entitySet &e) {
+    if(defer_rep != 0) {
+      return defer_rep->pack_size(e) ;
+    } else {
+      return 0 ;
+    }
+  }
+
+  int abstractStoreRepI::estimated_pack_size(const entitySet &e) {
+    if(defer_rep != 0) {
+      return defer_rep->estimated_pack_size(e) ;
+    } else {
+      return 0 ;
+    }
+  }
+
+  void abstractStoreRepI::pack(
+    void *ptr, int &loc, int &size, const entitySet &e
+  ) {
+    if(defer_rep != 0) {
+      defer_rep->pack(ptr, loc, size, e) ;
+    }
+  }
+
+  void abstractStoreRepI::unpack(void *ptr, int &loc, int &size, const sequence &seq) {
+    if(defer_rep != 0) {
+      defer_rep->unpack(ptr, loc, size, seq) ;
+    }
+  }
+
+  std::ostream & abstractStoreRepI::Print(std::ostream &s) const {
+    if(defer_rep != 0) {
+      defer_rep->Print(s) ;
+    }
+    return s ;
+  }
+
+  std::istream & abstractStoreRepI::Input(std::istream &s) {
+    if(defer_rep != 0) {
+      defer_rep->Input(s) ;
+    }
+    return s ;
+  }
+
+  void abstractStoreRepI::readhdf5(
+    hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension,
+    const char *name, frame_info &fi, entitySet &en
+  ) {
+    if(defer_rep != 0) {
+      defer_rep->readhdf5(group_id, dataspace, dataset, dimension, name, fi, en) ;
+    }
+  }
+
+  void abstractStoreRepI::writehdf5(
+    hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension,
+    const char *name, entitySet &en
+  ) const {
+    if(defer_rep != 0) {
+      defer_rep->writehdf5(group_id, dataspace, dataset, dimension, name, en) ;
+    }
+  }
+
+#ifdef H5_HAVE_PARALLEL
+  void abstractStoreRepI::readhdf5P(
+    hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension,
+    const char* name, frame_info &fi, entitySet &en, hid_t xfer_plist_id
+  ) {
+    if(defer_rep != 0) {
+      defer_rep->readhdf5P(group_id, dataspace, dataset, dimension,
+        name, fi, en, xfer_plist_id) ;
+    }
+  }
+#endif
+
+#ifdef H5_HAVE_PARALLEL
+  void abstractStoreRepI::writehdf5P(
+    hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension,
+    const char* name, entitySet& en, hid_t xfer_plist_id
+  ) const {
+    if(defer_rep != 0) {
+      defer_rep->writehdf5P(group_id, dataspace, dataset, dimension,
+        name, en, xfer_plist_id) ;
+    }
+  }
+#endif
+
+  DatatypeP abstractStoreRepI::getType() {
+    if(defer_rep != 0) {
+      return defer_rep->getType() ;
+    } else {
+      return DatatypeP(0) ;
+    }
+  }
+
+  frame_info abstractStoreRepI::get_frame_info() {
+    if(defer_rep != 0) {
+      return defer_rep->get_frame_info() ;
+    } else {
+      return frame_info() ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::getRep() {
+    if(defer_rep != 0) {
+      return defer_rep->getRep() ;
+    } else {
+      return storeRep::getRep() ;
+    }
+  }
+
+  storeRepP abstractStoreRepI::getRep() const {
+    if(defer_rep != 0) {
+      return defer_rep->getRep() ;
+    } else {
+      return storeRep::getRep() ;
+    }
+  }
+
+  int abstractStoreRepI::getDomainKeySpace() const {
+    if(defer_rep != 0) {
+      return defer_rep->getDomainKeySpace() ;
+    } else {
+      return storeRep::getDomainKeySpace() ;
+    }
+  }
+
+  void abstractStoreRepI::setDomainKeySpace(int v) {
+    if(defer_rep != 0) {
+      defer_rep->setDomainKeySpace(v) ;
+    } else {
+      storeRep::setDomainKeySpace(v) ;
+    }
+  }
+
 }

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -64,7 +64,7 @@ namespace Loci {
 
   inline variable makeREDUCEVAR(variable v) {
     variable::info vinfo = v.get_info() ;
-    std::string vname = vinfo.name + std::string("Partial") ;
+    std::string vname = vinfo.name + std::string("Partial__") ;
     vinfo.name = vname ;
     return variable(vinfo) ;
   }

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -1158,6 +1158,40 @@ namespace Loci {
   inline std::ostream &operator<<(std::ostream &s, const ruleSet& v)
     { return v.Print(s) ; }
 
+
+  //--------------------------------------------------------------------------
+  // Rules are registerered (recorderd) by constructing a register rule static
+  // object in the file.  Note that this idiom is dangerous because of the
+  // ** static initialization order fiasco ** problem.  Basically the order of
+  // object static object construction between compilation units can not well
+  // defined.  Thus if you construct a static object that depends on a
+  // static initialization in another compiler unit (For example, the stl
+  // library containers, then very bizzare behavior can be observed which
+  // can cause programs to crash before main runs.  This behavior may depend
+  // on compiler and linkage processes so it is possible that programs that
+  // depend on initialization order might fail at some future date when
+  // compiler or linkage behavior changes.
+
+  // However, we need some way that a module can record the rules that were
+  // defined within the linkage unit.  To solve this problem we still use
+  // static inititialization of an object to record the rule.  However we need
+  // to use care in the implementation of this infrastructure such that there
+  // can be no dependence on hidden globally initialized objects from other
+  // linkage units.  This is implemented through the register_rule_impl_list
+  // which implements a basic linear linked list using pointers (C style) to
+  // avoid any static initialization problems.  The list items contain a
+  // pointer to register_rule_type abstract base class which delegates the
+  // construction of the rule to a later time after main is called.  A special
+  // copy_rule_impl<T> helper is used to delegate the responsibility of
+  // deferring construction of the rule including managing transformations such
+  // as adding namespaces.  This complicated arrangement is only needed to
+  // avoid the static initialization order fiasco.  Note, non of this
+  // infrastructure is needed to create rules and register them after execution
+  // of main().
+
+  // Abstract class that provides an interface to get a copy of the rule
+  // implemetned by get_func().  A special is_module_rule method is provided
+  // to separate a special module management registration.
   class register_rule_type {
   public:
       virtual ~register_rule_type() {}
@@ -1166,8 +1200,17 @@ namespace Loci {
       
   } ; 
 
+  // Forward declaration of a class that we need to friend before it is
+  // defined.
   class register_rule_impl_list ;
-  
+
+  // This class implements a basic linear linked list of rules.  This will be
+  // used to store a global list of rules that are defined in files through the
+  // static initialization of the register_rule<T> templated class.  This has
+  // an interface that is roughly similar to the stl list with iterators
+  // that can be accessed with the begin() and end() methods.  New rules
+  // are added to the list with a push_rule() method, and shallow copy
+  // semantics are implemented for the assignment.
   class rule_impl_list {
   public:
     class rule_list_iterator ;
@@ -1216,11 +1259,13 @@ namespace Loci {
       copy_rule_list(x) ;
     }
     rule_impl_list &operator=(const rule_impl_list &x) {
-      list = 0 ;
+      clear() ;
       copy_rule_list(x) ;
       return *this ;
     }
   } ;
+
+  // Wrapper class that implemnts the global rule list
   class register_rule_impl_list : public rule_impl_list {
   public:
     static rule_list_ent *global_list ;
@@ -1235,24 +1280,10 @@ namespace Loci {
   extern register_rule_impl_list register_rule_list ;    
   extern rule_impl_list global_rule_list ;    
 
-  // Loci uses global declarations of register_rule instance to register rules
-  // in global rule list. This process takes place before main() is called. At
-  // this instance in the program lifecycle, proper initialization of standard
-  // library is not guaranteed. Therefore, a state-less instance of
-  // register_rule<T> is created and added to register_rule_list. register_rule
-  // knows only about type of the rule class, T. Instantiation of T occurs only
-  // when register_rule<T>::get_func() is invoked when populating the global
-  // rule list after main() starts. register_rule<T>::get_func() relies on
-  // copy_rule_impl<T> to enable generation of deep-copyable instance of type
-  // T. Class copy_rule_impl<T> encapsulates the process of generating clones
-  // of the rule implementation as it undergoes generalizations, promotions
-  // etc. as the schedule evolves. At every instantiation of concrete rule
-  // implementation class, copy_rule_impl starts from a fresh copy using the
-  // default constructor of the rule implementation class, and then applies 
-  // variable renaming on this instance in the same order. Therefore, each rule
-  // class is expected to initialize its named-stores, inputs, outputs,
-  // constraints, etc. in the default constructor.
-
+  // copy_rule_impl<T> is a class that is used to create a copy of a rule
+  // implmentation that can managed adding namespaces and other module rule
+  // modifications that are processed as part of loading rules from the rule
+  // list.
   template <class TCopyRuleImpl> class copy_rule_impl : public TCopyRuleImpl {
     typedef std::list<std::map<variable, variable> > rename_varList ;
     typedef std::list<std::map<variable, variable> >::const_iterator list_iter;
@@ -1277,13 +1308,18 @@ namespace Loci {
     rule_impl::prot_rename_vars(rvm) ;
   }
 
+  // This class adds itself to the global rule list on initialization
+  // and includes concrete implementations of the get_func() method which
+  // returns a new rule.
   template<class T> class register_rule : public register_rule_type {
   public:
     register_rule() { register_rule_list.push_rule(this) ; }
     virtual bool is_module_rule()  const{ return false; }
     virtual rule_implP get_func() const { return new copy_rule_impl<T> ; }
   } ;
-  
+
+  // This is for registering a special module identifier that is used to
+  // manage how a module will be loaded into the rule database.
   class register_module : public register_rule_type {
   public:
     register_module() { register_rule_list.push_rule(this) ; }
@@ -1298,6 +1334,8 @@ namespace Loci {
     virtual std::string disable_compute_vars() const ;
   } ;
   
+
+  // This is a database used for storing a database of Loci rules.
   class rule_db {
     typedef std::map<variable,ruleSet> varmap ;
     typedef varmap::const_iterator vc_iterator ;

--- a/src/include/rule.h
+++ b/src/include/rule.h
@@ -54,7 +54,21 @@ namespace Loci {
   
   class fact_db ;
   class sched_db ;
-  
+
+  inline variable makeGPUVAR(variable v) {
+    variable::info vinfo = v.get_info() ;
+    std::string vname = std::string("__GPU__") + vinfo.name ;
+    vinfo.name = vname ;
+    return variable(vinfo) ;
+  }
+
+  inline variable makeREDUCEVAR(variable v) {
+    variable::info vinfo = v.get_info() ;
+    std::string vname = vinfo.name + std::string("Partial") ;
+    vinfo.name = vname ;
+    return variable(vinfo) ;
+  }
+
   class joiner : public CPTR_type {
   public:
     virtual CPTR<joiner> clone() = 0 ;
@@ -243,31 +257,6 @@ namespace Loci {
   typedef rule_impl::rule_implP rule_implP ;
   
   
-  template <class TCopyRuleImpl> class copy_rule_impl : public TCopyRuleImpl {
-    typedef std::list<std::map<variable, variable> > rename_varList ;
-    typedef std::list<std::map<variable, variable> >::const_iterator list_iter;
-    rename_varList rvlist ;
-  public:
-    virtual rule_implP new_rule_impl() const ;
-    virtual void rename_vars(std::map<variable, variable> &rvm) ;
-  } ; 
-  
-  template <class TCopyRuleImpl> rule_implP copy_rule_impl<TCopyRuleImpl>::new_rule_impl() const {
-    rule_implP realrule_impl = new copy_rule_impl<TCopyRuleImpl> ;
-    for(list_iter li = rvlist.begin(); li != rvlist.end(); ++li) { 
-      std::map<variable, variable> rvm = *li;
-      realrule_impl->rename_vars(rvm) ;
-    }
-    return realrule_impl ;
-  }
-
-  template <class TCopyRuleImpl> 
-    void copy_rule_impl<TCopyRuleImpl>::rename_vars(std::map<variable,variable> &rvm) {
-    rvlist.push_back(rvm) ;
-    rule_impl::prot_rename_vars(rvm) ;
-  }
-
-
   // this is the new rule type for setting default
   // values in the facts database. It should not have
   // any inputs
@@ -627,6 +616,46 @@ namespace Loci {
       return CPTR<joiner>(jp) ;
     }
 
+  } ;
+
+  class gpu2cpu_param_apply_rule: public rule_impl {
+    typedef std::list<std::map<variable, variable> > rename_varList ;
+    typedef std::list<std::map<variable, variable> >::const_iterator list_iter;
+
+    rename_varList rvlist ;
+    std::string target_name ;
+    std::string source_name ;
+    abstractStore target ;
+    const_abstractStore source ;
+    CPTR<joiner> joinop ;
+
+    public:
+    gpu2cpu_param_apply_rule(
+      std::string const & target_name, std::string const & source_name,
+      storeRepP var_type, CPTR<joiner> joinop
+    ) : target_name(target_name), source_name(source_name),
+        target(var_type->new_store(EMPTY)), source(var_type->new_store(EMPTY)),
+        joinop(joinop) {
+      rule_class(APPLY) ;
+      name_store(target_name, target) ;
+      name_store(source_name, source) ;
+      output(target_name) ;
+      input(source_name) ;
+    }
+
+    void set_joiner(CPTR<joiner> op) {
+      joinop = op ;
+    }
+
+    CPTR<joiner> get_joiner() override {
+      return joinop ;
+    }
+
+    void compute(const sequence & seq) override ;
+
+    rule_implP new_rule_impl() const override ;
+
+    void rename_vars(std::map<variable, variable>  &rvm) override ;
   } ;
 
   template<typename Op, typename T>
@@ -1205,6 +1234,49 @@ namespace Loci {
   } ;
   extern register_rule_impl_list register_rule_list ;    
   extern rule_impl_list global_rule_list ;    
+
+  // Loci uses global declarations of register_rule instance to register rules
+  // in global rule list. This process takes place before main() is called. At
+  // this instance in the program lifecycle, proper initialization of standard
+  // library is not guaranteed. Therefore, a state-less instance of
+  // register_rule<T> is created and added to register_rule_list. register_rule
+  // knows only about type of the rule class, T. Instantiation of T occurs only
+  // when register_rule<T>::get_func() is invoked when populating the global
+  // rule list after main() starts. register_rule<T>::get_func() relies on
+  // copy_rule_impl<T> to enable generation of deep-copyable instance of type
+  // T. Class copy_rule_impl<T> encapsulates the process of generating clones
+  // of the rule implementation as it undergoes generalizations, promotions
+  // etc. as the schedule evolves. At every instantiation of concrete rule
+  // implementation class, copy_rule_impl starts from a fresh copy using the
+  // default constructor of the rule implementation class, and then applies 
+  // variable renaming on this instance in the same order. Therefore, each rule
+  // class is expected to initialize its named-stores, inputs, outputs,
+  // constraints, etc. in the default constructor.
+
+  template <class TCopyRuleImpl> class copy_rule_impl : public TCopyRuleImpl {
+    typedef std::list<std::map<variable, variable> > rename_varList ;
+    typedef std::list<std::map<variable, variable> >::const_iterator list_iter;
+    rename_varList rvlist ;
+  public:
+    virtual rule_implP new_rule_impl() const ;
+    virtual void rename_vars(std::map<variable, variable> &rvm) ;
+  } ; 
+  
+  template <class TCopyRuleImpl> rule_implP copy_rule_impl<TCopyRuleImpl>::new_rule_impl() const {
+    rule_implP realrule_impl = new copy_rule_impl<TCopyRuleImpl> ;
+    for(list_iter li = rvlist.begin(); li != rvlist.end(); ++li) { 
+      std::map<variable, variable> rvm = *li;
+      realrule_impl->rename_vars(rvm) ;
+    }
+    return realrule_impl ;
+  }
+
+  template <class TCopyRuleImpl> 
+    void copy_rule_impl<TCopyRuleImpl>::rename_vars(std::map<variable,variable> &rvm) {
+    rvlist.push_back(rvm) ;
+    rule_impl::prot_rename_vars(rvm) ;
+  }
+
   template<class T> class register_rule : public register_rule_type {
   public:
     register_rule() { register_rule_list.push_rule(this) ; }

--- a/src/include/store_rep.h
+++ b/src/include/store_rep.h
@@ -259,7 +259,7 @@ namespace Loci {
   
   
   enum store_type { STORE, PARAMETER, MAP, CONSTRAINT, BLACKBOX,
-                    GPUSTORE, GPUPARAMETER, GPUMAP} ;
+                    GPUSTORE, GPUPARAMETER, GPUMAP, ABSTRACTSTORE } ;
 
   class Map ;
   class dMap ;
@@ -537,20 +537,116 @@ namespace Loci {
 			 (rep->RepType() == Loci::GPUPARAMETER) )) ;
   }
 
-  class abstract_store : public store_instance {
+
+  class abstractStoreRepI : public storeRep {
+    storeRepP defer_rep ;
+
   public:
-    virtual ~abstract_store() { }
-    virtual instance_type access() const
-      { return READ_WRITE ; }
-    virtual void notification() { }
+    abstractStoreRepI() {
+      defer_rep = storeRepP(0) ;
+    }
+    abstractStoreRepI(const entitySet &p) {
+      defer_rep = storeRepP(0) ;
+    }
+    virtual ~abstractStoreRepI() { }
+    int get_alloc_id() const override ;
+    void allocate(const entitySet &p) override ;
+    void erase(const entitySet &rm) override ;
+    void invalidate(const entitySet& valid) override ;
+    void guarantee_domain(const entitySet &include) override ;
+    storeRepP redistribute(const std::vector<entitySet> &dom_ptn,
+      MPI_Comm comm=MPI_COMM_WORLD) override ;
+    storeRepP redistribute(const std::vector<entitySet> &dom_ptn,
+      const dMap &remap, MPI_Comm comm=MPI_COMM_WORLD) override ;
+    store_type RepType() const override ;
+    entitySet domain() const override ;
+    void shift(int_type offset) override ;
+    void set_elem_size(int sz) override ;
+    void setIsMat(bool im) override ;
+    storeRep * new_store(const entitySet &p) const override ;
+    storeRep * new_store(const entitySet &p, const int *cnt) const override ;
+    storeRepP remap(const dMap &m) const override ;
+    storeRepP freeze() override ;
+    storeRepP thaw() override ;
+    void copy(storeRepP &st, const entitySet &context) override ;
+    void fast_copy(storeRepP &st, const entitySet &context) override ;
+    void gather(const dMap &m, storeRepP &st, const entitySet &context) override ;
+    void scatter(const dMap &m, storeRepP &st, const entitySet &context) override ;
+    int pack_size(const entitySet &e, entitySet &packed) override ;
+    int pack_size(const entitySet &e) override ;
+    int estimated_pack_size(const entitySet &e) override ;
+    void pack(void *ptr, int &loc, int &size, const entitySet &e) override ;
+    void unpack(void *ptr, int &loc, int &size, const sequence &seq) override ;
+
+    std::ostream & Print(std::ostream &s) const override ;
+    std::istream & Input(std::istream &s) override ;
+    void readhdf5(hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension, const char *name, frame_info &fi, entitySet &en) override ;
+    void writehdf5(hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension, const char *name, entitySet &en) const override ;
+#ifdef H5_HAVE_PARALLEL
+    void readhdf5P(hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension, const char* name, frame_info &fi, entitySet &en, hid_t xfer_plist_id) override ;
+    void writehdf5P(hid_t group_id, hid_t dataspace, hid_t dataset, hsize_t dimension, const char* name, entitySet& en, hid_t xfer_plist_id) const override ;
+#endif
+    DatatypeP getType() override ;
+    frame_info get_frame_info() override ;
+    storeRepP getRep() override ;
+    storeRepP getRep() const override ;
+    int getDomainKeySpace() const override ;
+    void setDomainKeySpace(int v) override ;
   } ;
 
-  class const_abstract_store : public store_instance {
+  class abstractStore : public store_instance {
+    typedef abstractStoreRepI storeType ;
+    abstractStore(abstractStore const & src) {
+      setRep(src.Rep()) ;
+    }
+    abstractStore & operator=(abstractStore const & src) {
+      setRep(src.Rep()) ;
+      return *this ;
+    }
   public:
-    virtual ~const_abstract_store() { }
-    virtual instance_type access() const
+    abstractStore() {
+      setRep(new storeType) ;
+    }
+    abstractStore(storeRepP rp) {
+      setRep(rp) ;
+    }
+    virtual ~abstractStore() { }
+    abstractStore & operator=(storeRepP sp) {
+      setRep(sp) ;
+      return *this ;
+    }
+    instance_type access() const override
+      { return READ_WRITE ; }
+    void notification() override { } ;
+  } ;
+
+  class const_abstractStore : public store_instance {
+    typedef abstractStoreRepI storeType ;
+    const_abstractStore(abstractStore const & src) {
+      setRep(src.Rep());
+    }
+    const_abstractStore(const_abstractStore const & src) {
+      setRep(src.Rep()) ;
+    }
+    const_abstractStore & operator=(abstractStore const & src) {
+      setRep(src.Rep());
+      return *this ;
+    }
+    const_abstractStore & operator=(const_abstractStore const & src) {
+      setRep(src.Rep()) ;
+      return *this ;
+    }
+  public:
+    const_abstractStore() {
+      setRep(new storeType) ;
+    }
+    const_abstractStore(storeRepP rp) {
+      setRep(rp) ;
+    }
+    virtual ~const_abstractStore() { }
+    instance_type access() const override
       { return READ_ONLY ; }
-    virtual void notification() { }
+    void notification() override { } ;
   } ;
 
   /** ************************************************************************

--- a/src/include/store_rep.h
+++ b/src/include/store_rep.h
@@ -537,6 +537,22 @@ namespace Loci {
 			 (rep->RepType() == Loci::GPUPARAMETER) )) ;
   }
 
+  class abstract_store : public store_instance {
+  public:
+    virtual ~abstract_store() { }
+    virtual instance_type access() const
+      { return READ_WRITE ; }
+    virtual void notification() { }
+  } ;
+
+  class const_abstract_store : public store_instance {
+  public:
+    virtual ~const_abstract_store() { }
+    virtual instance_type access() const
+      { return READ_ONLY ; }
+    virtual void notification() { }
+  } ;
+
   /** ************************************************************************
    *
    * @brief cpypacksize() returns the 


### PR DESCRIPTION
Changes to enable multi-GPU global reductions. The CUDA-enabled reductions now require a CPU unit rule as well as a CPU dummy apply rule. There is no change in .cloci file specification of the GPU unit/apply rules for the global reduction. In the future, the checks for the redundant specifications would be removed as a unified framework for scheduling CPU and GPU rules will be developed.