### PR TITLE
Fixed issue causing spurious categories cherry-pick from stable41 branch

### DIFF
--- a/src/System/categories.cc
+++ b/src/System/categories.cc
@@ -102,7 +102,7 @@ namespace Loci {
           if(mp->getRangeKeySpace() == kd) {
             entitySet dom = my_entities & p->domain() ;
             entitySet image_dom = mp->image(dom) ;
-            image_dom += distribute_entitySet(image_dom, ptn) ;
+            image_dom = distribute_entitySet(image_dom, ptn) ;
             entitySet testSet = image_dom - total_entities ;
             int size = testSet.size() ;
             int tsize = 0 ;


### PR DESCRIPTION
This fixes issue where spurious categories were created.  Specifically this caused problems with outputting boundary surface data.