### PR TITLE
Fixed issue causing spurious categories, failed boundary plots

### DIFF
--- a/src/System/categories.cc
+++ b/src/System/categories.cc
@@ -102,7 +102,7 @@ namespace Loci {
           if(mp->getRangeKeySpace() == kd) {
             entitySet dom = my_entities & p->domain() ;
             entitySet image_dom = mp->image(dom) ;
-            image_dom += distribute_entitySet(image_dom, ptn) ;
+            image_dom = distribute_entitySet(image_dom, ptn) ;
             entitySet testSet = image_dom - total_entities ;
             int size = testSet.size() ;
             int tsize = 0 ;


### PR DESCRIPTION
This fixed an issue with the categories code where spurious categories were created.  This caused problems specifically with interactions with surface boundary plotting and edge2node data-structures where the ordering of local numbering did not match global numbering.  The boundary surface topology code is assuming that global number order will be the same as data distribution within the local numbering.  The spurious edge2node categories caused nodes to be reordered into different categories resulting in the problem.  Longer term, writeBoundaryTopo() needs to be update to consider that the local ordering and the global ordering may not be aligned within a processor allocation.
